### PR TITLE
Fix regression in AsyncManualResetEvent

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Tests/AsyncManualResetEventTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/AsyncManualResetEventTests.cs
@@ -212,5 +212,18 @@
                 Assert.Same(waitTask, setTask2);
             }
         }
+
+        [Fact]
+        public void WaitIsCompleteOnSignaledEvent()
+        {
+            using (TestUtilities.StarveThreadpool())
+            {
+                var presignaledEvent = new AsyncManualResetEvent(initialState: true, allowInliningAwaiters: false);
+
+                // We must assert that the exposed Task is complete as quickly as possible
+                // after creation of the AMRE, since we're testing for possible asynchronously completing Tasks.
+                Assert.True(presignaledEvent.WaitAsync().IsCompleted);
+            }
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.Threading/AsyncManualResetEvent.cs
+++ b/src/Microsoft.VisualStudio.Threading/AsyncManualResetEvent.cs
@@ -74,12 +74,7 @@ namespace Microsoft.VisualStudio.Threading
             this.isSet = initialState;
             if (initialState)
             {
-                // Complete the task immediately. We upcast first so that
-                // the task always completes immediately rather than sometimes
-                // being pushed to another thread and completed asynchronously
-                // on .NET 4.5.
-                TaskCompletionSource<EmptyStruct> tcs = this.taskCompletionSource;
-                tcs.SetResult(EmptyStruct.Instance);
+                this.taskCompletionSource.SetResult(EmptyStruct.Instance);
             }
         }
 

--- a/src/Microsoft.VisualStudio.Threading/TaskCompletionSourceWithoutInlining.cs
+++ b/src/Microsoft.VisualStudio.Threading/TaskCompletionSourceWithoutInlining.cs
@@ -51,7 +51,13 @@ namespace Microsoft.VisualStudio.Threading
         /// <summary>
         /// Gets the <see cref="Task"/> that may never complete inline with completion of this <see cref="TaskCompletionSource{TResult}"/>.
         /// </summary>
-        internal new Task<T> Task => this.exposedTask;
+        /// <devremarks>
+        /// Return the base.Task if it is already completed since inlining continuations
+        /// on the completer is no longer a concern. Also, when we are not inlining continuations,
+        /// this.exposedTask completes slightly later than base.Task, and callers expect
+        /// the Task we return to be complete as soon as they call TrySetResult.
+        /// </devremarks>
+        internal new Task<T> Task => base.Task.IsCompleted ? base.Task : this.exposedTask;
 
         /// <summary>
         /// Modifies the specified flags to include RunContinuationsAsynchronously


### PR DESCRIPTION
The Task it exposed was not completed immediately after calling TrySetResult when the instance was created with the argument to not inline continuations and running in net45 mode.