### PR TITLE
Prevent VSTHRD002 from mis-firing on use of JTF.Run

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD002UseJtfRunAnalyzerTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD002UseJtfRunAnalyzerTests.cs
@@ -266,5 +266,48 @@ namespace Microsoft.VisualStudio.JavaScript.Project {
 ";
             this.VerifyCSharpDiagnostic(test);
         }
+
+        [Fact]
+        public void DoNotReportWarningOnJTFRun()
+        {
+            var test = @"
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
+
+class ProjectProperties {
+    JoinableTaskFactory jtf;
+
+    void F() {
+        jtf.Run(async delegate {
+            await Task.Yield();
+        }); 
+    }
+}
+";
+            this.VerifyCSharpDiagnostic(test);
+        }
+
+        [Fact]
+        public void DoNotReportWarningOnJoinableTaskJoin()
+        {
+            var test = @"
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
+
+class ProjectProperties {
+    JoinableTaskFactory jtf;
+
+    void F() {
+        var jt = jtf.RunAsync(async delegate {
+            await Task.Yield();
+        }); 
+        jt.Join();
+    }
+}
+";
+            this.VerifyCSharpDiagnostic(test);
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/CommonInterest.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/CommonInterest.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Runtime.CompilerServices;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis;
@@ -11,21 +12,21 @@
 
     internal static class CommonInterest
     {
-        internal static readonly IReadOnlyList<SyncBlockingMethod> JTFSyncBlockers = new[]
+        internal static readonly IEnumerable<SyncBlockingMethod> JTFSyncBlockers = new[]
         {
             new SyncBlockingMethod(Namespaces.MicrosoftVisualStudioThreading, Types.JoinableTaskFactory.TypeName, Types.JoinableTaskFactory.Run, Types.JoinableTaskFactory.RunAsync),
             new SyncBlockingMethod(Namespaces.MicrosoftVisualStudioThreading, Types.JoinableTask.TypeName, Types.JoinableTask.Join, Types.JoinableTask.JoinAsync),
         };
 
-        internal static readonly IReadOnlyList<SyncBlockingMethod> SyncBlockingMethods = new[]
+        internal static readonly IEnumerable<SyncBlockingMethod> ProblematicSyncBlockingMethods = new[]
         {
-            new SyncBlockingMethod(Namespaces.MicrosoftVisualStudioThreading, Types.JoinableTaskFactory.TypeName, Types.JoinableTaskFactory.Run, Types.JoinableTaskFactory.RunAsync),
-            new SyncBlockingMethod(Namespaces.MicrosoftVisualStudioThreading, Types.JoinableTask.TypeName, Types.JoinableTask.Join, Types.JoinableTask.JoinAsync),
             new SyncBlockingMethod(Namespaces.SystemThreadingTasks, nameof(Task), nameof(Task.Wait), null),
             new SyncBlockingMethod(Namespaces.SystemRuntimeCompilerServices, nameof(TaskAwaiter), nameof(TaskAwaiter.GetResult), null),
         };
 
-        internal static readonly IReadOnlyList<LegacyThreadSwitchingMethod> LegacyThreadSwitchingMethods = new[]
+        internal static readonly IEnumerable<SyncBlockingMethod> SyncBlockingMethods = JTFSyncBlockers.Concat(ProblematicSyncBlockingMethods);
+
+        internal static readonly IEnumerable<LegacyThreadSwitchingMethod> LegacyThreadSwitchingMethods = new[]
         {
             new LegacyThreadSwitchingMethod(Namespaces.MicrosoftVisualStudioShell, Types.ThreadHelper.TypeName, Types.ThreadHelper.Invoke),
             new LegacyThreadSwitchingMethod(Namespaces.MicrosoftVisualStudioShell, Types.ThreadHelper.TypeName, Types.ThreadHelper.InvokeAsync),
@@ -76,7 +77,7 @@
             SyntaxNodeAnalysisContext context,
             MemberAccessExpressionSyntax memberAccessSyntax,
             DiagnosticDescriptor descriptor,
-            IReadOnlyList<SyncBlockingMethod> problematicMethods,
+            IEnumerable<SyncBlockingMethod> problematicMethods,
             bool ignoreIfInsideAnonymousDelegate = false)
         {
             if (descriptor == null)

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD002UseJtfRunAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD002UseJtfRunAnalyzer.cs
@@ -78,29 +78,7 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
                 context,
                 invocationExpressionSyntax.Expression as MemberAccessExpressionSyntax,
                 Descriptor,
-                CommonInterest.SyncBlockingMethods);
-
-            //if (CommonInterest.ShouldIgnoreContext(context))
-            //{
-            //    return;
-            //}
-
-            //var node = (InvocationExpressionSyntax)context.Node;
-            //var invokeMethod = context.SemanticModel.GetSymbolInfo(context.Node).Symbol as IMethodSymbol;
-            //if (invokeMethod != null)
-            //{
-            //    var taskType = context.SemanticModel.Compilation.GetTypeByMetadataName(typeof(Task).FullName);
-            //    if (string.Equals(invokeMethod.Name, nameof(Task.Wait), StringComparison.Ordinal)
-            //        && Utils.IsEqualToOrDerivedFrom(invokeMethod.ContainingType, taskType))
-            //    {
-            //        context.ReportDiagnostic(Diagnostic.Create(Descriptor, context.Node.GetLocation()));
-            //    }
-            //    else if (string.Equals(invokeMethod.Name, "GetResult", StringComparison.Ordinal)
-            //        && invokeMethod.ContainingType.Name.EndsWith("Awaiter", StringComparison.Ordinal))
-            //    {
-            //        context.ReportDiagnostic(Diagnostic.Create(Descriptor, context.Node.GetLocation()));
-            //    }
-            //}
+                CommonInterest.ProblematicSyncBlockingMethods);
         }
 
         private void AnalyzeMemberAccess(SyntaxNodeAnalysisContext context)
