### PR TITLE
Add .NET Standard 2.0 target framework

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,6 +39,10 @@ test_script:
     dotnet test src\Microsoft.VisualStudio.Threading.Tests\Microsoft.VisualStudio.Threading.Tests.csproj
     --no-build
     -f netcoreapp1.0
+
+    dotnet test src\Microsoft.VisualStudio.Threading.Tests\Microsoft.VisualStudio.Threading.Tests.csproj
+    --no-build
+    -f netcoreapp2.0
 artifacts:
 - path: bin\**\*.nupkg
   name: NuGet Package

--- a/src/Microsoft.VisualStudio.Threading.Tests/AsyncReaderWriterLockTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/AsyncReaderWriterLockTests.cs
@@ -38,7 +38,7 @@
         public AsyncReaderWriterLockTests(ITestOutputHelper logger)
             : base(logger)
         {
-#if DESKTOP
+#if DESKTOP || NETCOREAPP2_0
             this.asyncLock = new StaAverseLock();
 #else
             this.asyncLock = new AsyncReaderWriterLock();
@@ -859,7 +859,7 @@
             await this.NestedLocksAllocFreeHelperAsync(() => this.asyncLock.ReadLockAsync(), false);
         }
 
-#if DESKTOP
+#if DESKTOP || NETCOREAPP2_0
         [StaFact]
         public void LockAsyncThrowsOnGetResultBySta()
         {
@@ -1345,7 +1345,7 @@
             });
         }
 
-#if DESKTOP
+#if DESKTOP || NETCOREAPP2_0
         /// <summary>
         /// Tests that a common way to accidentally fork an exclusive lock for
         /// concurrent access gets called out as an error.
@@ -1696,7 +1696,7 @@
             }).GetAwaiter().GetResult();
         }
 
-#if DESKTOP
+#if DESKTOP || NETCOREAPP2_0
         /// <summary>
         /// Tests that a common way to accidentally fork an exclusive lock for
         /// concurrent access gets called out as an error.
@@ -2490,7 +2490,7 @@
 
 #region Completion tests
 
-#if DESKTOP
+#if DESKTOP || NETCOREAPP2_0
         [StaFact]
         public void CompleteBlocksNewTopLevelLocksSTA()
         {
@@ -3168,7 +3168,7 @@
                 }));
         }
 
