### PR TITLE
Fix build break on Dev15

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/Microsoft.VisualStudio.Threading.Analyzers.Tests.csproj
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/Microsoft.VisualStudio.Threading.Analyzers.Tests.csproj
@@ -31,7 +31,6 @@
     <DocumentationFile>..\..\bin\Release\Microsoft.VisualStudio.Threading.Analyzers.Tests.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Build.Utilities.Core, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/project.json
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/project.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "MicroBuild.NonShipping": "1.0.110-rc",
     "Microsoft.VisualStudio.Validation": "15.0.55-pre",
+    "Microsoft.Build.Utilities.Core": "14.3.0",
     "xunit": "2.1.0",
     "xunit.runner.visualstudio": "2.1.0"
   },

--- a/tools/Restore-NuGetPackages.ps1
+++ b/tools/Restore-NuGetPackages.ps1
@@ -17,5 +17,5 @@ Param(
 $nugetPath = & "$PSScriptRoot\Get-NuGetTool.ps1"
 
 Write-Verbose "Restoring NuGet packages for $Path"
-& $nugetPath restore $Path -msbuildversion 14.0 -Verbosity $Verbosity
+& $nugetPath restore $Path -Verbosity $Verbosity
 if ($lastexitcode -ne 0) { throw }


### PR DESCRIPTION
When MSBuild v14 hasn't been installed, the analyzer tests project would fail to build. This fixes it by allowing nuget restore to use MSBuild 15 and obtaining an MSBuild utility class from nuget.org