### PR TITLE
JoinableTask.JoinAsync completes without UI thread

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Shared/JoinableTask.cs
+++ b/src/Microsoft.VisualStudio.Threading.Shared/JoinableTask.cs
@@ -514,7 +514,7 @@ namespace Microsoft.VisualStudio.Threading
 
             using (this.AmbientJobJoinsThis())
             {
-                await this.Task.WithCancellation(cancellationToken);
+                await this.Task.WithCancellation(cancellationToken).ConfigureAwait(false);
             }
         }
 

--- a/src/Microsoft.VisualStudio.Threading.Tests.Shared/JoinableTaskTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests.Shared/JoinableTaskTests.cs
@@ -3249,6 +3249,34 @@
             });
         }
 
+        [StaFact]
+        public void JoinAsyncShouldCompleteWithoutUIThreadAfterCancellation()
+        {
+            var jt = this.asyncPump.RunAsync(async delegate {
+                await Task.Yield();
+            });
+            var cts = new CancellationTokenSource();
+            var joinTask = jt.JoinAsync(cts.Token);
+            cts.Cancel();
+
+            // We expect to be able to block on the UI thread and the Task complete.
+            // In completing, it will throw a TaskCanceledException, wrapped by an
+            // AggregateException. If it 'hangs', it will timeout, returning false.
+            Assert.Throws<AggregateException>(() => joinTask.Wait(AsyncDelay));
+        }
+
+        [StaFact]
+        public void JoinAsyncShouldCompleteWithoutUIThreadAfterTaskCompletes()
+        {
+            var mre = new AsyncManualResetEvent();
+            var jt = this.asyncPump.RunAsync(async delegate {
+                await mre.WaitAsync().ConfigureAwait(false);
+            });
+            var joinTask = jt.JoinAsync();
+            mre.Set();
+            Assert.True(joinTask.Wait(AsyncDelay));
+        }
+
         protected override JoinableTaskContext CreateJoinableTaskContext()
         {
             return new DerivedJoinableTaskContext();

--- a/src/Microsoft.VisualStudio.Threading.Tests.Shared/JoinableTaskTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests.Shared/JoinableTaskTests.cs
@@ -2348,8 +2348,7 @@
 
             // Simulate a modal dialog, with a message pump that is willing
             // to execute hiPriFactory messages but not loPriFactory messages.
-            hiPriFactory.DoModalLoopTillEmpty();
-            Assert.True(outer.IsCompleted);
+            hiPriFactory.DoModalLoopTillEmptyAndTaskCompleted(outer.Task, this.TimeoutToken);
         }
 
         /// <summary>
@@ -2467,8 +2466,7 @@
 
             // Simulate a modal dialog, with a message pump that is willing
             // to execute hiPriFactory messages but not loPriFactory messages.
-            hiPriFactory.DoModalLoopTillEmpty();
-            Assert.True(outer.IsCompleted);
+            hiPriFactory.DoModalLoopTillEmptyAndTaskCompleted(outer.Task, this.TimeoutToken);
         }
 
         /// <summary>
@@ -2502,8 +2500,7 @@
 
             // Simulate a modal dialog, with a message pump that is willing
             // to execute hiPriFactory messages but not loPriFactory messages.
-            hiPriFactory.DoModalLoopTillEmpty();
-            Assert.True(outer.IsCompleted);
+            hiPriFactory.DoModalLoopTillEmptyAndTaskCompleted(outer.Task, this.TimeoutToken);
         }
 
         [SkippableFact]
@@ -3572,7 +3569,8 @@
 
         private class ModalPumpingJoinableTaskFactory : JoinableTaskFactory
         {
-            private ConcurrentQueue<Tuple<SendOrPostCallback, object>> queuedMessages = new ConcurrentQueue<Tuple<SendOrPostCallback, object>>();
+            private readonly ConcurrentQueue<Tuple<SendOrPostCallback, object>> queuedMessages = new ConcurrentQueue<Tuple<SendOrPostCallback, object>>();
+            private readonly AutoResetEvent messageQueued = new AutoResetEvent(false);
 
             internal ModalPumpingJoinableTaskFactory(JoinableTaskContext context)
                 : base(context)
@@ -3596,10 +3594,42 @@
                 }
             }
 
+            /// <summary>
+            /// Executes all work posted to this factory, and waits for more work
+            /// till the specified <paramref name="task"/> completes.
+            /// </summary>
+            /// <param name="task">The task that completes to indicate we can stop pumping messages.</param>
+            /// <param name="cancellationToken">A cancellation token.</param>
+            /// <exception cref="TaskCanceledException">Thrown when <paramref name="cancellationToken"/> is canceled.</exception>
+            /// <remarks>
+            /// This method is useful when we cannot guarantee that all work that will be queued to the
+            /// <see cref="SynchronizationContext"/> has been queued before a Task completes.
+            /// For instance, when work is mixed between the threadpool and the (simulated) message queue.
+            /// </remarks>
+            internal void DoModalLoopTillEmptyAndTaskCompleted(Task task, CancellationToken cancellationToken)
+            {
+                do
+                {
+                    Tuple<SendOrPostCallback, object> work;
+                    while (this.queuedMessages.TryDequeue(out work))
+                    {
+                        work.Item1(work.Item2);
+                        cancellationToken.ThrowIfCancellationRequested();
+                    }
+
+                    WaitHandle.WaitAny(new WaitHandle[] {
+                        cancellationToken.WaitHandle,
+                        this.messageQueued,
+                        ((IAsyncResult)task).AsyncWaitHandle,
+                    });
+                } while (!task.IsCompleted || this.queuedMessages.Count > 0);
+            }
+
             protected override void PostToUnderlyingSynchronizationContext(SendOrPostCallback callback, object state)
             {
                 this.queuedMessages.Enqueue(Tuple.Create(callback, state));
                 base.PostToUnderlyingSynchronizationContext(callback, state);
+                this.messageQueued.Set();
             }
         }
 


### PR DESCRIPTION
The JoinAsync method would capture the context of its caller and require it to complete after its underlying JoinableTask completes. This is inefficient since completing should not require this SynchronizationContext.
Theoretically (and as the two new tests demonstrated) it could also lead to deadlocks (but that would require that callers weren't following the threading rules anyway).

Thanks to @sharwell for noticing the need for this.