### PR TITLE
Fix WaitWithoutInlinining to not wait for inlined continuations

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/TplExtensions.cs
+++ b/src/Microsoft.VisualStudio.Threading/TplExtensions.cs
@@ -52,7 +52,7 @@ namespace Microsoft.VisualStudio.Threading
             if (!task.IsCompleted)
             {
                 // Waiting on a continuation of a task won't ever inline the predecessor (in .NET 4.x anyway).
-                var continuation = task.ContinueWith(t => { }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+                var continuation = task.ContinueWith(t => { }, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default);
                 continuation.Wait();
             }
 


### PR DESCRIPTION
This adds a slight inefficiency (requiring the threadpool to execute a no-op delegate) in favor of mitigating the risk of deadlocks or very long unnecessary waits due to inlined continuations that precede the one we add.