### PR TITLE
Put analyzers in -beta quality

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Analyzers.NuGet/version.json
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.NuGet/version.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "15.0-beta",
+  "publicReleaseRefSpec": [
+    "^refs/heads/master$", // we release out of master
+    "^refs/heads/v\\d+(?:.\\d+)?$" // we also release out of vNN branches
+  ]
+}

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/version.json
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/version.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "15.0-beta",
+  "publicReleaseRefSpec": [
+    "^refs/heads/master$", // we release out of master
+    "^refs/heads/v\\d+(?:.\\d+)?$" // we also release out of vNN branches
+  ]
+}


### PR DESCRIPTION
Till we change the IDs and vet them a bit more, our analyzers package should claim to be `-beta`