### PR TITLE
Allow running tests locally via Test Explorer

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Tests/App.config
+++ b/src/Microsoft.VisualStudio.Threading.Tests/App.config
@@ -6,6 +6,7 @@
     <!-- Set this setting to "true" to test Windows 7 mode. -->
     <add key="Microsoft.VisualStudio.Threading.Windows7Mode" value="false"/>
     <add key="xunit.methodDisplay" value="method" />
+    <add key="xunit.shadowCopy" value="false"/>
   </appSettings>
 
 </configuration>


### PR DESCRIPTION
Fixes #103

Approach taken from dotnet/roslyn-analyzers#927.