### PR TITLE
Do not require threadpool to complete UI thread bound work

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Tests/JoinableTaskFactoryTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/JoinableTaskFactoryTests.cs
@@ -102,6 +102,31 @@
             });
         }
 
+        [StaFact]
+        public void RunShouldCompleteWithStarvedThreadPool()
+        {
+            using (TestUtilities.StarveThreadpool())
+            {
+                this.asyncPump.Run(async delegate
+                {
+                    await Task.Yield();
+                });
+            }
+        }
+
+        [StaFact]
+        public void RunOfTShouldCompleteWithStarvedThreadPool()
+        {
+            using (TestUtilities.StarveThreadpool())
+            {
+                int result = this.asyncPump.Run(async delegate
+                {
+                    await Task.Yield();
+                    return 1;
+                });
+            }
+        }
+
         /// <summary>
         /// A <see cref="JoinableTaskFactory"/> that allows a test to inject code
         /// in the main thread transition events.

--- a/src/Microsoft.VisualStudio.Threading.Tests/JoinableTaskTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/JoinableTaskTests.cs
@@ -3349,6 +3349,66 @@
             Assert.True(joinTask.Wait(AsyncDelay));
         }
 
+        [StaFact]
+        public void JoinShouldCompleteWithStarvedThreadPool()
+        {
+            using (TestUtilities.StarveThreadpool())
+            {
+                var jt = this.asyncPump.RunAsync(async delegate
+                {
+                    await Task.Yield();
+                });
+                jt.Join(this.TimeoutToken);
+            }
+        }
+
+        [StaFact]
+        public void JoinOfTShouldCompleteWithStarvedThreadPool()
+        {
+            using (TestUtilities.StarveThreadpool())
+            {
+                var jt = this.asyncPump.RunAsync(async delegate
+                {
+                    await Task.Yield();
+                    return 1;
+                });
+                int result = jt.Join(this.TimeoutToken);
+            }
+        }
+
+        [StaFact]
+        public void JoinAsyncShouldCompleteWithStarvedThreadPool()
+        {
+            using (TestUtilities.StarveThreadpool())
+            {
+                var jt = this.asyncPump.RunAsync(async delegate
+                {
+                    await Task.Yield();
+                });
+                this.asyncPump.Run(async delegate
+                {
+                    await jt.JoinAsync(this.TimeoutToken);
+                });
+            }
+        }
+
+        [StaFact]
+        public void JoinAsyncOfTShouldCompleteWithStarvedThreadPool()
+        {
+            using (TestUtilities.StarveThreadpool())
+            {
+                var jt = this.asyncPump.RunAsync(async delegate
+                {
+                    await Task.Yield();
+                    return 1;
+                });
+                this.asyncPump.Run(async delegate
+                {
+                    int result = await jt.JoinAsync(this.TimeoutToken);
+                });
+            }
+        }
+
         protected override JoinableTaskContext CreateJoinableTaskContext()
         {
             return new DerivedJoinableTaskContext();

--- a/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
@@ -532,7 +532,7 @@ namespace Microsoft.VisualStudio.Threading
 
             using (this.AmbientJobJoinsThis())
             {
-                await this.Task.WithCancellationJtfAware(cancellationToken).ConfigureAwait(AwaitShouldCaptureSyncContext);
+                await this.Task.WithCancellation(AwaitShouldCaptureSyncContext, cancellationToken).ConfigureAwait(AwaitShouldCaptureSyncContext);
             }
         }
 

--- a/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
@@ -532,7 +532,7 @@ namespace Microsoft.VisualStudio.Threading
 
             using (this.AmbientJobJoinsThis())
             {
-                await this.Task.WithCancellation(cancellationToken).ConfigureAwait(AwaitShouldCaptureSyncContext);
+                await this.Task.WithCancellationJtfAware(cancellationToken).ConfigureAwait(AwaitShouldCaptureSyncContext);
             }
         }
 

