### PR TITLE
Update packages to fix pack warnings

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -4,6 +4,7 @@
     <add key="repositorypath" value="packages" />
   </config>
   <packageSources>
+    <clear />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
     <add key="myget.org/F/aarnott" value="https://www.myget.org/F/aarnott/api/v3/index.json" protocolVersion="3" />
     <add key="vs-devcore" value="https://www.myget.org/F/vs-devcore/api/v3/index.json" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,6 +3,8 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)..\obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
     <BaseOutputPath Condition=" '$(BaseOutputPath)' == '' ">$(MSBuildThisFileDirectory)..\bin\$(MSBuildProjectName)\</BaseOutputPath>
+
+    <MicroBuildVersion>2.0.43</MicroBuildVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Version="1.6.35" PrivateAssets="all" />

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/Microsoft.VisualStudio.Threading.Analyzers.Tests.csproj
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/Microsoft.VisualStudio.Threading.Analyzers.Tests.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.11.0" Version="11.0.61030" IncludeAssets="none" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="MicroBuild.Nonshipping" Version="2.0.42" />
+    <PackageReference Include="MicroBuild.Nonshipping" Version="2.0.43" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/Microsoft.VisualStudio.Threading.Analyzers.Tests.csproj
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/Microsoft.VisualStudio.Threading.Analyzers.Tests.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.11.0" Version="11.0.61030" IncludeAssets="none" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="MicroBuild.Nonshipping" Version="2.0.43" />
+    <PackageReference Include="MicroBuild.Nonshipping" Version="$(MicroBuildVersion)" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Microsoft.VisualStudio.Threading.Analyzers.csproj
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Microsoft.VisualStudio.Threading.Analyzers.csproj
@@ -52,7 +52,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.2.0" />
-    <PackageReference Include="MicroBuild.VisualStudio" Version="2.0.42" />
+    <PackageReference Include="MicroBuild.VisualStudio" Version="2.0.43" />
     <PackageReference Include="PdbGit" Version="3.0.41" />
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" />

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Microsoft.VisualStudio.Threading.Analyzers.csproj
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Microsoft.VisualStudio.Threading.Analyzers.csproj
@@ -52,7 +52,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.2.0" />
-    <PackageReference Include="MicroBuild.VisualStudio" Version="2.0.43" />
+    <PackageReference Include="MicroBuild.VisualStudio" Version="$(MicroBuildVersion)" />
     <PackageReference Include="PdbGit" Version="3.0.41" />
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" />

--- a/src/Microsoft.VisualStudio.Threading.Tests.Win7RegistryWatcher/Microsoft.VisualStudio.Threading.Tests.Win7RegistryWatcher.csproj
+++ b/src/Microsoft.VisualStudio.Threading.Tests.Win7RegistryWatcher/Microsoft.VisualStudio.Threading.Tests.Win7RegistryWatcher.csproj
@@ -9,6 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.VisualStudio.Threading\Microsoft.VisualStudio.Threading.csproj" />
-    <PackageReference Include="MicroBuild.Nonshipping" Version="2.0.42" />
+    <PackageReference Include="MicroBuild.Nonshipping" Version="2.0.43" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.VisualStudio.Threading.Tests.Win7RegistryWatcher/Microsoft.VisualStudio.Threading.Tests.Win7RegistryWatcher.csproj
+++ b/src/Microsoft.VisualStudio.Threading.Tests.Win7RegistryWatcher/Microsoft.VisualStudio.Threading.Tests.Win7RegistryWatcher.csproj
@@ -9,6 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.VisualStudio.Threading\Microsoft.VisualStudio.Threading.csproj" />
-    <PackageReference Include="MicroBuild.Nonshipping" Version="2.0.43" />
+    <PackageReference Include="MicroBuild.Nonshipping" Version="$(MicroBuildVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.VisualStudio.Threading.Tests/Microsoft.VisualStudio.Threading.Tests.csproj
+++ b/src/Microsoft.VisualStudio.Threading.Tests/Microsoft.VisualStudio.Threading.Tests.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="Xunit.StaFact" Version="0.2.3-beta" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="OpenCover" Version="4.6.519" />
-    <PackageReference Include="MicroBuild.Nonshipping" Version="2.0.43" />
+    <PackageReference Include="MicroBuild.Nonshipping" Version="$(MicroBuildVersion)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.VisualStudio.Threading\Microsoft.VisualStudio.Threading.csproj" />