-#if DESKTOP
+#if DESKTOP || NETCOREAPP2_0
         [StaFact]
         public void OnBeforeWriteLockReleasedCallbackNeverInvokedOnSTA()
         {
@@ -3299,7 +3299,7 @@
 #endregion
 
 #region Thread apartment rules
-#if DESKTOP
+#if DESKTOP || NETCOREAPP2_0
 
         /// <summary>Verifies that locks requested on STA threads will marshal to an MTA.</summary>
         [StaFact]
@@ -3894,7 +3894,7 @@
                         {
                             try
                             {
-#if DESKTOP
+#if DESKTOP || NETCOREAPP2_0
                                 Assert.Equal(ApartmentState.MTA, Thread.CurrentThread.GetApartmentState());
 #endif
                                 secondLockObtained.SetAsync();
@@ -4478,7 +4478,9 @@
                 AssertEx.NotEqual(callingAppDomainId, AppDomain.CurrentDomain.Id, "AppDomain boundaries not crossed.");
             }
         }
+#endif
 
+#if DESKTOP || NETCOREAPP2_0
         private class StaAverseLock : AsyncReaderWriterLock
         {
             protected override bool CanCurrentThreadHoldActiveLock

--- a/src/Microsoft.VisualStudio.Threading.Tests/AwaitExtensionsTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/AwaitExtensionsTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.Threading.Tests
         [Fact]
         public void AwaitThreadPoolSchedulerYieldsOnNonThreadPoolThreads()
         {
-#if DESKTOP
+#if DESKTOP || NETCOREAPP2_0
             // In some test runs (including VSTS cloud test), this test runs on a threadpool thread.
             if (Thread.CurrentThread.IsThreadPoolThread)
             {
@@ -77,7 +77,7 @@ namespace Microsoft.VisualStudio.Threading.Tests
         {
             Task.Run(delegate
             {
-#if DESKTOP
+#if DESKTOP || NETCOREAPP2_0
                 Assert.True(Thread.CurrentThread.IsThreadPoolThread, "Test depends on thread looking like threadpool thread.");
 #else
                 // Erase AsyncTestSyncContext, which somehow still is set in VSTS cloud tests.
@@ -87,7 +87,7 @@ namespace Microsoft.VisualStudio.Threading.Tests
             }).GetAwaiter().GetResult();
         }
 
-#if DESKTOP
+#if DESKTOP || NETCOREAPP2_0
 
         [Fact]
         public void AwaitWaitHandle()
@@ -182,6 +182,10 @@ namespace Microsoft.VisualStudio.Threading.Tests
                 p.Kill();
             }
         }
+
+#endif
+
+#if DESKTOP
 
         [Fact]
         public async Task AwaitRegKeyChange()

--- a/src/Microsoft.VisualStudio.Threading.Tests/JoinableTaskContextNodeTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/JoinableTaskContextNodeTests.cs
@@ -58,7 +58,7 @@ namespace Microsoft.VisualStudio.Threading.Tests
         [StaFact]
         public void MainThread()
         {
-#if DESKTOP
+#if DESKTOP || NETCOREAPP2_0
             Assert.Same(this.context.MainThread, this.defaultNode.MainThread);
             Assert.Same(this.context.MainThread, this.derivedNode.MainThread);
 #endif

--- a/src/Microsoft.VisualStudio.Threading.Tests/JoinableTaskTestBase.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/JoinableTaskTestBase.cs
@@ -35,7 +35,7 @@
             this.originalThreadManagedId = Environment.CurrentManagedThreadId;
             this.testFrame = SingleThreadedSynchronizationContext.NewFrame();
 
-#if DESKTOP
+#if DESKTOP || NETCOREAPP2_0
             // Suppress the assert dialog that appears and causes test runs to hang.
             Trace.Listeners.OfType<DefaultTraceListener>().Single().AssertUiEnabled = false;
 #endif

--- a/src/Microsoft.VisualStudio.Threading.Tests/JoinableTaskTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/JoinableTaskTests.cs
@@ -3671,14 +3671,14 @@
 
                 if (canceled)
                 {
-#if DESKTOP
+#if DESKTOP || NETCOREAPP2_0
                     Assert.NotSame(this.Context.MainThread, Thread.CurrentThread); // A canceled transition should not complete on the main thread.
 #endif
                     Assert.False(this.Context.IsOnMainThread);
                 }
                 else
                 {
-#if DESKTOP
+#if DESKTOP || NETCOREAPP2_0
                     Assert.Same(this.Context.MainThread, Thread.CurrentThread); // We should be on the main thread if we've just transitioned.
 #endif
                     Assert.True(this.Context.IsOnMainThread);

--- a/src/Microsoft.VisualStudio.Threading.Tests/Microsoft.VisualStudio.Threading.Tests.csproj
+++ b/src/Microsoft.VisualStudio.Threading.Tests/Microsoft.VisualStudio.Threading.Tests.csproj
@@ -3,8 +3,7 @@
     <!-- We target net451 to test library code to support NET45 -->
     <!-- We target net452 to test library code to support NET46 light-up from a net45 assembly -->
     <!-- We target net46 to test library code that supports net46 natively. -->
-    <TargetFrameworks>net451;net452;net46;netcoreapp1.0</TargetFrameworks>
-    <PackageTargetFallback>portable-net45+win8+wp8+wpa81</PackageTargetFallback>
+    <TargetFrameworks>net451;net452;net46;netcoreapp1.0;netcoreapp2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisRuleSet>Microsoft.VisualStudio.Threading.Tests.ruleset</CodeAnalysisRuleSet>
     <NoWarn>$(NoWarn);CS1591</NoWarn>

--- a/src/Microsoft.VisualStudio.Threading.Tests/TestBase.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/TestBase.cs
@@ -212,7 +212,7 @@
             this.ExecuteOnDispatcher(() => this.CheckGCPressureAsync(scenario, maxBytesAllocated));
         }
 
-#if DESKTOP
+#if DESKTOP || NETCOREAPP2_0
         /// <summary>
         /// Executes the delegate on a thread with <see cref="ApartmentState.STA"/>
         /// and without a current <see cref="SynchronizationContext"/>.
@@ -291,7 +291,7 @@
                 }
             };
 
-#if DESKTOP
+#if DESKTOP || NETCOREAPP2_0
             if (Thread.CurrentThread.GetApartmentState() == ApartmentState.STA &&
                 SingleThreadedSynchronizationContext.IsSingleThreadedSyncContext(SynchronizationContext.Current))
             {

--- a/src/Microsoft.VisualStudio.Threading.Tests/TestBaseTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/TestBaseTests.cs
@@ -16,7 +16,7 @@
         {
         }
 
-#if DESKTOP
+#if DESKTOP || NETCOREAPP2_0
         [Fact]
         public void ExecuteOnSTA_ExecutesDelegateOnSTA()
         {

--- a/src/Microsoft.VisualStudio.Threading.Tests/TestUtilities.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/TestUtilities.cs
@@ -2,7 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
-#if DESKTOP
+#if DESKTOP || NETCOREAPP2_0
     using System.Configuration;
 #endif
     using System.Diagnostics;
@@ -18,7 +18,7 @@
         /// <summary>
         /// A value indicating whether the library is operating in .NET 4.5 mode.
         /// </summary>
-#if DESKTOP
+#if NET451 || NET452
         internal static readonly bool IsNet45Mode = ConfigurationManager.AppSettings["Microsoft.VisualStudio.Threading.NET45Mode"] == "true";
 #else
         internal static readonly bool IsNet45Mode = false;
@@ -152,7 +152,7 @@
         /// </remarks>
         internal static IDisposable StarveThreadpool()
         {
-#if DESKTOP
+#if DESKTOP || NETCOREAPP2_0
             ThreadPool.GetMaxThreads(out int workerThreads, out int completionPortThreads);
 #else
             int workerThreads = 1023;

--- a/src/Microsoft.VisualStudio.Threading.Tests/ThreadingToolsTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/ThreadingToolsTests.cs
@@ -2,7 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
-#if DESKTOP
+#if DESKTOP || NETCOREAPP2_0
     using System.Configuration;
 #endif
     using System.Linq;

--- a/src/Microsoft.VisualStudio.Threading.Tests/TplExtensionsTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/TplExtensionsTests.cs
@@ -574,7 +574,7 @@
             await callbackResult.Task;
         }
 
-#if DESKTOP
+#if DESKTOP || NETCOREAPP2_0
 
         [Fact]
         public void ToTaskReturnsCompletedTaskPreSignaled()

--- a/src/Microsoft.VisualStudio.Threading/AsyncReaderWriterLock+HangReportContributor.cs
+++ b/src/Microsoft.VisualStudio.Threading/AsyncReaderWriterLock+HangReportContributor.cs
@@ -147,7 +147,7 @@ namespace Microsoft.VisualStudio.Threading
             }
 
             Delegate lockWaitingContinuation;
-#if DESKTOP
+#if DESKTOP || NETSTANDARD2_0
             if (awaiter.RequestingStackTrace != null)
             {
                 label.AppendLine(awaiter.RequestingStackTrace.ToString());

--- a/src/Microsoft.VisualStudio.Threading/AsyncReaderWriterLock.cs
+++ b/src/Microsoft.VisualStudio.Threading/AsyncReaderWriterLock.cs
@@ -353,7 +353,7 @@ namespace Microsoft.VisualStudio.Threading
         /// </remarks>
         protected virtual bool CanCurrentThreadHoldActiveLock
         {
-#if DESKTOP
+#if DESKTOP || NETSTANDARD2_0
             get { return Thread.CurrentThread.GetApartmentState() != ApartmentState.STA; }
 #else
             get { return true; }
@@ -1023,7 +1023,7 @@ namespace Microsoft.VisualStudio.Threading
                 {
                     this.etw.WaitStart(awaiter);
 
-#if DESKTOP
+#if DESKTOP || NETSTANDARD2_0
                     // If the lock is immediately available, we don't need to coordinate with other threads.
                     // But if it is NOT available, we'd have to wait potentially for other threads to do more work.
                     Debugger.NotifyOfCrossThreadDependency();
@@ -2118,7 +2118,7 @@ namespace Microsoft.VisualStudio.Threading
             /// </summary>
             private Task releaseAsyncTask;
 
-#if DESKTOP
+#if DESKTOP || NETSTANDARD2_0
             /// <summary>
             /// The stacktrace of the caller originally requesting the lock.
             /// </summary>
@@ -2152,7 +2152,7 @@ namespace Microsoft.VisualStudio.Threading
                 this.options = options;
                 this.cancellationToken = cancellationToken;
                 this.nestingLock = lck.GetFirstActiveSelfOrAncestor(lck.topAwaiter.Value);
-#if DESKTOP
+#if DESKTOP || NETSTANDARD2_0
                 this.requestingStackTrace = lck.captureDiagnostics ? new StackTrace(2, true) : null;
 #endif
             }
@@ -2173,7 +2173,7 @@ namespace Microsoft.VisualStudio.Threading
                 get { return this.lck; }
             }
 
-#if DESKTOP
+#if DESKTOP || NETSTANDARD2_0
             /// <summary>
             /// Gets the stack trace of the requestor of this lock.
             /// </summary>

--- a/src/Microsoft.VisualStudio.Threading/AwaitExtensions.cs
+++ b/src/Microsoft.VisualStudio.Threading/AwaitExtensions.cs
@@ -48,7 +48,7 @@ namespace Microsoft.VisualStudio.Threading
             return new TaskSchedulerAwaitable(scheduler, alwaysYield);
         }
 
-#if DESKTOP
+#if DESKTOP || NETSTANDARD2_0
 
         /// <summary>
         /// Provides await functionality for ordinary <see cref="WaitHandle"/>s.
@@ -102,6 +102,9 @@ namespace Microsoft.VisualStudio.Threading
             }
         }
 
