### PR TITLE
Add VSSDK014 "Avoid legacy thread switching" analyzer

### DIFF
--- a/doc/analyzers/VSSDK014.md
+++ b/doc/analyzers/VSSDK014.md
@@ -1,0 +1,28 @@
+# VSSDK014 Avoid legacy thread switching methods
+
+Switching to the UI thread should be done using `JoinableTaskFactory.SwitchToMainThreadAsync`
+rather than legacy methods such as `Dispatcher.Invoke` or `ThreadHelper.Invoke`.
+This avoids deadlocks and can reduce threadpool starvation.
+
+## Examples of patterns that are flagged by this analyzer
+
+```csharp
+void Foo() {
+    ThreadHelper.Generic.Invoke(delegate {
+        DoSomething();
+    });
+}
+```
+
+## Solution
+
+Use `await SwitchToMainThreadAsync()` instead, wrapping with `JoinableTaskFactory.Run` if necessary:
+
+```csharp
+void Foo() {
+    ThreadHelper.JoinableTaskFactory.Run(async delegate {
+        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+        DoSomething();
+    });
+}
+```

--- a/doc/analyzers/index.md
+++ b/doc/analyzers/index.md
@@ -18,5 +18,6 @@ ID | Title
 [VSSDK011](VSSDK011.md) | Avoid method overloads that assume TaskScheduler.Current
 [VSSDK012](VSSDK012.md) | Provide JoinableTaskFactory where allowed
 [VSSDK013](VSSDK013.md) | Offer async option
+[VSSDK014](VSSDK014.md) | Avoid legacy thread switching methods
 
 [1]: https://nuget.org/packages/microsoft.visualstudio.threading.analyzers

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/Helpers/DiagnosticVerifier.Helper.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/Helpers/DiagnosticVerifier.Helper.cs
@@ -8,6 +8,7 @@ namespace Microsoft.VisualStudio.Threading.Analyzers.Tests
     using System.IO;
     using System.Linq;
     using System.Threading;
+    using System.Windows.Threading;
     using Microsoft.Build.Utilities;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
@@ -26,6 +27,7 @@ namespace Microsoft.VisualStudio.Threading.Analyzers.Tests
         private static readonly MetadataReference CSharpSymbolsReference = MetadataReference.CreateFromFile(typeof(CSharpCompilation).Assembly.Location);
         private static readonly MetadataReference CodeAnalysisReference = MetadataReference.CreateFromFile(typeof(Compilation).Assembly.Location);
         private static readonly MetadataReference ThreadingReference = MetadataReference.CreateFromFile(typeof(AsyncEventHandler).Assembly.Location);
