### PR TITLE
Fix two race conditions around JoinableTaskSynchronizationContext.Post

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Shared/JoinableTask+JoinableTaskSynchronizationContext.cs
+++ b/src/Microsoft.VisualStudio.Threading.Shared/JoinableTask+JoinableTaskSynchronizationContext.cs
@@ -75,9 +75,10 @@ namespace Microsoft.VisualStudio.Threading
             /// </summary>
             public override void Post(SendOrPostCallback d, object state)
             {
-                if (this.job != null)
+                JoinableTask job = this.job; // capture as local in case field becomes null later.
+                if (job != null)
                 {
-                    this.job.Post(d, state, this.mainThreadAffinitized);
+                    job.Post(d, state, this.mainThreadAffinitized);
                 }
                 else
                 {

--- a/src/Microsoft.VisualStudio.Threading.Shared/JoinableTask.cs
+++ b/src/Microsoft.VisualStudio.Threading.Shared/JoinableTask.cs
@@ -465,7 +465,7 @@ namespace Microsoft.VisualStudio.Threading
             get
             {
                 return (this.state & JoinableTaskFlags.StartedSynchronously) == JoinableTaskFlags.StartedSynchronously
-                    && (this.state & JoinableTaskFlags.StartedOnMainThread) == JoinableTaskFlags.None
+                    && (this.state & JoinableTaskFlags.StartedOnMainThread) != JoinableTaskFlags.StartedOnMainThread
                     && (this.state & JoinableTaskFlags.CompleteRequested) != JoinableTaskFlags.CompleteRequested;
             }
         }

--- a/src/Microsoft.VisualStudio.Threading.Shared/JoinableTask.cs
+++ b/src/Microsoft.VisualStudio.Threading.Shared/JoinableTask.cs
@@ -465,7 +465,8 @@ namespace Microsoft.VisualStudio.Threading
             get
             {
                 return (this.state & JoinableTaskFlags.StartedSynchronously) == JoinableTaskFlags.StartedSynchronously
-                    && (this.state & JoinableTaskFlags.StartedOnMainThread) == JoinableTaskFlags.None;
+                    && (this.state & JoinableTaskFlags.StartedOnMainThread) == JoinableTaskFlags.None
+                    && (this.state & JoinableTaskFlags.CompleteRequested) != JoinableTaskFlags.CompleteRequested;
             }
         }
 
@@ -475,7 +476,8 @@ namespace Microsoft.VisualStudio.Threading
             get
             {
                 return (this.state & JoinableTaskFlags.StartedSynchronously) == JoinableTaskFlags.StartedSynchronously
-                && (this.state & JoinableTaskFlags.StartedOnMainThread) == JoinableTaskFlags.StartedOnMainThread;
+                    && (this.state & JoinableTaskFlags.StartedOnMainThread) == JoinableTaskFlags.StartedOnMainThread
+                    && (this.state & JoinableTaskFlags.CompleteRequested) != JoinableTaskFlags.CompleteRequested;
             }
         }
 


### PR DESCRIPTION
When `JoinableTaskFactory.Run` is invoked from a background thread, and its delegate captures the `SynchronizationContext` and posts to it from another thread at about the same time as the JTF.Run delegate completes, two race conditions exist:

1. `JoinableTaskSynchronizationContext.Post` checks `this.job!=null` before dereferencing it, but another thread sets it to null between the check and the dereference, leading to `NullReferenceException` being thrown from the `Post` method. This crashes Visual Studio. Issue #114. The fix for this is to capture the field as a local variable first. If the field changes in the middle, that's OK, because a completed `JoinableTask` knows how to transfer posted work to the threadpool or `JoinableTaskFactory`.
1. When `JoinableTask.Post` executes it may add the posted work to `threadPoolQueue` after `JoinableTask.CompleteOnCurrentThread` has considered migrating that queue to the .NET ThreadPool as part of completing the task. With no one processing that queue, that delegate gets GC'd instead of scheduled and executed. Issue #115. The fix for this is to make our state-checking properties a bit more careful about saying whether JTF.Run is *still* blocking its calling thread. In the race condition case, these were reporting that the thread was blocked, even though JTF.Run had returned or was in the process of returning. By making these properties return false in this condition, the `JoinableTask.Post` method decides to skip its `threadPoolQueue` and go directly to the `ThreadPool` as required.

FYI, we found #114 via crash dumps. I found #115 by accident while writing the unit test to repro #114. Yay, TDD!

Fixes #114 
Fixes #115 