### PR TITLE
Suppress VSTHRD103 diagnostic when alleged async alternative is not awaitable

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD103UseAsyncOptionAnalyzerTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD103UseAsyncOptionAnalyzerTests.cs
@@ -969,5 +969,27 @@ class Test {
 
             this.VerifyCSharpDiagnostic(test);
         }
+
+        [Fact]
+        public void DoNotSuggestAsyncAlternativeWhenItReturnsVoid()
+        {
+            var test = @"
+using System;
+using System.Threading.Tasks;
+
+class Test {
+    void LogInformation() { }
+    void LogInformationAsync() { }
+
+    Task MethodAsync()
+    {
+        LogInformation();
+        return Task.CompletedTask;
+    }
+}
+";
+
+            this.VerifyCSharpDiagnostic(test);
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD103UseAsyncOptionAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD103UseAsyncOptionAnalyzer.cs
@@ -106,7 +106,8 @@
                             includeReducedExtensionMethods: true).OfType<IMethodSymbol>()
                             .Where(m => !m.IsObsolete())
                             .Where(m => HasSupersetOfParameterTypes(m, methodSymbol))
-                            .Where(m => m.Name != invocationDeclaringMethod?.Identifier.Text);
+                            .Where(m => m.Name != invocationDeclaringMethod?.Identifier.Text)
+                            .Where(Utils.HasAsyncCompatibleReturnType);
 
                         if (asyncMethodMatches.Any())
                         {


### PR DESCRIPTION
If `Foo()` and `FooAsync()` both exist, but both return void, it isn't at all clear how they differ. Therefore VSTHRD103 should not suggest that an async method that calls `Foo()` should instead call `FooAsync()`. For instance, `FooAsync()` may be a fire-and-forget method that executes asynchronously with respect to the caller, which would _not_ be equivalent to the code running before which might handle exceptions and certainly didn't proceed until the work was done.

Fixes #167