@@ -111,28 +89,6 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
                 memberAccessSyntax,
                 Descriptor,
                 CommonInterest.SyncBlockingProperties);
-
-            //if (CommonInterest.ShouldIgnoreContext(context))
-            //{
-            //    return;
-            //}
-
-            //if (Utils.IsWithinNameOf(context.Node as ExpressionSyntax))
-            //{
-            //    // We do not consider arguments to nameof( ) because they do not represent invocations of code.
-            //    return;
-            //}
-
-            //var property = context.SemanticModel.GetSymbolInfo(context.Node).Symbol as IPropertySymbol;
-            //if (property != null)
-            //{
-            //    var taskType = context.SemanticModel.Compilation.GetTypeByMetadataName(typeof(Task).FullName);
-            //    if (string.Equals(property.Name, nameof(Task<object>.Result), StringComparison.Ordinal)
-            //        && Utils.IsEqualToOrDerivedFrom(property.ContainingType, taskType))
-            //    {
-            //        context.ReportDiagnostic(Diagnostic.Create(Descriptor, context.Node.GetLocation()));
-            //    }
-            //}
         }
     }
 }

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD103UseAsyncOptionAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD103UseAsyncOptionAnalyzer.cs
@@ -164,7 +164,7 @@
                     && returnType.BelongsToNamespace(Namespaces.SystemThreadingTasks);
             }
 
-            private static bool InspectMemberAccess(SyntaxNodeAnalysisContext context, MemberAccessExpressionSyntax memberAccessSyntax, IReadOnlyList<CommonInterest.SyncBlockingMethod> problematicMethods)
+            private static bool InspectMemberAccess(SyntaxNodeAnalysisContext context, MemberAccessExpressionSyntax memberAccessSyntax, IEnumerable<CommonInterest.SyncBlockingMethod> problematicMethods)
             {
                 if (memberAccessSyntax == null)
                 {

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD104OfferAsyncOptionAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD104OfferAsyncOptionAnalyzer.cs
@@ -61,7 +61,7 @@
                 this.InspectMemberAccess(context, invocationExpressionSyntax.Expression as MemberAccessExpressionSyntax, CommonInterest.JTFSyncBlockers);
             }
 
-            private void InspectMemberAccess(SyntaxNodeAnalysisContext context, MemberAccessExpressionSyntax memberAccessSyntax, IReadOnlyList<CommonInterest.SyncBlockingMethod> problematicMethods)
+            private void InspectMemberAccess(SyntaxNodeAnalysisContext context, MemberAccessExpressionSyntax memberAccessSyntax, IEnumerable<CommonInterest.SyncBlockingMethod> problematicMethods)
             {
                 if (memberAccessSyntax == null)
                 {


### PR DESCRIPTION
A recent change to share more code between analyzers led to the ironic regression that VSTHRD002 would mis-fire on the very code it suggests people use.