### PR TITLE
Add initial .editorconfig

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,0 +1,62 @@
+root = true
+
+[*.cs]
+indent_style = space
+indent_size = 4
+
+# Make Visual Studio consistent with SA1101 (use "this" prefix), but allow StyleCop to report it
+dotnet_style_qualification_for_field = true:silent
+dotnet_style_qualification_for_property = true:silent
+dotnet_style_qualification_for_method = true:silent
+dotnet_style_qualification_for_event = true:silent
+
+# Make Visual Studio consistent with SA1121 (use predefined type), but allow StyleCop to report it
+dotnet_style_predefined_type_for_locals_parameters_members = true:silent
+dotnet_style_predefined_type_for_member_access = true:silent
+csharp_style_var_for_built_in_types = false:silent
+
+# Additional settings to make the Visual Studio formatter follow StyleCop
+dotnet_sort_system_directives_first = true
+
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = false
+
+# New line preferences
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_within_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = flush_left
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = do_not_ignore
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false

--- a/src/Microsoft.VisualStudio.Threading.sln
+++ b/src/Microsoft.VisualStudio.Threading.sln
@@ -12,6 +12,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\appveyor.yml = ..\appveyor.yml
 		..\Directory.Build.props = ..\Directory.Build.props
 		..\nuget.config = ..\nuget.config
+		.editorconfig = .editorconfig
+		stylecop.json = stylecop.json
 		version.json = version.json
 	EndProjectSection
 EndProject


### PR DESCRIPTION
This file configures most formatting settings in Visual Studio 2017 to follow
StyleCop guidelines, reducing the number of cases where a developer sees a
warning that needs to be fixed.