+#endif
+
+#if DESKTOP
         /// <summary>
         /// Returns a Task that completes when the specified registry key changes.
         /// </summary>
@@ -480,7 +483,7 @@ namespace Microsoft.VisualStudio.Threading
                     // TaskScheduler.Current is never null.  Even if no scheduler is really active and the current
                     // thread is not a threadpool thread, TaskScheduler.Current == TaskScheduler.Default, so we have
                     // to protect against that case too.
-#if DESKTOP
+#if DESKTOP || NETSTANDARD2_0
                     bool isThreadPoolThread = Thread.CurrentThread.IsThreadPoolThread;
 #else
                     // An approximation of whether we're on a threadpool thread is whether

--- a/src/Microsoft.VisualStudio.Threading/InternalUtilities.cs
+++ b/src/Microsoft.VisualStudio.Threading/InternalUtilities.cs
@@ -155,7 +155,7 @@ namespace Microsoft.VisualStudio.Threading
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "value", Justification = "We no-op on one platform.")]
         private static IntPtr GetAddress(object value)
         {
-#if DESKTOP
+#if DESKTOP || NETSTANDARD2_0
             unsafe
             {
                 TypedReference tr = __makeref(value);

--- a/src/Microsoft.VisualStudio.Threading/JoinableTask+JoinableTaskSynchronizationContext.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTask+JoinableTaskSynchronizationContext.cs
@@ -109,7 +109,7 @@ namespace Microsoft.VisualStudio.Threading
                 }
                 else
                 {
-#if DESKTOP
+#if DESKTOP || NETSTANDARD2_0
                     bool isThreadPoolThread = Thread.CurrentThread.IsThreadPoolThread;
 #else
                     // On portable profile this is the best estimation we can do.

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskContext.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskContext.cs
@@ -132,7 +132,7 @@ namespace Microsoft.VisualStudio.Threading
         /// to the main thread from another thread.
         /// </summary>
         public JoinableTaskContext()
-#if DESKTOP
+#if DESKTOP || NETSTANDARD2_0
             : this(Thread.CurrentThread, SynchronizationContext.Current)
         {
 #else
@@ -141,7 +141,7 @@ namespace Microsoft.VisualStudio.Threading
 #endif
         }
 
-#if DESKTOP
+#if DESKTOP || NETSTANDARD2_0
 
         /// <summary>
         /// Initializes a new instance of the <see cref="JoinableTaskContext"/> class.
@@ -207,7 +207,7 @@ namespace Microsoft.VisualStudio.Threading
             }
         }
 