--- a/src/Microsoft.VisualStudio.Threading.Tests/Microsoft.VisualStudio.Threading.Tests.csproj
+++ b/src/Microsoft.VisualStudio.Threading.Tests/Microsoft.VisualStudio.Threading.Tests.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="Xunit.StaFact" Version="0.2.3-beta" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="OpenCover" Version="4.6.519" />
-    <PackageReference Include="MicroBuild.Nonshipping" Version="2.0.42" />
+    <PackageReference Include="MicroBuild.Nonshipping" Version="2.0.43" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.VisualStudio.Threading\Microsoft.VisualStudio.Threading.csproj" />

--- a/src/Microsoft.VisualStudio.Threading/Microsoft.VisualStudio.Threading.csproj
+++ b/src/Microsoft.VisualStudio.Threading/Microsoft.VisualStudio.Threading.csproj
@@ -50,8 +50,8 @@
   <ItemGroup>
     <Reference Include="System.Configuration" Condition=" '$(TargetFramework)' == 'net45' " />
     <PackageReference Include="Microsoft.VisualStudio.Validation" Version="15.3.15" />
-    <PackageReference Include="MicroBuild.VisualStudio" Version="2.0.42" PrivateAssets="all" />
-    <PackageReference Include="MSBuild.SDK.Extras" Version="1.0.5" PrivateAssets="all" />
+    <PackageReference Include="MicroBuild.VisualStudio" Version="2.0.43" PrivateAssets="all" />
+    <PackageReference Include="MSBuild.SDK.Extras" Version="1.0.6" PrivateAssets="all" />
     <PackageReference Include="PdbGit" Version="3.0.41" PrivateAssets="all" />
   </ItemGroup>
   <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />

--- a/src/Microsoft.VisualStudio.Threading/Microsoft.VisualStudio.Threading.csproj
+++ b/src/Microsoft.VisualStudio.Threading/Microsoft.VisualStudio.Threading.csproj
@@ -50,7 +50,7 @@
   <ItemGroup>
     <Reference Include="System.Configuration" Condition=" '$(TargetFramework)' == 'net45' " />
     <PackageReference Include="Microsoft.VisualStudio.Validation" Version="15.3.15" />
-    <PackageReference Include="MicroBuild.VisualStudio" Version="2.0.43" PrivateAssets="all" />
+    <PackageReference Include="MicroBuild.VisualStudio" Version="$(MicroBuildVersion)" PrivateAssets="all" />
     <PackageReference Include="MSBuild.SDK.Extras" Version="1.0.6" PrivateAssets="all" />
     <PackageReference Include="PdbGit" Version="3.0.41" PrivateAssets="all" />
   </ItemGroup>


### PR DESCRIPTION
This resolves the build warnings that appear on 15.3 build agents, such as the following:

> C:\Program Files\dotnet\sdk\2.0.0\Sdks\NuGet.Build.Tasks.Pack\buildCrossTargeting\NuGet.Build.Tasks.Pack.targets(141,5): warning : File 'C:\projects\vs-threading\obj\Microsoft.VisualStudio.Threading\Release\netstandard1.1\es\Microsoft.VisualStudio.Threading.resources.dll' is not added because the package already contains file 'lib\netstandard1.1\es\Microsoft.VisualStudio.Threading.resources.dll' [C:\projects\vs-threading\src\Microsoft.VisualStudio.Threading\Microsoft.VisualStudio.Threading.csproj]