### PR TITLE
Update to Nerdbank.GitVersioning 1.5.58

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Analyzers.NuGet/project.json
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.NuGet/project.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "MicroBuild.Core": "0.2.0",
     "MicroBuild.VisualStudio": "2.0.22-beta",
-    "Nerdbank.GitVersioning": "1.5.46",
+    "Nerdbank.GitVersioning": "1.5.58",
     "NuProj": "0.10.48-beta-gea4a31bbc5",
     "ReadOnlySourceTree": "0.1.37-beta"
   },

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/project.json
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/project.json
@@ -10,7 +10,7 @@
     },
     "Microsoft.CodeAnalysis.CSharp.Workspaces": "1.0.0",
     "Nerdbank.GitVersioning": {
-      "version": "1.5.46",
+      "version": "1.5.58",
       "suppressParent": "none"
     },
     "NuProj.Common": {

--- a/src/Microsoft.VisualStudio.Threading.Desktop/project.json
+++ b/src/Microsoft.VisualStudio.Threading.Desktop/project.json
@@ -10,7 +10,7 @@
     },
     "Microsoft.VisualStudio.Validation": "15.0.55-pre",
     "Nerdbank.GitVersioning": {
-      "version": "1.5.46",
+      "version": "1.5.58",
       "suppressParent": "none"
     },
     "NuProj.Common": {

--- a/src/Microsoft.VisualStudio.Threading.NuGet/project.json
+++ b/src/Microsoft.VisualStudio.Threading.NuGet/project.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "MicroBuild.Core": "0.2.0",
     "MicroBuild.VisualStudio": "2.0.22-beta",
-    "Nerdbank.GitVersioning": "1.5.46",
+    "Nerdbank.GitVersioning": "1.5.58",
     "NuProj": "0.10.48-beta-gea4a31bbc5",
     "ReadOnlySourceTree": "0.1.37-beta"
   },

--- a/src/Microsoft.VisualStudio.Threading.Portable/project.json
+++ b/src/Microsoft.VisualStudio.Threading.Portable/project.json
@@ -10,7 +10,7 @@
     },
     "Microsoft.VisualStudio.Validation": "15.0.55-pre",
     "Nerdbank.GitVersioning": {
-      "version": "1.5.46",
+      "version": "1.5.58",
       "suppressParent": "none"
     },
     "NuProj.Common": {


### PR DESCRIPTION
This should fix the recognition of public refs built by VSTS from github
