### PR TITLE
VSTHRD002 should allow Task.Wait() within its own continuation

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD002UseJtfRunAnalyzerTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD002UseJtfRunAnalyzerTests.cs
@@ -140,14 +140,38 @@ class Test {
         var irrelevantTask = Task.Run(() => 1);
         var task = Task.Run(() => 5);
         task.ContinueWith(t => irrelevantTask.Result);
+        ContinueWith(t => t.Result);
         task.ContinueWith(t => t.Result);
+        task.ContinueWith((t) => t.Result);
+        task.ContinueWith(delegate (Task<int> t) { return t.Result; });
         task.ContinueWith(t => t.Wait());
+        ((Task)task).ContinueWith(t => t.Wait());
         task.ContinueWith((t, s) => t.Result, new object());
     }
+
+    void ContinueWith(Func<Task<int>, int> del) { }
 }
 ";
-            this.expect.Locations = new[] { new DiagnosticResultLocation("Test0.cs", 9, 47, 9, 53) };
-            this.VerifyCSharpDiagnostic(test, this.expect);
+            var expect = new DiagnosticResult[]
+            {
+                new DiagnosticResult
+                {
+                    Message = this.expect.Message,
+                    Id = this.expect.Id,
+                    Severity = this.expect.Severity,
+                    SkipVerifyMessage = this.expect.SkipVerifyMessage,
+                    Locations = new[] { new DiagnosticResultLocation("Test0.cs", 9, 47, 9, 53) },
+                },
+                new DiagnosticResult
+                {
+                    Message = this.expect.Message,
+                    Id = this.expect.Id,
+                    Severity = this.expect.Severity,
+                    SkipVerifyMessage = this.expect.SkipVerifyMessage,
+                    Locations = new[] { new DiagnosticResultLocation("Test0.cs", 10, 29, 10, 35) },
+                },
+            };
+            this.VerifyCSharpDiagnostic(test, expect);
             this.VerifyNoCSharpFixOffered(test);
         }
 

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD002UseJtfRunAnalyzerTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD002UseJtfRunAnalyzerTests.cs
@@ -129,6 +129,29 @@ class Test {
         }
 
         [Fact]
+        public void TaskResultShouldNotReportWarning_WithinItsOwnContinuationDelegate()
+        {
+            var test = @"
+using System;
+using System.Threading.Tasks;
+
+class Test {
+    void F() {
+        var irrelevantTask = Task.Run(() => 1);
+        var task = Task.Run(() => 5);
+        task.ContinueWith(t => irrelevantTask.Result);
+        task.ContinueWith(t => t.Result);
+        task.ContinueWith(t => t.Wait());
+        task.ContinueWith((t, s) => t.Result, new object());
+    }
+}
+";
+            this.expect.Locations = new[] { new DiagnosticResultLocation("Test0.cs", 9, 47, 9, 53) };
+            this.VerifyCSharpDiagnostic(test, this.expect);
+            this.VerifyNoCSharpFixOffered(test);
+        }
+
+        [Fact]
         public void AwaiterGetResultShouldReportWarning()
         {
             var test = @"

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Types.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Types.cs
@@ -121,5 +121,14 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
 
             internal const string InvokeAsync = "InvokeAsync";
         }
+
+        internal static class Task
+        {
+            internal const string TypeName = nameof(System.Threading.Tasks.Task);
+
+            internal const string Namespace = "System.Threading.Tasks.";
+
+            internal const string FullName = Namespace + TypeName;
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD002UseJtfRunAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD002UseJtfRunAnalyzer.cs
@@ -59,37 +59,97 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
             context.EnableConcurrentExecution();
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze);
 
-            context.RegisterCodeBlockStartAction<SyntaxKind>(ctxt =>
+            context.RegisterCompilationStartAction(compilationContext =>
             {
-                // We want to scan properties and methods that do not return Task or Task<T>.
-                var methodSymbol = ctxt.OwningSymbol as IMethodSymbol;
-                var propertySymbol = ctxt.OwningSymbol as IPropertySymbol;
-                if (propertySymbol != null || (methodSymbol != null && !methodSymbol.HasAsyncCompatibleReturnType()))
+                var taskSymbol = compilationContext.Compilation.GetTypeByMetadataName(Types.Task.FullName);
+                if (taskSymbol != null)
                 {
-                    ctxt.RegisterSyntaxNodeAction(Utils.DebuggableWrapper(this.AnalyzeInvocation), SyntaxKind.InvocationExpression);
-                    ctxt.RegisterSyntaxNodeAction(Utils.DebuggableWrapper(this.AnalyzeMemberAccess), SyntaxKind.SimpleMemberAccessExpression);
+                    compilationContext.RegisterCodeBlockStartAction<SyntaxKind>(codeBlockContext =>
+                    {
+                        // We want to scan properties and methods that do not return Task or Task<T>.
+                        var methodSymbol = codeBlockContext.OwningSymbol as IMethodSymbol;
+                        var propertySymbol = codeBlockContext.OwningSymbol as IPropertySymbol;
+                        if (propertySymbol != null || (methodSymbol != null && !methodSymbol.HasAsyncCompatibleReturnType()))
+                        {
+                            codeBlockContext.RegisterSyntaxNodeAction(Utils.DebuggableWrapper(c => this.AnalyzeInvocation(c, taskSymbol)), SyntaxKind.InvocationExpression);
+                            codeBlockContext.RegisterSyntaxNodeAction(Utils.DebuggableWrapper(c => this.AnalyzeMemberAccess(c, taskSymbol)), SyntaxKind.SimpleMemberAccessExpression);
+                        }
+                    });
                 }
             });
         }
 
