### PR TITLE
JoinableTask.JoinAsync<T> completes without UI thread

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Shared/JoinableTask`1.cs
+++ b/src/Microsoft.VisualStudio.Threading.Shared/JoinableTask`1.cs
@@ -55,8 +55,8 @@ namespace Microsoft.VisualStudio.Threading
         /// <returns>A task that completes after the asynchronous operation completes and the join is reverted, with the result of the operation.</returns>
         public new async Task<T> JoinAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            await base.JoinAsync(cancellationToken);
-            return await this.Task;
+            await base.JoinAsync(cancellationToken).ConfigureAwait(false);
+            return await this.Task.ConfigureAwait(false);
         }
 
         /// <summary>


### PR DESCRIPTION
The JoinAsync method would capture the context of its caller and require it to complete after its underlying JoinableTask completes. This is inefficient since completing should not require this SynchronizationContext.
Theoretically (and as the two new tests demonstrated) it could also lead to deadlocks (but that would require that callers weren't following the threading rules anyway).

Similar to #69 but applies to the derived `JoinableTask<T>` class whereas the former PR only applied to the base `JoinableTask` class.

Fixes #98