--- a/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
@@ -484,6 +484,20 @@ namespace Microsoft.VisualStudio.Threading
         }
 
         /// <summary>
+        /// Gets a value indicating whether an awaiter should capture the
+        /// <see cref="SynchronizationContext"/>.
+        /// </summary>
+        /// <remarks>
+        /// As a library, we generally wouldn't capture the <see cref="SynchronizationContext"/>
+        /// when awaiting, except that where our thread is synchronously blocking anyway, it is actually
+        /// more efficient to capture the <see cref="SynchronizationContext"/> so that the continuation
+        /// will resume on the blocking thread instead of occupying yet another one in order to execute.
+        /// In fact, when threadpool starvation conditions exist, resuming on the calling thread
+        /// can avoid significant delays in executing an often trivial continuation.
+        /// </remarks>
+        internal static bool AwaitShouldCaptureSyncContext => SynchronizationContext.Current is JoinableTaskSynchronizationContext;
+
+        /// <summary>
         /// Synchronously blocks the calling thread until the operation has completed.
         /// If the caller is on the Main thread (or is executing within a JoinableTask that has access to the main thread)
         /// the caller's access to the Main thread propagates to this JoinableTask so that it may also access the main thread.
@@ -518,7 +532,7 @@ namespace Microsoft.VisualStudio.Threading
 
             using (this.AmbientJobJoinsThis())
             {
-                await this.Task.WithCancellation(cancellationToken).ConfigureAwait(false);
+                await this.Task.WithCancellation(cancellationToken).ConfigureAwait(AwaitShouldCaptureSyncContext);
             }
         }
 

--- a/src/Microsoft.VisualStudio.Threading/JoinableTask`1.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTask`1.cs
@@ -55,8 +55,8 @@ namespace Microsoft.VisualStudio.Threading
         /// <returns>A task that completes after the asynchronous operation completes and the join is reverted, with the result of the operation.</returns>
         public new async Task<T> JoinAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            await base.JoinAsync(cancellationToken).ConfigureAwait(false);
-            return await this.Task.ConfigureAwait(false);
+            await base.JoinAsync(cancellationToken).ConfigureAwait(AwaitShouldCaptureSyncContext);
+            return await this.Task.ConfigureAwait(AwaitShouldCaptureSyncContext);
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.Threading/ThreadingTools.cs
+++ b/src/Microsoft.VisualStudio.Threading/ThreadingTools.cs
@@ -184,7 +184,7 @@ namespace Microsoft.VisualStudio.Threading
             var tcs = new TaskCompletionSource<bool>();
             using (cancellationToken.Register(s => ((TaskCompletionSource<bool>)s).TrySetResult(true), tcs))
             {
-                if (task != await Task.WhenAny(task, tcs.Task).ConfigureAwait(false))
+                if (task != await Task.WhenAny(task, tcs.Task).ConfigureAwait(JoinableTask.AwaitShouldCaptureSyncContext))
                 {
                     cancellationToken.ThrowIfCancellationRequested();
                 }
@@ -193,7 +193,7 @@ namespace Microsoft.VisualStudio.Threading
             // Rethrow any fault/cancellation exception, even if we awaited above.
             // But if we skipped the above if branch, this will actually yield
             // on an incompleted task.
-            await task.ConfigureAwait(false);
+            await task.ConfigureAwait(JoinableTask.AwaitShouldCaptureSyncContext);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.Threading/ThreadingTools.cs
+++ b/src/Microsoft.VisualStudio.Threading/ThreadingTools.cs
@@ -97,7 +97,7 @@ namespace Microsoft.VisualStudio.Threading
                 return TaskFromCanceled(cancellationToken);
             }
 
-            return WithCancellationSlow(task, cancellationToken);
+            return WithCancellationSlow(task, cancellationToken, jtfAware: false);
         }
 
         /// <summary>
