### PR TITLE
Avoid a few more allocations for AsyncLazy execution

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Shared/AsyncLazy.cs
+++ b/src/Microsoft.VisualStudio.Threading.Shared/AsyncLazy.cs
@@ -149,9 +149,9 @@ namespace Microsoft.VisualStudio.Threading
                         this.valueFactory = null;
                         Func<Task<T>> valueFactory = async delegate
                         {
-                            await resumableAwaiter;
                             try
                             {
+                                await resumableAwaiter;
                                 return await originalValueFactory().ConfigureAwait(continueOnCapturedContext: false);
                             }
                             finally

--- a/src/Microsoft.VisualStudio.Threading.Shared/AsyncLazy.cs
+++ b/src/Microsoft.VisualStudio.Threading.Shared/AsyncLazy.cs
@@ -171,6 +171,8 @@ namespace Microsoft.VisualStudio.Threading
                                         that.joinableTask = null;
                                     },
                                     this,
+                                    CancellationToken.None,
+                                    TaskContinuationOptions.ExecuteSynchronously,
                                     TaskScheduler.Default);
                             }
                             else


### PR DESCRIPTION
We only recently introduced this delegate around the provided value factory, and with that came a small tax. We can make that tax work better for us by moving our cleanup code into it rather than as an extra Task object that must be allocated, along with (likely) an allocated collection to handle the multiple continuations off of the this.value Task.