### PR TITLE
Fix mis-fire of VSSDK012 when JTF is the receiver of an extension method

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSSDK012SpecifyJtfWhereAllowedTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSSDK012SpecifyJtfWhereAllowedTests.cs
@@ -167,5 +167,30 @@ class Test {
 
             this.VerifyCSharpDiagnostic(test);
         }
+
+        [Fact]
+        public void JTF_RunAsync_GeneratesNoWarning()
+        {
+            var test = @"
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
+using System.Threading.Tasks;
+using Task = System.Threading.Tasks.Task;
+
+class Test {
+    JoinableTaskFactory jtf;
+
+    void F() {
+        jtf.RunAsync(
+            VsTaskRunContext.UIThreadBackgroundPriority,
+            async delegate {
+                await Task.Yield();
+            });
+    }
+}
+";
+
+            this.VerifyCSharpDiagnostic(test);
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/VSSDK012SpecifyJtfWhereAllowed.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/VSSDK012SpecifyJtfWhereAllowed.cs
@@ -73,7 +73,7 @@
                 // The method being invoked doesn't take any JTC/JTF parameters.
                 // Look for an overload that does.
                 bool preferableAlternativesExist = otherOverloads
-                    .Any(m => m.Parameters.Any(IsJtfParameter));
+                    .Any(m => m.Parameters.Skip(m.IsExtensionMethod ? 1 : 0).Any(IsJtfParameter));
                 if (preferableAlternativesExist)
                 {
                     Diagnostic diagnostic = Diagnostic.Create(


### PR DESCRIPTION
When installing these analyzers to the VS source tree, I discovered that using the `JTF.RunAsync(VsTaskRunContext, Func<Task>)` extension method would cause VSSDK012 to fire since no argument was supplied for the JTF (since it is the implicit receiver of the method call when used with extension method syntax.

This fixes that bug by recognizing that we should skip first parameters of extension methods when looking for overloads that accept JTF.