@@ -108,6 +108,30 @@ namespace Microsoft.VisualStudio.Threading
         public static SpecializedSyncContext Apply(this SynchronizationContext syncContext, bool checkForChangesOnRevert = true)
         {
             return SpecializedSyncContext.Apply(syncContext, checkForChangesOnRevert);
+        }
+
+        /// <summary>
+        /// Wraps a task with one that will complete as cancelled based on a cancellation token,
+        /// allowing someone to await a task but be able to break out early by cancelling the token.
+        /// </summary>
+        /// <param name="task">The task to wrap.</param>
+        /// <param name="cancellationToken">The token that can be canceled to break out of the await.</param>
+        /// <returns>The wrapping task.</returns>
+        internal static Task WithCancellationJtfAware(this Task task, CancellationToken cancellationToken)
+        {
+            Requires.NotNull(task, nameof(task));
+
+            if (!cancellationToken.CanBeCanceled || task.IsCompleted)
+            {
+                return task;
+            }
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return TaskFromCanceled(cancellationToken);
+            }
+
+            return WithCancellationSlow(task, cancellationToken, jtfAware: true);
         }
 
         internal static bool TrySetCanceled<T>(this TaskCompletionSource<T> tcs, CancellationToken cancellationToken)
@@ -175,8 +199,9 @@ namespace Microsoft.VisualStudio.Threading
         /// </summary>
         /// <param name="task">The task to wrap.</param>
         /// <param name="cancellationToken">The token that can be canceled to break out of the await.</param>
+        /// <param name="jtfAware">A value indicating whether the caller is expected to be following the rules of the <see cref="JoinableTaskFactory"/>.</param>
         /// <returns>The wrapping task.</returns>
-        private static async Task WithCancellationSlow(this Task task, CancellationToken cancellationToken)
+        private static async Task WithCancellationSlow(this Task task, CancellationToken cancellationToken, bool jtfAware)
         {
             Assumes.NotNull(task);
             Assumes.True(cancellationToken.CanBeCanceled);
@@ -184,7 +209,7 @@ namespace Microsoft.VisualStudio.Threading
             var tcs = new TaskCompletionSource<bool>();
             using (cancellationToken.Register(s => ((TaskCompletionSource<bool>)s).TrySetResult(true), tcs))
             {
-                if (task != await Task.WhenAny(task, tcs.Task).ConfigureAwait(JoinableTask.AwaitShouldCaptureSyncContext))
+                if (task != await Task.WhenAny(task, tcs.Task).ConfigureAwait(jtfAware && JoinableTask.AwaitShouldCaptureSyncContext))
                 {
                     cancellationToken.ThrowIfCancellationRequested();
                 }
@@ -193,7 +218,7 @@ namespace Microsoft.VisualStudio.Threading
             // Rethrow any fault/cancellation exception, even if we awaited above.
             // But if we skipped the above if branch, this will actually yield
             // on an incompleted task.
-            await task.ConfigureAwait(JoinableTask.AwaitShouldCaptureSyncContext);
+            await task.ConfigureAwait(jtfAware && JoinableTask.AwaitShouldCaptureSyncContext);
         }
     }
 }


### PR DESCRIPTION
A few months back we "fixed" some "deadlocks" when callers of `JoinableTaskFactory.JoinAsync` would then call `Task.Wait()` on the returned Task. That is obviously a violation of the threading rules but some legacy code exists that really wants to call `Task.Wait()` on the result of a JTF.RunAsync operation so it was important that nothing in the vs-threading code depended on the UI thread being responsive.

However, that led to several tests becoming unstable. It also made `JTF.Run` and `JT.Join()` more vulnerable to threadpool starvation conditions in that they couldn't complete even with a dedicated thread if the threadpool wasn't immediately available. This PR fine-tunes the `ConfigureAwait(bool)` policy for these awaiting methods so that when run inside (some) JTF delegates they capture the SyncContext, otherwise they don't.

Changes the way PRs #69 and #99 solve the original issue.