### PR TITLE
Support ! operator in maintypes data file

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/AdditionalFiles/vs-threading.TypesRequiringMainThread.mocks.txt
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/AdditionalFiles/vs-threading.TypesRequiringMainThread.mocks.txt
@@ -1,0 +1,4 @@
+﻿TestNS.*
+!TestNS.FreeThreadedType
+!TestNS2.FreeThreadedType
+TestNS2.*

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/Microsoft.VisualStudio.Threading.Analyzers.Tests.csproj
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/Microsoft.VisualStudio.Threading.Analyzers.Tests.csproj
@@ -37,6 +37,9 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
+    <None Remove="AdditionalFiles\**" />
+  </ItemGroup>
+  <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD010MainThreadUsageAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD010MainThreadUsageAnalyzer.cs
@@ -127,7 +127,7 @@
 
             internal ImmutableArray<CommonInterest.QualifiedMember> MainThreadSwitchingMethods { get; set; }
 
-            internal ImmutableArray<CommonInterest.QualifiedType> TypesRequiringMainThread { get; set; }
+            internal ImmutableArray<CommonInterest.TypeMatchSpec> TypesRequiringMainThread { get; set; }
 
             internal void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
             {


### PR DESCRIPTION
This allows for identifying an entire namespace of types as STA objects, but selectively bringing specific types back into their default free-threaded status. The vssdk-analyzers project can then start marking specific types as free-threaded as they are made so.