### PR TITLE
Fix two race conditions around JoinableTaskSynchronizationContext.Post

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Shared/JoinableTask+JoinableTaskSynchronizationContext.cs
+++ b/src/Microsoft.VisualStudio.Threading.Shared/JoinableTask+JoinableTaskSynchronizationContext.cs
@@ -75,9 +75,10 @@ namespace Microsoft.VisualStudio.Threading
             /// </summary>
             public override void Post(SendOrPostCallback d, object state)
             {
-                if (this.job != null)
+                JoinableTask job = this.job; // capture as local in case field becomes null later.
+                if (job != null)
                 {
-                    this.job.Post(d, state, this.mainThreadAffinitized);
+                    job.Post(d, state, this.mainThreadAffinitized);
                 }
                 else
                 {

--- a/src/Microsoft.VisualStudio.Threading.Shared/JoinableTask.cs
+++ b/src/Microsoft.VisualStudio.Threading.Shared/JoinableTask.cs
@@ -465,7 +465,7 @@ namespace Microsoft.VisualStudio.Threading
             get
             {
                 return (this.state & JoinableTaskFlags.StartedSynchronously) == JoinableTaskFlags.StartedSynchronously
-                    && (this.state & JoinableTaskFlags.StartedOnMainThread) == JoinableTaskFlags.None
+                    && (this.state & JoinableTaskFlags.StartedOnMainThread) != JoinableTaskFlags.StartedOnMainThread
                     && (this.state & JoinableTaskFlags.CompleteRequested) != JoinableTaskFlags.CompleteRequested;
             }
         }

--- a/src/Microsoft.VisualStudio.Threading.Shared/JoinableTask.cs
+++ b/src/Microsoft.VisualStudio.Threading.Shared/JoinableTask.cs
@@ -465,7 +465,8 @@ namespace Microsoft.VisualStudio.Threading
             get
             {
                 return (this.state & JoinableTaskFlags.StartedSynchronously) == JoinableTaskFlags.StartedSynchronously
-                    && (this.state & JoinableTaskFlags.StartedOnMainThread) == JoinableTaskFlags.None;
+                    && (this.state & JoinableTaskFlags.StartedOnMainThread) == JoinableTaskFlags.None
+                    && (this.state & JoinableTaskFlags.CompleteRequested) != JoinableTaskFlags.CompleteRequested;
             }
         }
 
@@ -475,7 +476,8 @@ namespace Microsoft.VisualStudio.Threading
             get
             {
                 return (this.state & JoinableTaskFlags.StartedSynchronously) == JoinableTaskFlags.StartedSynchronously
-                && (this.state & JoinableTaskFlags.StartedOnMainThread) == JoinableTaskFlags.StartedOnMainThread;
+                    && (this.state & JoinableTaskFlags.StartedOnMainThread) == JoinableTaskFlags.StartedOnMainThread
+                    && (this.state & JoinableTaskFlags.CompleteRequested) != JoinableTaskFlags.CompleteRequested;
             }
         }
 


### PR DESCRIPTION
Ports the fixes for #114 and #115 to the v15.2 branch to fix [DevDiv#457263](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/457263) since this is crashing Dev15.2 frequently.

#116 was the original PR for this fix into v15.3, and was approved by @IlyaBiryukov @ikeras @BertanAygun.