### PR TITLE
Fix race conditions in AsyncReadWriteLock to handle CancellationToken

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Tests/AsyncReaderWriterLockTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/AsyncReaderWriterLockTests.cs
@@ -2509,9 +2509,79 @@
             Assert.False(this.asyncLock.IsWriteLockHeld);
         }
 
-#endregion
+        [StaFact]
+        public async Task CancelAfterIsCompletedNoLeak()
+        {
+            var lockAwaitFinished = new TaskCompletionSource<object>();
+            var testCompleted = new TaskCompletionSource<object>();
+            var cts = new CancellationTokenSource();
 
-#region Completion tests
+            Thread staThread = new Thread((ThreadStart)delegate
+            {
+                try
+                {
+                    var awaitable = this.asyncLock.UpgradeableReadLockAsync(cts.Token);
+                    var awaiter = awaitable.GetAwaiter();
+                    cts.Cancel();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult().Dispose();
+                            Assert.True(false, "The lock should not be issued on an STA thread.");
+                        }
+                        catch (OperationCanceledException)
+                        {
+
+                        }
+
+                        lockAwaitFinished.SetAsync();
+                    }
+                    else
+                    {
+                        awaiter.OnCompleted(delegate
+                        {
+                            Assert.Equal(ApartmentState.MTA, Thread.CurrentThread.GetApartmentState());
+                            try
+                            {
+                                awaiter.GetResult().Dispose();
+                            }
+                            catch (OperationCanceledException)
+                            {
+                            }
+
+                            lockAwaitFinished.SetAsync();
+                        });
+                    }
+
+                    lockAwaitFinished.Task.Wait();
+
+                    // No lock is leaked
+                    awaitable = this.asyncLock.UpgradeableReadLockAsync();
+                    awaiter = awaitable.GetAwaiter();
+                    Assert.False(awaiter.IsCompleted, "The lock should not be issued on an STA thread.");
+                    awaiter.OnCompleted(delegate
+                    {
+                        Assert.Equal(ApartmentState.MTA, Thread.CurrentThread.GetApartmentState());
+                        awaiter.GetResult().Dispose();
+                        testCompleted.SetAsync();
+                    });
+                }
+                catch (Exception ex)
+                {
+                    testCompleted.TrySetException(ex);
+                }
+            });
+
+            staThread.SetApartmentState(ApartmentState.STA);
+            staThread.Start();
+            await testCompleted.Task;
+        }
+
+        #endregion
+
+        #region Completion tests
 
 #if DESKTOP || NETCOREAPP2_0
         [StaFact]

--- a/src/Microsoft.VisualStudio.Threading.Tests/AsyncReaderWriterLockTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/AsyncReaderWriterLockTests.cs
@@ -2510,7 +2510,7 @@
         }
 
         [StaFact]
-        public async Task CancelAfterIsCompletedNoLeak()
+        public async Task CancelJustBeforeIsCompletedNoLeak()
         {
             var lockAwaitFinished = new TaskCompletionSource<object>();
             var testCompleted = new TaskCompletionSource<object>();
@@ -2533,7 +2533,6 @@
                         }
                         catch (OperationCanceledException)
                         {
-
                         }
 
                         lockAwaitFinished.SetAsync();

--- a/src/Microsoft.VisualStudio.Threading/AsyncReaderWriterLock.cs
+++ b/src/Microsoft.VisualStudio.Threading/AsyncReaderWriterLock.cs
@@ -2284,8 +2284,8 @@ namespace Microsoft.VisualStudio.Threading
                     throw new NotSupportedException("Multiple continuations are not supported.");
                 }
 
-                this.cancellationRegistration = this.cancellationToken.Register(CancellationResponseAction, this, useSynchronizationContext: false);
                 this.lck.PendAwaiter(this);
+                this.cancellationRegistration = this.cancellationToken.Register(CancellationResponseAction, this, useSynchronizationContext: false);
             }
 
             /// <summary>

--- a/src/Microsoft.VisualStudio.Threading/AsyncReaderWriterLock.cs
+++ b/src/Microsoft.VisualStudio.Threading/AsyncReaderWriterLock.cs
@@ -2160,7 +2160,21 @@ namespace Microsoft.VisualStudio.Threading
             /// </summary>
             public bool IsCompleted
             {
-                get { return this.cancellationToken.IsCancellationRequested || this.fault != null || this.LockIssued; }
+                get
+                {
+                    if (this.fault != null)
+                    {
+                        return true;
+                    }
+
+                    // If lock has already been issued, we have to switch to the right context, and ignore the CancellationToken. 
+                    if (this.lck.IsLockActive(this, considerStaActive: true))
+                    {
+                        return this.lck.IsLockSupportingContext(this);
+                    }
+
+                    return this.cancellationToken.IsCancellationRequested;
+                }
             }
 
             /// <summary>


### PR DESCRIPTION
Two issues are fixed in the pull request:

https://github.com/Microsoft/vs-threading/issues/201
https://github.com/Microsoft/vs-threading/issues/200

Both are reproduced with new unit tests, and those tests are passing after the fix.

First issue:
CancellationToken.Register will call into the callback immediately, if the cancellation token is cancelled. The current code didn't expect that, and add pending request to the queue after this step, and hope the registered cancellation callback will be called later.  A simple reordering the code fixes this issue.

Second issue:
when the lock is issued in the awaiter before IsCompleted is called, and the cancellation token is triggered before IsCompleted is called.  This leads IsCompleted to return true immediately.  However, this can be on a thread, which the lock is invalid.  GetResult() will throw OperationCancelledException in this case.  This leads the lock is issued internally, but will not be released by anyone.  This leads many dead locks inside Visual Studio.

The fix is to ignore the CancellationToken if the lock has already been issued.