-#if DESKTOP
+#if DESKTOP || NETSTANDARD2_0
         /// <summary>
         /// Gets the main thread that can be shared by tasks created by this context.
         /// </summary>
@@ -270,7 +270,7 @@ namespace Microsoft.VisualStudio.Threading
         {
             get
             {
-#if DESKTOP
+#if DESKTOP || NETSTANDARD2_0
                 // Callers of this method are about to take a private lock, which tends
                 // to cause a deadlock while debugging because of lock contention with the
                 // debugger's expression evaluator. So prevent that.

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskContextException.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskContextException.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.Threading
     /// are incorrect or a virtual method is overridden such that it violates a contract.
     /// This exception should not be caught. It is thrown when the application has a programming fault.
     /// </summary>
-#if DESKTOP
+#if DESKTOP || NETSTANDARD2_0
     [Serializable]
 #endif
     public class JoinableTaskContextException : Exception
@@ -44,7 +44,7 @@ namespace Microsoft.VisualStudio.Threading
         {
         }
 
-#if DESKTOP
+#if DESKTOP || NETSTANDARD2_0
         /// <summary>
         /// Initializes a new instance of the <see cref="JoinableTaskContextException"/> class.
         /// </summary>

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskContextNode.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskContextNode.cs
@@ -59,7 +59,7 @@ namespace Microsoft.VisualStudio.Threading
             }
         }
 