+        private static readonly MetadataReference WindowsBaseReference = MetadataReference.CreateFromFile(typeof(Dispatcher).Assembly.Location);
 
         private static readonly ImmutableArray<string> VSSDKPackageReferences = ImmutableArray.Create(new string[] {
             Path.Combine("Microsoft.VisualStudio.Shell.Interop", "7.10.6071", "lib", "Microsoft.VisualStudio.Shell.Interop.dll"),
@@ -192,6 +194,7 @@ namespace Microsoft.VisualStudio.Threading.Analyzers.Tests
                 .AddMetadataReference(projectId, CSharpSymbolsReference)
                 .AddMetadataReference(projectId, CodeAnalysisReference)
                 .AddMetadataReference(projectId, ThreadingReference)
+                .AddMetadataReference(projectId, WindowsBaseReference)
                 .WithProjectCompilationOptions(projectId, new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
 
             var pathToLibs = ToolLocationHelper.GetPathToStandardLibraries(".NETFramework", "v4.5.1", string.Empty);

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/Microsoft.VisualStudio.Threading.Analyzers.Tests.csproj
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/Microsoft.VisualStudio.Threading.Analyzers.Tests.csproj
@@ -34,6 +34,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="VSSDK005AsyncEventHandlerAnalyzerTests.cs" />
@@ -58,6 +59,7 @@
     <Compile Include="VSSDK002VsServiceInvocationAnalyzerTests.cs" />
     <Compile Include="VSSDK012SpecifyJtfWhereAllowedTests.cs" />
     <Compile Include="VSSDK013OfferAsyncOptionAnalyzerTests.cs" />
+    <Compile Include="VSSDK014AvoidLegacyThreadSwitchingAnalyzerTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.VisualStudio.Threading.Analyzers\Microsoft.VisualStudio.Threading.Analyzers.csproj">

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSSDK014AvoidLegacyThreadSwitchingAnalyzerTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSSDK014AvoidLegacyThreadSwitchingAnalyzerTests.cs
@@ -1,0 +1,166 @@
+﻿namespace Microsoft.VisualStudio.Threading.Analyzers.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using CodeAnalysis.Diagnostics;
+    using Microsoft.CodeAnalysis;
+    using Xunit;
+    using Xunit.Abstractions;
+
+    public class VSSDK014AvoidLegacyThreadSwitchingAnalyzerTests : DiagnosticVerifier
+    {
+        private DiagnosticResult expect = new DiagnosticResult
+        {
+            Id = VSSDK014AvoidLegacyThreadSwitchingAnalyzer.Id,
+            SkipVerifyMessage = true,
+            Severity = DiagnosticSeverity.Warning,
+        };
+
+        public VSSDK014AvoidLegacyThreadSwitchingAnalyzerTests(ITestOutputHelper logger)
+            : base(logger)
+        {
+        }
+
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new VSSDK014AvoidLegacyThreadSwitchingAnalyzer();
+
+        [Fact]
+        public void ThreadHelperInvoke_ProducesDiagnostic()
+        {
+            var test = @"
+using Microsoft.VisualStudio.Shell;
+
+class Test {
+    void Foo() {
+        ThreadHelper.Generic.Invoke(delegate { });
+    }
+}
+";
+
+            this.expect.Locations = new[] { new DiagnosticResultLocation("Test0.cs", 6, 9, 6, 36) };
+            this.VerifyCSharpDiagnostic(test, this.expect);
+        }
+
+        [Fact]
+        public void ThreadHelperBeginInvoke_ProducesDiagnostic()
+        {
+            var test = @"
+using Microsoft.VisualStudio.Shell;
+
+class Test {
+    void Foo() {
+        ThreadHelper.Generic.BeginInvoke(delegate { });
+    }
+}
+";
+
+            this.expect.Locations = new[] { new DiagnosticResultLocation("Test0.cs", 6, 9, 6, 41) };
+            this.VerifyCSharpDiagnostic(test, this.expect);
+        }
+
+        [Fact]
+        public void ThreadHelperInvokeAsync_ProducesDiagnostic()
+        {
+            var test = @"
+using Microsoft.VisualStudio.Shell;
+
+class Test {
+    void Foo() {
+        ThreadHelper.Generic.InvokeAsync(delegate { });
+    }
+}
+";
+
+            this.expect.Locations = new[] { new DiagnosticResultLocation("Test0.cs", 6, 9, 6, 41) };
+            this.VerifyCSharpDiagnostic(test, this.expect);
+        }
+
+        [Fact]
+        public void DispatcherInvoke_ProducesDiagnostic()
+        {
+            var test = @"
+using System.Windows.Threading;
+
+class Test {
+    void Foo() {
+        Dispatcher.CurrentDispatcher.Invoke(delegate { }, DispatcherPriority.ContextIdle);
+    }
+}
+";
+
+            this.expect.Locations = new[] { new DiagnosticResultLocation("Test0.cs", 6, 9, 6, 44) };
+            this.VerifyCSharpDiagnostic(test, this.expect);
+        }
+
+        [Fact]
+        public void DispatcherBeginInvoke_ProducesDiagnostic()
+        {
+            var test = @"
+using System;
+using System.Windows.Threading;
+
+class Test {
+    void Foo() {
+        Dispatcher.CurrentDispatcher.BeginInvoke(new Action(() => { }));
+    }
+}
+";
+
+            this.expect.Locations = new[] { new DiagnosticResultLocation("Test0.cs", 7, 9, 7, 49) };
+            this.VerifyCSharpDiagnostic(test, this.expect);
+        }
+
+        [Fact]
+        public void DispatcherInvokeAsync_ProducesDiagnostic()
+        {
+            var test = @"
+using System.Windows.Threading;
+
+class Test {
+    void Foo() {
+        Dispatcher.CurrentDispatcher.InvokeAsync(delegate { }, DispatcherPriority.ContextIdle);
+    }
+}
+";
+
+            this.expect.Locations = new[] { new DiagnosticResultLocation("Test0.cs", 6, 9, 6, 49) };
+            this.VerifyCSharpDiagnostic(test, this.expect);
+        }
+
+        [Fact]
+        public void SynchronizationContextSend_ProducesDiagnostic()
+        {
+            var test = @"
+using System.Threading;
+
+class Test {
+    void Foo() {
+        SynchronizationContext.Current.Send(s => { }, null);
+    }
+}
+";
+
+            this.expect.Locations = new[] { new DiagnosticResultLocation("Test0.cs", 6, 9, 6, 44) };
+            this.VerifyCSharpDiagnostic(test, this.expect);
+        }
+
+        [Fact]
+        public void SynchronizationContextPost_ProducesDiagnostic()
+        {
+            var test = @"
+using System.Threading;
+
+class Test {
+    void Foo() {
+        SynchronizationContext.Current.Post(s => { }, null);
+    }
+}
+";
+
+            this.expect.Locations = new[] { new DiagnosticResultLocation("Test0.cs", 6, 9, 6, 44) };
+            this.VerifyCSharpDiagnostic(test, this.expect);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/CommonInterest.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/CommonInterest.cs
@@ -20,6 +20,18 @@
             new SyncBlockingMethod(Namespaces.SystemRuntimeCompilerServices, nameof(TaskAwaiter), nameof(TaskAwaiter.GetResult), null),
         };
 
+        internal static readonly IReadOnlyList<LegacyThreadSwitchingMethod> LegacyThreadSwitchingMethods = new[]
+        {
+            new LegacyThreadSwitchingMethod(Namespaces.MicrosoftVisualStudioShell, Types.ThreadHelper.TypeName, Types.ThreadHelper.Invoke),
+            new LegacyThreadSwitchingMethod(Namespaces.MicrosoftVisualStudioShell, Types.ThreadHelper.TypeName, Types.ThreadHelper.InvokeAsync),
+            new LegacyThreadSwitchingMethod(Namespaces.MicrosoftVisualStudioShell, Types.ThreadHelper.TypeName, Types.ThreadHelper.BeginInvoke),
+            new LegacyThreadSwitchingMethod(Namespaces.SystemWindowsThreading, Types.Dispatcher.TypeName, Types.Dispatcher.Invoke),
+            new LegacyThreadSwitchingMethod(Namespaces.SystemWindowsThreading, Types.Dispatcher.TypeName, Types.Dispatcher.BeginInvoke),
+            new LegacyThreadSwitchingMethod(Namespaces.SystemWindowsThreading, Types.Dispatcher.TypeName, Types.Dispatcher.InvokeAsync),
+            new LegacyThreadSwitchingMethod(Namespaces.SystemThreading, Types.SynchronizationContext.TypeName, Types.SynchronizationContext.Send),
+            new LegacyThreadSwitchingMethod(Namespaces.SystemThreading, Types.SynchronizationContext.TypeName, Types.SynchronizationContext.Post),
+        };
+
         internal static readonly IReadOnlyList<SyncBlockingMethod> SyncBlockingProperties = new[]
         {
             new SyncBlockingMethod(Namespaces.SystemThreadingTasks, nameof(Task), nameof(Task<int>.Result), null),
@@ -42,6 +54,22 @@
             public string MethodName { get; private set; }
 
             public string AsyncAlternativeMethodName { get; private set; }
+        }
+
+        internal struct LegacyThreadSwitchingMethod
+        {
+            public LegacyThreadSwitchingMethod(IReadOnlyList<string> containingTypeNamespace, string containingTypeName, string methodName)
+            {
+                this.ContainingTypeNamespace = containingTypeNamespace;
+                this.ContainingTypeName = containingTypeName;
+                this.MethodName = methodName;
+            }
+
+            public IReadOnlyList<string> ContainingTypeNamespace { get; private set; }
+
+            public string ContainingTypeName { get; private set; }
+
+            public string MethodName { get; private set; }
         }
     }
 }

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Microsoft.VisualStudio.Threading.Analyzers.csproj
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Microsoft.VisualStudio.Threading.Analyzers.csproj
@@ -65,6 +65,7 @@
     <Compile Include="VSSDK002VsServiceUsageAnalyzer.cs" />
     <Compile Include="VSSDK012SpecifyJtfWhereAllowed.cs" />
     <Compile Include="VSSDK013OfferAsyncOptionAnalyzer.cs" />
+    <Compile Include="VSSDK014AvoidLegacyThreadSwitchingAnalyzer.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config">

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.cs.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.cs.xlf
@@ -169,6 +169,14 @@ Byste měli použít AsyncLazy&lt;T&gt; místo.</target>
           <source>Offer async methods</source>
           <target state="new">Offer async methods</target>
         </trans-unit>
+        <trans-unit id="VSSDK014_MessageFormat" translate="yes" xml:space="preserve">
+          <source>Await JoinableTaskFactory.SwitchToMainThreadAsync() to switch to the UI thread instead of APIs that can deadlock or require specifying a priority.</source>
+          <target state="new">Await JoinableTaskFactory.SwitchToMainThreadAsync() to switch to the UI thread instead of APIs that can deadlock or require specifying a priority.</target>
+        </trans-unit>
+        <trans-unit id="VSSDK014_Title" translate="yes" xml:space="preserve">
+          <source>Avoid legacy threading switching APIs</source>
+          <target state="new">Avoid legacy threading switching APIs</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.de.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.de.xlf
@@ -169,6 +169,14 @@ AsyncLazy&lt;T&gt; sollten Sie stattdessen verwenden.</target>
           <source>Offer async methods</source>
           <target state="new">Offer async methods</target>
         </trans-unit>
+        <trans-unit id="VSSDK014_MessageFormat" translate="yes" xml:space="preserve">
+          <source>Await JoinableTaskFactory.SwitchToMainThreadAsync() to switch to the UI thread instead of APIs that can deadlock or require specifying a priority.</source>
+          <target state="new">Await JoinableTaskFactory.SwitchToMainThreadAsync() to switch to the UI thread instead of APIs that can deadlock or require specifying a priority.</target>
+        </trans-unit>
+        <trans-unit id="VSSDK014_Title" translate="yes" xml:space="preserve">
+          <source>Avoid legacy threading switching APIs</source>
+          <target state="new">Avoid legacy threading switching APIs</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.es.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.es.xlf
@@ -169,6 +169,14 @@ Debe utilizar AsyncLazy&lt;T&gt; en su lugar.</target>
           <source>Offer async methods</source>
           <target state="new">Offer async methods</target>
         </trans-unit>
+        <trans-unit id="VSSDK014_MessageFormat" translate="yes" xml:space="preserve">
+          <source>Await JoinableTaskFactory.SwitchToMainThreadAsync() to switch to the UI thread instead of APIs that can deadlock or require specifying a priority.</source>
+          <target state="new">Await JoinableTaskFactory.SwitchToMainThreadAsync() to switch to the UI thread instead of APIs that can deadlock or require specifying a priority.</target>
+        </trans-unit>
+        <trans-unit id="VSSDK014_Title" translate="yes" xml:space="preserve">
+          <source>Avoid legacy threading switching APIs</source>
+          <target state="new">Avoid legacy threading switching APIs</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.fr.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.fr.xlf
@@ -169,6 +169,14 @@ Vous devez plutôt utiliser AsyncLazy&lt;T&gt; .</target>
           <source>Offer async methods</source>
           <target state="new">Offer async methods</target>
         </trans-unit>
+        <trans-unit id="VSSDK014_MessageFormat" translate="yes" xml:space="preserve">
+          <source>Await JoinableTaskFactory.SwitchToMainThreadAsync() to switch to the UI thread instead of APIs that can deadlock or require specifying a priority.</source>
+          <target state="new">Await JoinableTaskFactory.SwitchToMainThreadAsync() to switch to the UI thread instead of APIs that can deadlock or require specifying a priority.</target>
+        </trans-unit>
+        <trans-unit id="VSSDK014_Title" translate="yes" xml:space="preserve">
+          <source>Avoid legacy threading switching APIs</source>
+          <target state="new">Avoid legacy threading switching APIs</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.it.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.it.xlf
@@ -169,6 +169,14 @@ Use AsyncLazy&lt;T&gt; instead.</source>
           <source>Offer async methods</source>
           <target state="new">Offer async methods</target>
         </trans-unit>
+        <trans-unit id="VSSDK014_MessageFormat" translate="yes" xml:space="preserve">
+          <source>Await JoinableTaskFactory.SwitchToMainThreadAsync() to switch to the UI thread instead of APIs that can deadlock or require specifying a priority.</source>
+          <target state="new">Await JoinableTaskFactory.SwitchToMainThreadAsync() to switch to the UI thread instead of APIs that can deadlock or require specifying a priority.</target>
+        </trans-unit>
+        <trans-unit id="VSSDK014_Title" translate="yes" xml:space="preserve">
+          <source>Avoid legacy threading switching APIs</source>
+          <target state="new">Avoid legacy threading switching APIs</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.ja.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.ja.xlf
@@ -169,6 +169,14 @@ AsyncLazy&lt;T&gt;を代わりに使用する必要があります。</target>
           <source>Offer async methods</source>
           <target state="new">Offer async methods</target>
         </trans-unit>
+        <trans-unit id="VSSDK014_MessageFormat" translate="yes" xml:space="preserve">
+          <source>Await JoinableTaskFactory.SwitchToMainThreadAsync() to switch to the UI thread instead of APIs that can deadlock or require specifying a priority.</source>
+          <target state="new">Await JoinableTaskFactory.SwitchToMainThreadAsync() to switch to the UI thread instead of APIs that can deadlock or require specifying a priority.</target>
+        </trans-unit>
+        <trans-unit id="VSSDK014_Title" translate="yes" xml:space="preserve">
+          <source>Avoid legacy threading switching APIs</source>
+          <target state="new">Avoid legacy threading switching APIs</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.ko.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.ko.xlf
@@ -145,6 +145,14 @@ Use AsyncLazy&lt;T&gt; instead.</source>
           <source>Offer async methods</source>
           <target state="new">Offer async methods</target>
         </trans-unit>
+        <trans-unit id="VSSDK014_MessageFormat" translate="yes" xml:space="preserve">
+          <source>Await JoinableTaskFactory.SwitchToMainThreadAsync() to switch to the UI thread instead of APIs that can deadlock or require specifying a priority.</source>
+          <target state="new">Await JoinableTaskFactory.SwitchToMainThreadAsync() to switch to the UI thread instead of APIs that can deadlock or require specifying a priority.</target>
+        </trans-unit>
+        <trans-unit id="VSSDK014_Title" translate="yes" xml:space="preserve">
+          <source>Avoid legacy threading switching APIs</source>
+          <target state="new">Avoid legacy threading switching APIs</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.pl.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.pl.xlf
@@ -169,6 +169,14 @@ Use AsyncLazy&lt;T&gt; instead.</source>
           <source>Offer async methods</source>
           <target state="new">Offer async methods</target>
         </trans-unit>
+        <trans-unit id="VSSDK014_MessageFormat" translate="yes" xml:space="preserve">
+          <source>Await JoinableTaskFactory.SwitchToMainThreadAsync() to switch to the UI thread instead of APIs that can deadlock or require specifying a priority.</source>
+          <target state="new">Await JoinableTaskFactory.SwitchToMainThreadAsync() to switch to the UI thread instead of APIs that can deadlock or require specifying a priority.</target>
+        </trans-unit>
+        <trans-unit id="VSSDK014_Title" translate="yes" xml:space="preserve">
+          <source>Avoid legacy threading switching APIs</source>
+          <target state="new">Avoid legacy threading switching APIs</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.pt-BR.xlf
@@ -169,6 +169,14 @@ Use AsyncLazy&lt;T&gt; instead.</source>
           <source>Offer async methods</source>
           <target state="new">Offer async methods</target>
         </trans-unit>
+        <trans-unit id="VSSDK014_MessageFormat" translate="yes" xml:space="preserve">
+          <source>Await JoinableTaskFactory.SwitchToMainThreadAsync() to switch to the UI thread instead of APIs that can deadlock or require specifying a priority.</source>
+          <target state="new">Await JoinableTaskFactory.SwitchToMainThreadAsync() to switch to the UI thread instead of APIs that can deadlock or require specifying a priority.</target>
+        </trans-unit>
+        <trans-unit id="VSSDK014_Title" translate="yes" xml:space="preserve">
+          <source>Avoid legacy threading switching APIs</source>
+          <target state="new">Avoid legacy threading switching APIs</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.ru.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.ru.xlf
@@ -169,6 +169,14 @@ Use AsyncLazy&lt;T&gt; instead.</source>
           <source>Offer async methods</source>
           <target state="new">Offer async methods</target>
         </trans-unit>
+        <trans-unit id="VSSDK014_MessageFormat" translate="yes" xml:space="preserve">
+          <source>Await JoinableTaskFactory.SwitchToMainThreadAsync() to switch to the UI thread instead of APIs that can deadlock or require specifying a priority.</source>
+          <target state="new">Await JoinableTaskFactory.SwitchToMainThreadAsync() to switch to the UI thread instead of APIs that can deadlock or require specifying a priority.</target>
+        </trans-unit>
+        <trans-unit id="VSSDK014_Title" translate="yes" xml:space="preserve">
+          <source>Avoid legacy threading switching APIs</source>
+          <target state="new">Avoid legacy threading switching APIs</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.tr.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.tr.xlf
@@ -169,6 +169,14 @@ AsyncLazy&lt;T&gt; yerine kullanmanız gerekir.</target>
           <source>Offer async methods</source>
           <target state="new">Offer async methods</target>
         </trans-unit>
+        <trans-unit id="VSSDK014_MessageFormat" translate="yes" xml:space="preserve">
+          <source>Await JoinableTaskFactory.SwitchToMainThreadAsync() to switch to the UI thread instead of APIs that can deadlock or require specifying a priority.</source>
+          <target state="new">Await JoinableTaskFactory.SwitchToMainThreadAsync() to switch to the UI thread instead of APIs that can deadlock or require specifying a priority.</target>
+        </trans-unit>
+        <trans-unit id="VSSDK014_Title" translate="yes" xml:space="preserve">
+          <source>Avoid legacy threading switching APIs</source>
+          <target state="new">Avoid legacy threading switching APIs</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.zh-Hans.xlf
@@ -169,6 +169,14 @@ Use AsyncLazy&lt;T&gt; instead.</source>
           <source>Offer async methods</source>
           <target state="new">Offer async methods</target>
         </trans-unit>
+        <trans-unit id="VSSDK014_MessageFormat" translate="yes" xml:space="preserve">
+          <source>Await JoinableTaskFactory.SwitchToMainThreadAsync() to switch to the UI thread instead of APIs that can deadlock or require specifying a priority.</source>
+          <target state="new">Await JoinableTaskFactory.SwitchToMainThreadAsync() to switch to the UI thread instead of APIs that can deadlock or require specifying a priority.</target>
+        </trans-unit>
+        <trans-unit id="VSSDK014_Title" translate="yes" xml:space="preserve">
+          <source>Avoid legacy threading switching APIs</source>
+          <target state="new">Avoid legacy threading switching APIs</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.zh-Hant.xlf
@@ -169,6 +169,14 @@ Use AsyncLazy&lt;T&gt; instead.</source>
           <source>Offer async methods</source>
           <target state="new">Offer async methods</target>
         </trans-unit>
+        <trans-unit id="VSSDK014_MessageFormat" translate="yes" xml:space="preserve">
+          <source>Await JoinableTaskFactory.SwitchToMainThreadAsync() to switch to the UI thread instead of APIs that can deadlock or require specifying a priority.</source>
+          <target state="new">Await JoinableTaskFactory.SwitchToMainThreadAsync() to switch to the UI thread instead of APIs that can deadlock or require specifying a priority.</target>
+        </trans-unit>
+        <trans-unit id="VSSDK014_Title" translate="yes" xml:space="preserve">
+          <source>Avoid legacy threading switching APIs</source>
+          <target state="new">Avoid legacy threading switching APIs</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Namespaces.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Namespaces.cs
@@ -9,6 +9,12 @@
             nameof(System),
         };
 
+        internal static readonly IReadOnlyList<string> SystemThreading = new[]
+        {
+            nameof(System),
+            nameof(global::System.Threading),
+        };
+
         internal static readonly IReadOnlyList<string> SystemThreadingTasks = new[]
         {
             nameof(System),
@@ -23,11 +29,25 @@
             nameof(global::System.Runtime.CompilerServices),
         };
 
+        internal static readonly IReadOnlyList<string> SystemWindowsThreading = new[]
+        {
+            nameof(System),
+            nameof(global::System.Windows),
+            "Threading",
+        };
+
         internal static readonly IReadOnlyList<string> MicrosoftVisualStudioThreading = new[]
         {
             "Microsoft",
             "VisualStudio",
             "Threading",
+        };
+
+        internal static readonly IReadOnlyList<string> MicrosoftVisualStudioShell = new[]
+        {
+            "Microsoft",
+            "VisualStudio",
+            "Shell",
         };
     }
 }

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.Designer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.Designer.cs
@@ -341,5 +341,23 @@ namespace Microsoft.VisualStudio.Threading.Analyzers {
                 return ResourceManager.GetString("VSSDK013_Title", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Await JoinableTaskFactory.SwitchToMainThreadAsync() to switch to the UI thread instead of APIs that can deadlock or require specifying a priority..
+        /// </summary>
+        internal static string VSSDK014_MessageFormat {
+            get {
+                return ResourceManager.GetString("VSSDK014_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Avoid legacy threading switching APIs.
+        /// </summary>
+        internal static string VSSDK014_Title {
+            get {
+                return ResourceManager.GetString("VSSDK014_Title", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.resx
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.resx
@@ -222,4 +222,10 @@ Use AsyncLazy&lt;T&gt; instead.</value>
   <data name="VSSDK013_Title" xml:space="preserve">
     <value>Offer async methods</value>
   </data>
+  <data name="VSSDK014_MessageFormat" xml:space="preserve">
+    <value>Await JoinableTaskFactory.SwitchToMainThreadAsync() to switch to the UI thread instead of APIs that can deadlock or require specifying a priority.</value>
+  </data>
+  <data name="VSSDK014_Title" xml:space="preserve">
+    <value>Avoid legacy threading switching APIs</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Types.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Types.cs
@@ -80,5 +80,36 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
 
             internal const string JoinAsync = "JoinAsync";
         }
+
+        internal static class SynchronizationContext
+        {
+            internal const string TypeName = nameof(System.Threading.SynchronizationContext);
+
+            internal const string Post = nameof(System.Threading.SynchronizationContext.Post);
+
+            internal const string Send = nameof(System.Threading.SynchronizationContext.Send);
+        }
+
+        internal static class ThreadHelper
+        {
+            internal const string TypeName = "ThreadHelper";
+
+            internal const string Invoke = "Invoke";
+
+            internal const string InvokeAsync = "InvokeAsync";
+
+            internal const string BeginInvoke = "BeginInvoke";
+        }
+
+        internal static class Dispatcher
+        {
+            internal const string TypeName = "Dispatcher";
+
+            internal const string Invoke = "Invoke";
+
+            internal const string BeginInvoke = "BeginInvoke";
+
+            internal const string InvokeAsync = "InvokeAsync";
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/VSSDK014AvoidLegacyThreadSwitchingAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/VSSDK014AvoidLegacyThreadSwitchingAnalyzer.cs
@@ -1,0 +1,61 @@
+﻿namespace Microsoft.VisualStudio.Threading.Analyzers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using CodeAnalysis;
+    using CodeAnalysis.CSharp;
+    using CodeAnalysis.CSharp.Syntax;
+    using CodeAnalysis.Diagnostics;
+
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class VSSDK014AvoidLegacyThreadSwitchingAnalyzer : DiagnosticAnalyzer
+    {
+        public const string Id = "VSSDK014";
+
+        internal static readonly DiagnosticDescriptor Descriptor = new DiagnosticDescriptor(
+            id: Id,
+            title: Strings.VSSDK014_Title,
+            messageFormat: Strings.VSSDK014_MessageFormat,
+            category: "Usage",
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptor);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze);
+
+            context.RegisterSyntaxNodeAction(this.AnalyzeInvocation, SyntaxKind.InvocationExpression);
+        }
+
+        private void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+        {
+            var invocationSyntax = (InvocationExpressionSyntax)context.Node;
+            var invokeMethod = context.SemanticModel.GetSymbolInfo(context.Node).Symbol as IMethodSymbol;
+            if (invokeMethod != null)
+            {
+                foreach (var legacyMethod in CommonInterest.LegacyThreadSwitchingMethods)
+                {
+                    context.CancellationToken.ThrowIfCancellationRequested();
+
+                    if (invokeMethod.Name == legacyMethod.MethodName &&
+                        invokeMethod.ContainingType.Name == legacyMethod.ContainingTypeName &&
+                        invokeMethod.ContainingType.BelongsToNamespace(legacyMethod.ContainingTypeNamespace))
+                    {
+                        var diagnostic = Diagnostic.Create(
+                            Descriptor,
+                            invocationSyntax.Expression.GetLocation());
+                        context.ReportDiagnostic(diagnostic);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
# VSSDK014 Avoid legacy thread switching methods

Switching to the UI thread should be done using `JoinableTaskFactory.SwitchToMainThreadAsync`
rather than legacy methods such as `Dispatcher.Invoke` or `ThreadHelper.Invoke`.
This avoids deadlocks and can reduce threadpool starvation.

## Examples of patterns that are flagged by this analyzer

```csharp
void Foo() {
    ThreadHelper.Generic.Invoke(delegate {
        DoSomething();
    });
}
```

## Solution

Use `await SwitchToMainThreadAsync()` instead, wrapping with `JoinableTaskFactory.Run` if necessary:

```csharp
void Foo() {
    ThreadHelper.JoinableTaskFactory.Run(async delegate {
        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
        DoSomething();
    });
}
```