### PR TITLE
Rename VSTHRD013 to VSTHRD108 and document analyzer

### DIFF
--- a/doc/analyzers/VSTHRD108.md
+++ b/doc/analyzers/VSTHRD108.md
@@ -1,0 +1,41 @@
+# VSTHRD108 Assert thread affinity unconditionally
+
+When a method has thread affinity and throws if called from the wrong thread, it should do so without regard to any other condition. This helps ensure the caller will notice early during development that they are calling from the wrong thread. Extra conditions can hide the problem till end users discover an application failure.
+
+## Examples of patterns that are flagged by this analyzer
+
+```csharp
+private int? age;
+
+public int GetAge()
+{
+    if (!this.age.HasValue)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        this.age = DoExpensiveUIThreadWork();
+    }
+
+    return this.age.Value;
+}
+```
+
+The problem here is that although the UI thread is only strictly required when the field is actually initialized, callers generally cannot predict whether they will be the first or a subsequent caller. If they call from a background thread and tend to be a subsequent caller, no exception will be thrown. But under some conditions in the app when they happen to be the first caller, they'll fail at runtime because they're calling from the background thread.
+
+## Solution
+
+Move the code that throws when not on the UI thread outside the conditional block.
+
+```csharp
+private int? age;
+
+public int GetAge()
+{
+    ThreadHelper.ThrowIfNotOnUIThread();
+    if (!this.age.HasValue)
+    {
+        this.age = DoExpensiveUIThreadWork();
+    }
+
+    return this.age.Value;
+}
+```

--- a/doc/analyzers/index.md
+++ b/doc/analyzers/index.md
@@ -19,6 +19,7 @@ ID | Title | Severity | Supports
 [VSTHRD105](VSTHRD105.md) | Avoid implicit use of TaskScheduler.Current | Advisory
 [VSTHRD106](VSTHRD106.md) | Use `InvokeAsync` to raise async events | Advisory
 [VSTHRD107](VSTHRD107.md) | Await Task within using expression | Advisory