-#if DESKTOP
+#if DESKTOP || NETSTANDARD2_0
         /// <summary>
         /// Gets the main thread that can be shared by tasks created by this context.
         /// </summary>

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskCreationOptions.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskCreationOptions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.Threading
     /// Specifies flags that control optional behavior for the creation and execution of tasks.
     /// </summary>
     [Flags]
-#if DESKTOP
+#if DESKTOP || NETSTANDARD2_0
     [Serializable]
 #endif
     public enum JoinableTaskCreationOptions

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.Threading
     using System.Threading;
     using System.Threading.Tasks;
     using JoinableTaskSynchronizationContext = Microsoft.VisualStudio.Threading.JoinableTask.JoinableTaskSynchronizationContext;
-#if !DESKTOP
+#if !(DESKTOP || NETSTANDARD2_0)
     using WaitCallback = System.Action<object>;
 #endif
 

--- a/src/Microsoft.VisualStudio.Threading/LightUps.cs
+++ b/src/Microsoft.VisualStudio.Threading/LightUps.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.Threading
     /// </summary>
     internal static class LightUps
     {
-#if DESKTOP
+#if DESKTOP || NETSTANDARD2_0
         /// <summary>
         /// The <see cref="OperatingSystem.Version"/> for Windows 8.
         /// </summary>
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.Threading
         /// Gets a value indicating whether we execute Windows 7 code even on later versions of Windows.
         /// </summary>
         internal static readonly bool ForceWindows7Mode = System.Configuration.ConfigurationManager.AppSettings["Microsoft.VisualStudio.Threading.Windows7Mode"] == "true";
-#elif DESKTOP
+#elif DESKTOP || NETSTANDARD2_0
         /// <summary>
         /// Gets a value indicating whether we execute Windows 7 code even on later versions of Windows.
         /// </summary>
@@ -88,7 +88,7 @@ namespace Microsoft.VisualStudio.Threading
             }
         }
 
-#if DESKTOP
+#if DESKTOP || NETSTANDARD2_0
         /// <summary>
         /// Gets a value indicating whether the current operating system is Windows 8 or later.
         /// </summary>