-        private void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+        private static ParameterSyntax GetFirstParameter(AnonymousFunctionExpressionSyntax anonymousFunctionSyntax)
         {
-            var invocationExpressionSyntax = (InvocationExpressionSyntax)context.Node;
-            CommonInterest.InspectMemberAccess(
-                context,
-                invocationExpressionSyntax.Expression as MemberAccessExpressionSyntax,
-                Descriptor,
-                CommonInterest.ProblematicSyncBlockingMethods);
+            switch (anonymousFunctionSyntax)
+            {
+                case SimpleLambdaExpressionSyntax lambda:
+                    return lambda.Parameter;
+                case ParenthesizedLambdaExpressionSyntax lambda:
+                    return lambda.ParameterList.Parameters.FirstOrDefault();
+                case AnonymousMethodExpressionSyntax anonymousMethod:
+                    return anonymousMethod.ParameterList?.Parameters.FirstOrDefault();
+            }
+
+            return null;
         }
 
-        private void AnalyzeMemberAccess(SyntaxNodeAnalysisContext context)
+        private void AnalyzeInvocation(SyntaxNodeAnalysisContext context, INamedTypeSymbol taskSymbol)
+        {
+            var invocationExpressionSyntax = (InvocationExpressionSyntax)context.Node;
+            this.InspectMemberAccess(
+                context,
+                invocationExpressionSyntax.Expression as MemberAccessExpressionSyntax,
+                CommonInterest.ProblematicSyncBlockingMethods,
+                taskSymbol);
+        }
+
+        private void AnalyzeMemberAccess(SyntaxNodeAnalysisContext context, INamedTypeSymbol taskSymbol)
         {
             var memberAccessSyntax = (MemberAccessExpressionSyntax)context.Node;
-            CommonInterest.InspectMemberAccess(
+            this.InspectMemberAccess(
                 context,
                 memberAccessSyntax,
-                Descriptor,
-                CommonInterest.SyncBlockingProperties);
+                CommonInterest.SyncBlockingProperties,
+                taskSymbol);
+        }
+
+        private void InspectMemberAccess(
+            SyntaxNodeAnalysisContext context,
+            MemberAccessExpressionSyntax memberAccessSyntax,
+            IEnumerable<CommonInterest.SyncBlockingMethod> problematicMethods,
+            INamedTypeSymbol taskSymbol)
+        {
+            // Are we in the context of an anonymous function that is passed directly in as an argument to another method?
+            var anonymousFunctionSyntax = context.Node.FirstAncestorOrSelf<AnonymousFunctionExpressionSyntax>();
+            var anonFuncAsArgument = anonymousFunctionSyntax?.Parent as ArgumentSyntax;
+            var invocationPassingExpression = anonFuncAsArgument?.Parent?.Parent as InvocationExpressionSyntax;
+            var invokedMemberAccess = invocationPassingExpression?.Expression as MemberAccessExpressionSyntax;
+            if (invokedMemberAccess?.Name != null)
+            {
+                // Does the anonymous function appear as the first argument to Task.ContinueWith?
+                var invokedMemberSymbol = context.SemanticModel.GetSymbolInfo(invokedMemberAccess.Name).Symbol as IMethodSymbol;
+                if (invokedMemberSymbol?.Name == nameof(Task.ContinueWith) &&
+                    Utils.IsEqualToOrDerivedFrom(invokedMemberSymbol?.ContainingType, taskSymbol) &&
+                    invocationPassingExpression?.ArgumentList?.Arguments.FirstOrDefault() == anonFuncAsArgument)
+                {
+                    // Does the member access being analyzed belong to the Task that just completed?
+                    var firstParameter = GetFirstParameter(anonymousFunctionSyntax);
+                    if (firstParameter != null)
+                    {
+                        // Are we accessing a member of the completed task?
+                        ISymbol invokedObjectSymbol = context.SemanticModel.GetSymbolInfo(memberAccessSyntax?.Expression).Symbol;
+                        IParameterSymbol completedTask = context.SemanticModel.GetDeclaredSymbol(firstParameter);
+                        if (invokedObjectSymbol.Equals(completedTask))
+                        {
+                            // Skip analysis since Task.Result (et. al) of a completed Task is fair game.
+                            return;
+                        }
+                    }
+                }
+            }
+
+            CommonInterest.InspectMemberAccess(context, memberAccessSyntax, Descriptor, problematicMethods);
         }
     }
 }


### PR DESCRIPTION
Makes this legal (no diagnostic created):

```csharp
Task<int> t;
t.ContinueWith(t2 => t2.Result);
```

Normally accessing `Task.Result` would produce a VSTHRD002 warning, but in a case like this, it's provably safe because it will never block. 

Fixes #217