### PR TITLE
Fix AsyncAutoResetEvent.WaitAsync(CT) race condition

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Tests/AsyncAutoResetEventTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/AsyncAutoResetEventTests.cs
@@ -176,6 +176,26 @@
             VerifyCanInlineContinuations(task, () => cts.Cancel());
         }
 
+        [Fact]
+        public async Task WaitAsync_Canceled_Stress()
+        {
+            for (int i = 0; i < 500; i++)
+            {
+                var cts = new CancellationTokenSource();
+                Task mostRecentWaitTask;
+                try
+                {
+                    Task.Run(() => cts.Cancel()).Forget();
+                    await Assert.ThrowsAsync<TaskCanceledException>(() => mostRecentWaitTask = this.evt.WaitAsync(cts.Token)).WithTimeout(UnexpectedTimeout);
+                }
+                catch (TimeoutException)
+                {
+                    this.Logger.WriteLine("Failed after {0} iterations.", i);
+                    throw;
+                }
+            }
+        }
+
         /// <summary>
         /// Verifies that long-lived, uncanceled CancellationTokens do not result in leaking memory.
         /// </summary>

--- a/src/Microsoft.VisualStudio.Threading/AsyncAutoResetEvent.cs
+++ b/src/Microsoft.VisualStudio.Threading/AsyncAutoResetEvent.cs
@@ -99,7 +99,15 @@ namespace Microsoft.VisualStudio.Threading
                 else
                 {
                     var waiter = new WaiterCompletionSource(this, cancellationToken, this.allowInliningAwaiters);
-                    this.signalAwaiters.Enqueue(waiter);
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        waiter.TrySetCanceled(cancellationToken);
+                    }
+                    else
+                    {
+                        this.signalAwaiters.Enqueue(waiter);
+                    }
+
                     return waiter.Task;
                 }
             }
@@ -144,7 +152,10 @@ namespace Microsoft.VisualStudio.Threading
             }
 
             // We only cancel the task if we removed it from the queue.
-            // If it wasn't in the queue, it has already been signaled.
+            // If it wasn't in the queue, either it has already been signaled
+            // or it hasn't even been added to the queue yet. If the latter,
+            // the Task will be canceled later so long as the signal hasn't been awarded
+            // to this Task yet.
             if (removed)
             {
                 tcs.TrySetCanceled(tcs.CancellationToken);


### PR DESCRIPTION
The Task returned from this method may never complete in response to a canceled CancellationToken if it is canceled at just the right moment while WaitAsync is still executing. This change fixes that.

Fixes #185