--- a/src/Microsoft.VisualStudio.Threading/Microsoft.VisualStudio.Threading.csproj
+++ b/src/Microsoft.VisualStudio.Threading/Microsoft.VisualStudio.Threading.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.1;netstandard1.3;portable-net45+win8+wpa81;net45;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;netstandard1.3;netstandard2.0;portable-net45+win8+wpa81;net45;net46</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisRuleSet>FxCopRules.ruleset</CodeAnalysisRuleSet>
 
     <TargetsDesktop Condition=" '$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'net46' ">true</TargetsDesktop>
     <DefineConstants Condition=" '$(TargetsDesktop)' == 'true' ">$(DefineConstants);DESKTOP</DefineConstants>
-    <DefineConstants Condition=" '$(TargetFramework)' == 'net46' or '$(TargetFramework)' == 'netstandard1.3' ">$(DefineConstants);ASYNCLOCAL</DefineConstants>
-    <DefineConstants Condition=" '$(TargetFramework)' == 'net46' or '$(TargetFramework)' == 'netstandard1.3' ">$(DefineConstants);TRYSETCANCELEDCT</DefineConstants>
+    <DefineConstants Condition=" '$(TargetFramework)' == 'net46' or '$(TargetFramework)' == 'netstandard1.3' or '$(TargetFramework)' == 'netstandard2.0' ">$(DefineConstants);ASYNCLOCAL</DefineConstants>
+    <DefineConstants Condition=" '$(TargetFramework)' == 'net46' or '$(TargetFramework)' == 'netstandard1.3' or '$(TargetFramework)' == 'netstandard2.0' ">$(DefineConstants);TRYSETCANCELEDCT</DefineConstants>
     <DefineConstants Condition=" '$(TargetsDesktop)' == 'true' ">$(DefineConstants);CALLCONTEXT</DefineConstants>
-    <DefineConstants Condition=" '$(TargetsDesktop)' == 'true' ">$(DefineConstants);THREADPOOL</DefineConstants>
+    <DefineConstants Condition=" '$(TargetsDesktop)' == 'true'  or '$(TargetFramework)' == 'netstandard2.0' ">$(DefineConstants);THREADPOOL</DefineConstants>
 
     <Summary>Async synchronization primitives, async collections, TPL and dataflow extensions.</Summary>
     <Description>Async synchronization primitives, async collections, TPL and dataflow extensions. The JoinableTaskFactory allows synchronously blocking the UI thread for async work. This package is applicable to any .NET application (not just Visual Studio).</Description>
@@ -23,7 +23,7 @@
     <PackageReleaseNotes>https://go.microsoft.com/fwlink/?LinkID=746387</PackageReleaseNotes>
 
     <DebugType>full</DebugType>
-    <RunCodeAnalysis Condition=" '$(TargetFramework)' != 'portable-net45+win8+wpa81' and '$(Configuration)' != 'Debug' ">true</RunCodeAnalysis>
+    <RunCodeAnalysis Condition=" '$(TargetFramework)' != 'portable-net45+win8+wpa81' and '$(TargetFramework)' != 'netstandard2.0' and '$(Configuration)' != 'Debug' ">true</RunCodeAnalysis>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Label="MultilingualAppToolkit">

--- a/src/Microsoft.VisualStudio.Threading/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.VisualStudio.Threading/Properties/AssemblyInfo.cs
@@ -2,7 +2,7 @@
 using System.Resources;
 using System.Runtime.InteropServices;
 
-#if DESKTOP
+#if DESKTOP || NETSTANDARD2_0
 [assembly: NeutralResourcesLanguage("en-US", UltimateResourceFallbackLocation.MainAssembly)]
 #else
 [assembly: NeutralResourcesLanguage("en-US")]

--- a/src/Microsoft.VisualStudio.Threading/TplExtensions.cs
+++ b/src/Microsoft.VisualStudio.Threading/TplExtensions.cs
@@ -428,7 +428,7 @@ namespace Microsoft.VisualStudio.Threading
             return tcs.Task;
         }
 
-#if DESKTOP
+#if DESKTOP || NETSTANDARD2_0
 
         /// <summary>
         /// Creates a TPL Task that returns <c>true</c> when a <see cref="WaitHandle"/> is signaled or returns <c>false</c> if a timeout occurs first.


### PR DESCRIPTION
This adds most of the desktop-only functionality of the library to the netstandard builds since netstandard2.0 makes the necessary APIs available.

Closes #161