+[VSTHRD108](VSTHRD108.md) | Assert thread affinity unconditionally | Advisory | [1st rule](../threading_rules.md#Rule1), [VSTHRD010](VSTHRD010.md)
 [VSTHRD200](VSTHRD200.md) | Use `Async` naming convention | Guideline | [VSTHRD103](VSTHRD103.md)
 
 ## Severity descriptions

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD108AssertThreadRequirementUnconditionallyTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD108AssertThreadRequirementUnconditionallyTests.cs
@@ -10,21 +10,21 @@
     using Xunit;
     using Xunit.Abstractions;
 
-    public class VSTHRD013AssertThreadRequirementUnconditionallyTests : DiagnosticVerifier
+    public class VSTHRD108AssertThreadRequirementUnconditionallyTests : DiagnosticVerifier
     {
         private DiagnosticResult expect = new DiagnosticResult
         {
-            Id = VSTHRD013AssertThreadRequirementUnconditionally.Id,
+            Id = VSTHRD108AssertThreadRequirementUnconditionally.Id,
             SkipVerifyMessage = true,
             Severity = DiagnosticSeverity.Warning,
         };
 
-        public VSTHRD013AssertThreadRequirementUnconditionallyTests(ITestOutputHelper logger)
+        public VSTHRD108AssertThreadRequirementUnconditionallyTests(ITestOutputHelper logger)
             : base(logger)
         {
         }
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new VSTHRD013AssertThreadRequirementUnconditionally();
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new VSTHRD108AssertThreadRequirementUnconditionally();
 
         [Fact]
         public void AffinityAssertion_Unconditional_ProducesNoDiagnostic()

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.cs.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.cs.xlf
@@ -174,11 +174,11 @@ Použijte raději AsyncLazy&lt;T&gt;.</target>
           <target state="translated">Použijte raději await.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">"await" is a C# keyword and should not be translated.</note>
         </trans-unit>
-        <trans-unit id="VSTHRD013_MessageFormat" translate="yes" xml:space="preserve">
+        <trans-unit id="VSTHRD108_MessageFormat" translate="yes" xml:space="preserve">
           <source>Thread affinity checks should be unconditional.</source>
           <target state="new">Thread affinity checks should be unconditional.</target>
         </trans-unit>
-        <trans-unit id="VSTHRD013_Title" translate="yes" xml:space="preserve">
+        <trans-unit id="VSTHRD108_Title" translate="yes" xml:space="preserve">
           <source>Assert thread affinity unconditionally</source>
           <target state="new">Assert thread affinity unconditionally</target>
         </trans-unit>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.de.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.de.xlf
@@ -174,11 +174,11 @@ Verwenden Sie stattdessen "AsyncLazy&lt;T&gt;".</target>
           <target state="translated">Stattdessen "await" verwenden</target>
           <note from="MultilingualBuild" annotates="source" priority="2">"await" is a C# keyword and should not be translated.</note>
         </trans-unit>
-        <trans-unit id="VSTHRD013_MessageFormat" translate="yes" xml:space="preserve">
+        <trans-unit id="VSTHRD108_MessageFormat" translate="yes" xml:space="preserve">
           <source>Thread affinity checks should be unconditional.</source>
           <target state="new">Thread affinity checks should be unconditional.</target>
         </trans-unit>
-        <trans-unit id="VSTHRD013_Title" translate="yes" xml:space="preserve">
+        <trans-unit id="VSTHRD108_Title" translate="yes" xml:space="preserve">
           <source>Assert thread affinity unconditionally</source>
           <target state="new">Assert thread affinity unconditionally</target>
         </trans-unit>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.es.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.es.xlf
@@ -174,11 +174,11 @@ Use AsyncLazy&lt;T&gt; en su lugar.</target>
           <target state="translated">Use await en su lugar</target>
           <note from="MultilingualBuild" annotates="source" priority="2">"await" is a C# keyword and should not be translated.</note>
         </trans-unit>
-        <trans-unit id="VSTHRD013_MessageFormat" translate="yes" xml:space="preserve">
+        <trans-unit id="VSTHRD108_MessageFormat" translate="yes" xml:space="preserve">
           <source>Thread affinity checks should be unconditional.</source>
           <target state="new">Thread affinity checks should be unconditional.</target>
         </trans-unit>
-        <trans-unit id="VSTHRD013_Title" translate="yes" xml:space="preserve">
+        <trans-unit id="VSTHRD108_Title" translate="yes" xml:space="preserve">
           <source>Assert thread affinity unconditionally</source>
           <target state="new">Assert thread affinity unconditionally</target>
         </trans-unit>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.fr.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.fr.xlf
@@ -174,11 +174,11 @@ Utilisez AsyncLazy&lt;T&gt; à la place</target>
           <target state="translated">Utiliser await à la place</target>
           <note from="MultilingualBuild" annotates="source" priority="2">"await" is a C# keyword and should not be translated.</note>
         </trans-unit>
-        <trans-unit id="VSTHRD013_MessageFormat" translate="yes" xml:space="preserve">
+        <trans-unit id="VSTHRD108_MessageFormat" translate="yes" xml:space="preserve">
           <source>Thread affinity checks should be unconditional.</source>
           <target state="new">Thread affinity checks should be unconditional.</target>
         </trans-unit>
-        <trans-unit id="VSTHRD013_Title" translate="yes" xml:space="preserve">
+        <trans-unit id="VSTHRD108_Title" translate="yes" xml:space="preserve">
           <source>Assert thread affinity unconditionally</source>
           <target state="new">Assert thread affinity unconditionally</target>
         </trans-unit>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.it.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.it.xlf
@@ -174,11 +174,11 @@ In alternativa, usare AsyncLazy&lt;T&gt;.</target>
           <target state="translated">In alternativa, usare await</target>
           <note from="MultilingualBuild" annotates="source" priority="2">"await" is a C# keyword and should not be translated.</note>
         </trans-unit>
-        <trans-unit id="VSTHRD013_MessageFormat" translate="yes" xml:space="preserve">
+        <trans-unit id="VSTHRD108_MessageFormat" translate="yes" xml:space="preserve">
           <source>Thread affinity checks should be unconditional.</source>
           <target state="new">Thread affinity checks should be unconditional.</target>
         </trans-unit>
-        <trans-unit id="VSTHRD013_Title" translate="yes" xml:space="preserve">
+        <trans-unit id="VSTHRD108_Title" translate="yes" xml:space="preserve">
           <source>Assert thread affinity unconditionally</source>
           <target state="new">Assert thread affinity unconditionally</target>
         </trans-unit>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.ja.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.ja.xlf
@@ -174,11 +174,11 @@ Use AsyncLazy&lt;T&gt; instead.</source>
           <target state="translated">代わりに Await を使用する</target>
           <note from="MultilingualBuild" annotates="source" priority="2">"await" is a C# keyword and should not be translated.</note>
         </trans-unit>
-        <trans-unit id="VSTHRD013_MessageFormat" translate="yes" xml:space="preserve">
+        <trans-unit id="VSTHRD108_MessageFormat" translate="yes" xml:space="preserve">
           <source>Thread affinity checks should be unconditional.</source>
           <target state="new">Thread affinity checks should be unconditional.</target>
         </trans-unit>
-        <trans-unit id="VSTHRD013_Title" translate="yes" xml:space="preserve">
+        <trans-unit id="VSTHRD108_Title" translate="yes" xml:space="preserve">
           <source>Assert thread affinity unconditionally</source>
           <target state="new">Assert thread affinity unconditionally</target>
         </trans-unit>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.ko.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.ko.xlf
@@ -174,11 +174,11 @@ Use AsyncLazy&lt;T&gt; instead.</source>
           <target state="translated">대신 await를 사용합니다.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">"await" is a C# keyword and should not be translated.</note>
         </trans-unit>
-        <trans-unit id="VSTHRD013_MessageFormat" translate="yes" xml:space="preserve">
+        <trans-unit id="VSTHRD108_MessageFormat" translate="yes" xml:space="preserve">
           <source>Thread affinity checks should be unconditional.</source>
           <target state="new">Thread affinity checks should be unconditional.</target>
         </trans-unit>
-        <trans-unit id="VSTHRD013_Title" translate="yes" xml:space="preserve">
+        <trans-unit id="VSTHRD108_Title" translate="yes" xml:space="preserve">
           <source>Assert thread affinity unconditionally</source>
           <target state="new">Assert thread affinity unconditionally</target>
         </trans-unit>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.pl.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.pl.xlf
@@ -174,11 +174,11 @@ Zamiast tego używaj klasy AsyncLazy&lt;T&gt;.</target>
           <target state="translated">Zamiast tego używaj oczekiwania</target>
           <note from="MultilingualBuild" annotates="source" priority="2">"await" is a C# keyword and should not be translated.</note>
         </trans-unit>
-        <trans-unit id="VSTHRD013_MessageFormat" translate="yes" xml:space="preserve">
+        <trans-unit id="VSTHRD108_MessageFormat" translate="yes" xml:space="preserve">
           <source>Thread affinity checks should be unconditional.</source>
           <target state="new">Thread affinity checks should be unconditional.</target>
         </trans-unit>
-        <trans-unit id="VSTHRD013_Title" translate="yes" xml:space="preserve">
+        <trans-unit id="VSTHRD108_Title" translate="yes" xml:space="preserve">
           <source>Assert thread affinity unconditionally</source>
           <target state="new">Assert thread affinity unconditionally</target>
         </trans-unit>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.pt-BR.xlf
@@ -174,11 +174,11 @@ Em vez disso, use AsyncLazy&lt;T&gt;.</target>
           <target state="translated">Em vez disso, use a espera</target>
           <note from="MultilingualBuild" annotates="source" priority="2">"await" is a C# keyword and should not be translated.</note>
         </trans-unit>
-        <trans-unit id="VSTHRD013_MessageFormat" translate="yes" xml:space="preserve">
+        <trans-unit id="VSTHRD108_MessageFormat" translate="yes" xml:space="preserve">
           <source>Thread affinity checks should be unconditional.</source>
           <target state="new">Thread affinity checks should be unconditional.</target>
         </trans-unit>
-        <trans-unit id="VSTHRD013_Title" translate="yes" xml:space="preserve">
+        <trans-unit id="VSTHRD108_Title" translate="yes" xml:space="preserve">
           <source>Assert thread affinity unconditionally</source>
           <target state="new">Assert thread affinity unconditionally</target>
         </trans-unit>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.ru.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.ru.xlf
@@ -174,11 +174,11 @@ Use AsyncLazy&lt;T&gt; instead.</source>
           <target state="translated">Вместо этого используйте await.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">"await" is a C# keyword and should not be translated.</note>
         </trans-unit>
-        <trans-unit id="VSTHRD013_MessageFormat" translate="yes" xml:space="preserve">
+        <trans-unit id="VSTHRD108_MessageFormat" translate="yes" xml:space="preserve">
           <source>Thread affinity checks should be unconditional.</source>
           <target state="new">Thread affinity checks should be unconditional.</target>
         </trans-unit>
-        <trans-unit id="VSTHRD013_Title" translate="yes" xml:space="preserve">
+        <trans-unit id="VSTHRD108_Title" translate="yes" xml:space="preserve">
           <source>Assert thread affinity unconditionally</source>
           <target state="new">Assert thread affinity unconditionally</target>
         </trans-unit>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.tr.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.tr.xlf
@@ -174,11 +174,11 @@ Bunun yerine AsyncLazy&lt;T&gt; kullanın.</target>
           <target state="translated">Bunun yerine await kullanın</target>
           <note from="MultilingualBuild" annotates="source" priority="2">"await" is a C# keyword and should not be translated.</note>
         </trans-unit>
-        <trans-unit id="VSTHRD013_MessageFormat" translate="yes" xml:space="preserve">
+        <trans-unit id="VSTHRD108_MessageFormat" translate="yes" xml:space="preserve">
           <source>Thread affinity checks should be unconditional.</source>
           <target state="new">Thread affinity checks should be unconditional.</target>
         </trans-unit>
-        <trans-unit id="VSTHRD013_Title" translate="yes" xml:space="preserve">
+        <trans-unit id="VSTHRD108_Title" translate="yes" xml:space="preserve">
           <source>Assert thread affinity unconditionally</source>
           <target state="new">Assert thread affinity unconditionally</target>
         </trans-unit>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.zh-Hans.xlf
@@ -174,11 +174,11 @@ Use AsyncLazy&lt;T&gt; instead.</source>
           <target state="translated">改用 await</target>
           <note from="MultilingualBuild" annotates="source" priority="2">"await" is a C# keyword and should not be translated.</note>
         </trans-unit>
-        <trans-unit id="VSTHRD013_MessageFormat" translate="yes" xml:space="preserve">
+        <trans-unit id="VSTHRD108_MessageFormat" translate="yes" xml:space="preserve">
           <source>Thread affinity checks should be unconditional.</source>
           <target state="new">Thread affinity checks should be unconditional.</target>
         </trans-unit>
-        <trans-unit id="VSTHRD013_Title" translate="yes" xml:space="preserve">
+        <trans-unit id="VSTHRD108_Title" translate="yes" xml:space="preserve">
           <source>Assert thread affinity unconditionally</source>
           <target state="new">Assert thread affinity unconditionally</target>
         </trans-unit>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.zh-Hant.xlf
@@ -174,11 +174,11 @@ Use AsyncLazy&lt;T&gt; instead.</source>
           <target state="translated">改用 await</target>
           <note from="MultilingualBuild" annotates="source" priority="2">"await" is a C# keyword and should not be translated.</note>
         </trans-unit>
-        <trans-unit id="VSTHRD013_MessageFormat" translate="yes" xml:space="preserve">
+        <trans-unit id="VSTHRD108_MessageFormat" translate="yes" xml:space="preserve">
           <source>Thread affinity checks should be unconditional.</source>
           <target state="new">Thread affinity checks should be unconditional.</target>
         </trans-unit>
-        <trans-unit id="VSTHRD013_Title" translate="yes" xml:space="preserve">
+        <trans-unit id="VSTHRD108_Title" translate="yes" xml:space="preserve">
           <source>Assert thread affinity unconditionally</source>
           <target state="new">Assert thread affinity unconditionally</target>
         </trans-unit>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.Designer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.Designer.cs
@@ -202,18 +202,18 @@ namespace Microsoft.VisualStudio.Threading.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Thread affinity checks should be unconditional..
         /// </summary>
-        internal static string VSTHRD013_MessageFormat {
+        internal static string VSTHRD108_MessageFormat {
             get {
-                return ResourceManager.GetString("VSTHRD013_MessageFormat", resourceCulture);
+                return ResourceManager.GetString("VSTHRD108_MessageFormat", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to Assert thread affinity unconditionally.
         /// </summary>
-        internal static string VSTHRD013_Title {
+        internal static string VSTHRD108_Title {
             get {
-                return ResourceManager.GetString("VSTHRD013_Title", resourceCulture);
+                return ResourceManager.GetString("VSTHRD108_Title", resourceCulture);
             }
         }
         

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.resx
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.resx
@@ -245,10 +245,10 @@ Use AsyncLazy&lt;T&gt; instead.</value>
     <value>Use await instead</value>
     <comment>"await" is a C# keyword and should not be translated.</comment>
   </data>
-  <data name="VSTHRD013_MessageFormat" xml:space="preserve">
+  <data name="VSTHRD108_MessageFormat" xml:space="preserve">
     <value>Thread affinity checks should be unconditional.</value>
   </data>
-  <data name="VSTHRD013_Title" xml:space="preserve">
+  <data name="VSTHRD108_Title" xml:space="preserve">
     <value>Assert thread affinity unconditionally</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD108AssertThreadRequirementUnconditionally.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD108AssertThreadRequirementUnconditionally.cs
@@ -32,14 +32,14 @@
     /// So a new analyzer should require that the thread-asserting statement appear near the top of the method, and outside of any conditional blocks.
     /// </remarks>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class VSTHRD013AssertThreadRequirementUnconditionally : DiagnosticAnalyzer
+    public class VSTHRD108AssertThreadRequirementUnconditionally : DiagnosticAnalyzer
     {
-        public const string Id = "VSTHRD013";
+        public const string Id = "VSTHRD108";
 
         internal static readonly DiagnosticDescriptor Descriptor = new DiagnosticDescriptor(
            id: Id,
-           title: Strings.VSTHRD013_Title,
-           messageFormat: Strings.VSTHRD013_MessageFormat,
+           title: Strings.VSTHRD108_Title,
+           messageFormat: Strings.VSTHRD108_MessageFormat,
            category: "Usage",
            defaultSeverity: DiagnosticSeverity.Warning,
            isEnabledByDefault: true);


### PR DESCRIPTION
The VSTHRD0xx range is for critical analyzers. This is merely an advisory and therefore should be in the VSTHRD1xx range.