### PR TITLE
Raise VSTHRD010 diagnostics transitively

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD010MainThreadUsageAnalyzerTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD010MainThreadUsageAnalyzerTests.cs
@@ -289,24 +289,38 @@ class Test {
         G();
     }
 
-    int Foo {
+    int MainThreadGetter {
         get {
             H();
             return 0;
         }
 
         set {
-            G();
         }
     }
 
-    int I() => Foo; // intentionally leave off `this.` to exercise identifier name access
+    int MainThreadSetter {
+        get => 0;
+        set => H();
+    }
 
-    void J() => this.Foo = 5; // intentionally include `this.` to exercise member access
+    int CallMainThreadGetter_get() => MainThreadGetter;               // Flagged
+    int CallMainThreadGetter_get2() => this.MainThreadGetter;         // Flagged
+    int CallMainThreadGetter_get3() => ((Test)this).MainThreadGetter; // Flagged
+    int CallMainThreadGetter_set() => MainThreadGetter = 1;
+    int CallMainThreadGetter_set2() => this.MainThreadGetter = 1;
+
+    int CallMainThreadSetter_get() => MainThreadSetter;
+    int CallMainThreadSetter_get2() => this.MainThreadSetter;
+    int CallMainThreadSetter_set() => MainThreadSetter = 1;               // Flagged
+    int CallMainThreadSetter_set2() => this.MainThreadSetter = 1;         // Flagged
+    int CallMainThreadSetter_set3() => ((Test)this).MainThreadSetter = 1; // Flagged
 
     // None of these should produce diagnostics since we're not invoking the members.
-    string NameOfFoo() => nameof(Foo);
-    string NameOfThisFoo() => nameof(this.Foo);
+    string NameOfFoo1() => nameof(MainThreadGetter);
+    string NameOfFoo2() => nameof(MainThreadSetter);
+    string NameOfThisFoo1() => nameof(this.MainThreadGetter);
+    string NameOfThisFoo2() => nameof(this.MainThreadSetter);
     string NameOfH() => nameof(H);
     Action GAsDelegate() => this.G;
 
@@ -314,56 +328,27 @@ class Test {
     }
 }
 ";
+            DiagnosticResult CreateDiagnostic(int line, int column, int endLine, int endColumn) =>
+                new DiagnosticResult
+                {
+                    Id = this.expect.Id,
+                    Message = this.expect.Message,
+                    SkipVerifyMessage = this.expect.SkipVerifyMessage,
+                    Severity = this.expect.Severity,
+                    Locations = new[] { new DiagnosticResultLocation("Test0.cs", line, column, endLine, endColumn) },
+                };
             var expect = new DiagnosticResult[]
             {
-                new DiagnosticResult
-                {
-                    Id = this.expect.Id,
-                    Message = this.expect.Message,
-                    SkipVerifyMessage = this.expect.SkipVerifyMessage,
-                    Severity = this.expect.Severity,
-                    Locations = new[] { new DiagnosticResultLocation("Test0.cs", 12, 10, 12, 11) },
-                },
-                new DiagnosticResult
-                {
-                    Id = this.expect.Id,
-                    Message = this.expect.Message,
-                    SkipVerifyMessage = this.expect.SkipVerifyMessage,
-                    Severity = this.expect.Severity,
-                    Locations = new[] { new DiagnosticResultLocation("Test0.cs", 16, 10, 16, 11) },
-                },
-                new DiagnosticResult
-                {
-                    Id = this.expect.Id,
-                    Message = this.expect.Message,
-                    SkipVerifyMessage = this.expect.SkipVerifyMessage,
-                    Severity = this.expect.Severity,
-                    Locations = new[] { new DiagnosticResultLocation("Test0.cs", 21, 9, 21, 12) },
-                },
-                new DiagnosticResult
-                {
-                    Id = this.expect.Id,
-                    Message = this.expect.Message,
-                    SkipVerifyMessage = this.expect.SkipVerifyMessage,
-                    Severity = this.expect.Severity,
-                    Locations = new[] { new DiagnosticResultLocation("Test0.cs", 26, 9, 26, 12) },
-                },
-                new DiagnosticResult
-                {
-                    Id = this.expect.Id,
-                    Message = this.expect.Message,
-                    SkipVerifyMessage = this.expect.SkipVerifyMessage,
-                    Severity = this.expect.Severity,
-                    Locations = new[] { new DiagnosticResultLocation("Test0.cs", 31, 9, 31, 10) },
-                },
-                new DiagnosticResult
-                {
-                    Id = this.expect.Id,
-                    Message = this.expect.Message,
-                    SkipVerifyMessage = this.expect.SkipVerifyMessage,
-                    Severity = this.expect.Severity,
-                    Locations = new[] { new DiagnosticResultLocation("Test0.cs", 33, 10, 33, 11) },
-                },
+                CreateDiagnostic(12, 10, 12, 11),
+                CreateDiagnostic(16, 10, 16, 11),
+                CreateDiagnostic(21, 9, 21, 12),
+                CreateDiagnostic(32, 9, 32, 12),
+                CreateDiagnostic(35, 9, 35, 33),
+                CreateDiagnostic(36, 9, 36, 34),
+                CreateDiagnostic(37, 9, 37, 34),
+                CreateDiagnostic(43, 9, 43, 33),
+                CreateDiagnostic(44, 9, 44, 34),
+                CreateDiagnostic(45, 9, 45, 34),
             };
             this.VerifyCSharpDiagnostic(test, expect);
         }

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.cs.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.cs.xlf
@@ -192,6 +192,11 @@ Await JoinableTaskFactory.SwitchToMainThreadAsync() first.</source>
 Await JoinableTaskFactory.SwitchToMainThreadAsync() first.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is a type name and {1} is the name of a method that throws if not called from the main thread.</note>
         </trans-unit>
+        <trans-unit id="VSTHRD010_MessageFormat_TransitiveMainThreadUser" translate="yes" xml:space="preserve">
+          <source>Add call to {0}() at start of member body because this member invokes other members that require the main thread.</source>
+          <target state="new">Add call to {0}() at start of member body because this member invokes other members that require the main thread.</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a method name.</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.de.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.de.xlf
@@ -192,6 +192,11 @@ Await JoinableTaskFactory.SwitchToMainThreadAsync() first.</source>
 Await JoinableTaskFactory.SwitchToMainThreadAsync() first.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is a type name and {1} is the name of a method that throws if not called from the main thread.</note>
         </trans-unit>
+        <trans-unit id="VSTHRD010_MessageFormat_TransitiveMainThreadUser" translate="yes" xml:space="preserve">
+          <source>Add call to {0}() at start of member body because this member invokes other members that require the main thread.</source>
+          <target state="new">Add call to {0}() at start of member body because this member invokes other members that require the main thread.</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a method name.</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.es.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.es.xlf
@@ -192,6 +192,11 @@ Await JoinableTaskFactory.SwitchToMainThreadAsync() first.</source>
 Await JoinableTaskFactory.SwitchToMainThreadAsync() first.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is a type name and {1} is the name of a method that throws if not called from the main thread.</note>
         </trans-unit>
+        <trans-unit id="VSTHRD010_MessageFormat_TransitiveMainThreadUser" translate="yes" xml:space="preserve">
+          <source>Add call to {0}() at start of member body because this member invokes other members that require the main thread.</source>
+          <target state="new">Add call to {0}() at start of member body because this member invokes other members that require the main thread.</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a method name.</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.fr.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.fr.xlf
@@ -192,6 +192,11 @@ Await JoinableTaskFactory.SwitchToMainThreadAsync() first.</source>
 Await JoinableTaskFactory.SwitchToMainThreadAsync() first.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is a type name and {1} is the name of a method that throws if not called from the main thread.</note>
         </trans-unit>
+        <trans-unit id="VSTHRD010_MessageFormat_TransitiveMainThreadUser" translate="yes" xml:space="preserve">
+          <source>Add call to {0}() at start of member body because this member invokes other members that require the main thread.</source>
+          <target state="new">Add call to {0}() at start of member body because this member invokes other members that require the main thread.</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a method name.</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.it.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.it.xlf
@@ -192,6 +192,11 @@ Await JoinableTaskFactory.SwitchToMainThreadAsync() first.</source>
 Await JoinableTaskFactory.SwitchToMainThreadAsync() first.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is a type name and {1} is the name of a method that throws if not called from the main thread.</note>
         </trans-unit>
+        <trans-unit id="VSTHRD010_MessageFormat_TransitiveMainThreadUser" translate="yes" xml:space="preserve">
+          <source>Add call to {0}() at start of member body because this member invokes other members that require the main thread.</source>
+          <target state="new">Add call to {0}() at start of member body because this member invokes other members that require the main thread.</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a method name.</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.ja.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.ja.xlf
@@ -192,6 +192,11 @@ Await JoinableTaskFactory.SwitchToMainThreadAsync() first.</source>
 Await JoinableTaskFactory.SwitchToMainThreadAsync() first.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is a type name and {1} is the name of a method that throws if not called from the main thread.</note>
         </trans-unit>
+        <trans-unit id="VSTHRD010_MessageFormat_TransitiveMainThreadUser" translate="yes" xml:space="preserve">
+          <source>Add call to {0}() at start of member body because this member invokes other members that require the main thread.</source>
+          <target state="new">Add call to {0}() at start of member body because this member invokes other members that require the main thread.</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a method name.</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.ko.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.ko.xlf
@@ -192,6 +192,11 @@ Await JoinableTaskFactory.SwitchToMainThreadAsync() first.</source>
 Await JoinableTaskFactory.SwitchToMainThreadAsync() first.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is a type name and {1} is the name of a method that throws if not called from the main thread.</note>
         </trans-unit>
+        <trans-unit id="VSTHRD010_MessageFormat_TransitiveMainThreadUser" translate="yes" xml:space="preserve">
+          <source>Add call to {0}() at start of member body because this member invokes other members that require the main thread.</source>
+          <target state="new">Add call to {0}() at start of member body because this member invokes other members that require the main thread.</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a method name.</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.pl.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.pl.xlf
@@ -192,6 +192,11 @@ Await JoinableTaskFactory.SwitchToMainThreadAsync() first.</source>
 Await JoinableTaskFactory.SwitchToMainThreadAsync() first.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is a type name and {1} is the name of a method that throws if not called from the main thread.</note>
         </trans-unit>
+        <trans-unit id="VSTHRD010_MessageFormat_TransitiveMainThreadUser" translate="yes" xml:space="preserve">
+          <source>Add call to {0}() at start of member body because this member invokes other members that require the main thread.</source>
+          <target state="new">Add call to {0}() at start of member body because this member invokes other members that require the main thread.</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a method name.</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.pt-BR.xlf
@@ -192,6 +192,11 @@ Await JoinableTaskFactory.SwitchToMainThreadAsync() first.</source>
 Await JoinableTaskFactory.SwitchToMainThreadAsync() first.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is a type name and {1} is the name of a method that throws if not called from the main thread.</note>
         </trans-unit>
+        <trans-unit id="VSTHRD010_MessageFormat_TransitiveMainThreadUser" translate="yes" xml:space="preserve">
+          <source>Add call to {0}() at start of member body because this member invokes other members that require the main thread.</source>
+          <target state="new">Add call to {0}() at start of member body because this member invokes other members that require the main thread.</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a method name.</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.ru.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.ru.xlf
@@ -192,6 +192,11 @@ Await JoinableTaskFactory.SwitchToMainThreadAsync() first.</source>
 Await JoinableTaskFactory.SwitchToMainThreadAsync() first.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is a type name and {1} is the name of a method that throws if not called from the main thread.</note>
         </trans-unit>
+        <trans-unit id="VSTHRD010_MessageFormat_TransitiveMainThreadUser" translate="yes" xml:space="preserve">
+          <source>Add call to {0}() at start of member body because this member invokes other members that require the main thread.</source>
+          <target state="new">Add call to {0}() at start of member body because this member invokes other members that require the main thread.</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a method name.</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.tr.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.tr.xlf
@@ -192,6 +192,11 @@ Await JoinableTaskFactory.SwitchToMainThreadAsync() first.</source>
 Await JoinableTaskFactory.SwitchToMainThreadAsync() first.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is a type name and {1} is the name of a method that throws if not called from the main thread.</note>
         </trans-unit>
+        <trans-unit id="VSTHRD010_MessageFormat_TransitiveMainThreadUser" translate="yes" xml:space="preserve">
+          <source>Add call to {0}() at start of member body because this member invokes other members that require the main thread.</source>
+          <target state="new">Add call to {0}() at start of member body because this member invokes other members that require the main thread.</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a method name.</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.zh-Hans.xlf
@@ -192,6 +192,11 @@ Await JoinableTaskFactory.SwitchToMainThreadAsync() first.</source>
 Await JoinableTaskFactory.SwitchToMainThreadAsync() first.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is a type name and {1} is the name of a method that throws if not called from the main thread.</note>
         </trans-unit>
+        <trans-unit id="VSTHRD010_MessageFormat_TransitiveMainThreadUser" translate="yes" xml:space="preserve">
+          <source>Add call to {0}() at start of member body because this member invokes other members that require the main thread.</source>
+          <target state="new">Add call to {0}() at start of member body because this member invokes other members that require the main thread.</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a method name.</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.zh-Hant.xlf
@@ -192,6 +192,11 @@ Await JoinableTaskFactory.SwitchToMainThreadAsync() first.</source>
 Await JoinableTaskFactory.SwitchToMainThreadAsync() first.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is a type name and {1} is the name of a method that throws if not called from the main thread.</note>
         </trans-unit>
+        <trans-unit id="VSTHRD010_MessageFormat_TransitiveMainThreadUser" translate="yes" xml:space="preserve">
+          <source>Add call to {0}() at start of member body because this member invokes other members that require the main thread.</source>
+          <target state="new">Add call to {0}() at start of member body because this member invokes other members that require the main thread.</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a method name.</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.Designer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.Designer.cs
@@ -164,6 +164,15 @@ namespace Microsoft.VisualStudio.Threading.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Add call to {0}() at start of member body because this member invokes other members that require the main thread..
+        /// </summary>
+        internal static string VSTHRD010_MessageFormat_TransitiveMainThreadUser {
+            get {
+                return ResourceManager.GetString("VSTHRD010_MessageFormat_TransitiveMainThreadUser", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invoke single-threaded types on Main thread.
         /// </summary>
         internal static string VSTHRD010_Title {

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.resx
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.resx
@@ -257,4 +257,8 @@ Use AsyncLazy&lt;T&gt; instead.</value>
 Await JoinableTaskFactory.SwitchToMainThreadAsync() first.</value>
     <comment>{0} is a type name and {1} is the name of a method that throws if not called from the main thread.</comment>
   </data>
+  <data name="VSTHRD010_MessageFormat_TransitiveMainThreadUser" xml:space="preserve">
+    <value>Add call to {0}() at start of member body because this member invokes other members that require the main thread.</value>
+    <comment>{0} is a method name.</comment>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Utils.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Utils.cs
@@ -607,9 +607,9 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
         /// <summary>
         /// Determines whether an expression appears inside a C# "nameof" pseudo-method.
         /// </summary>
-        internal static bool IsWithinNameOf(ExpressionSyntax memberAccess)
+        internal static bool IsWithinNameOf(SyntaxNode syntaxNode)
         {
-            var invocation = memberAccess?.FirstAncestorOrSelf<InvocationExpressionSyntax>();
+            var invocation = syntaxNode?.FirstAncestorOrSelf<InvocationExpressionSyntax>();
             return (invocation?.Expression as IdentifierNameSyntax)?.Identifier.Text == "nameof"
                 && invocation.ArgumentList.Arguments.Count == 1;
         }

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Utils.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Utils.cs
@@ -276,6 +276,22 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
             return symbol.GetAttributes().Any(a => a.AttributeClass.Name == nameof(ObsoleteAttribute) && a.AttributeClass.BelongsToNamespace(Namespaces.System));
         }
 
+        internal static bool IsOnLeftHandOfAssignment(SyntaxNode syntaxNode)
+        {
+            SyntaxNode parent = null;
+            while ((parent = syntaxNode.Parent) != null)
+            {
+                if (parent is AssignmentExpressionSyntax assignment)
+                {
+                    return assignment.Left == syntaxNode;
+                }
+
+                syntaxNode = parent;
+            }
+
+            return false;
+        }
+
         internal static IEnumerable<ITypeSymbol> FindInterfacesImplemented(this ISymbol symbol)
         {
             if (symbol == null)

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD010MainThreadUsageAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD010MainThreadUsageAnalyzer.cs
@@ -9,6 +9,7 @@
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
+    using Microsoft.CodeAnalysis.Semantics;
     using Microsoft.CodeAnalysis.Text;
 
     /// <summary>
@@ -62,6 +63,23 @@
             defaultSeverity: DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
 
+        internal static readonly DiagnosticDescriptor DescriptorTransitiveMainThreadUser = new DiagnosticDescriptor(
+            id: Id,
+            title: Strings.VSTHRD010_Title,
+            messageFormat: Strings.VSTHRD010_MessageFormat_TransitiveMainThreadUser,
+            helpLinkUri: Utils.GetHelpLink(Id),
+            category: "Usage",
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        /// <summary>
+        /// A reusable value to return from <see cref="SupportedDiagnostics"/>.
+        /// </summary>
+        private static readonly ImmutableArray<DiagnosticDescriptor> ReusableSupportedDescriptors = ImmutableArray.Create(
+            Descriptor,
+            DescriptorNoAssertingMethod,
+            DescriptorTransitiveMainThreadUser);
+
         private enum ThreadingContext
         {
             /// <summary>
@@ -82,13 +100,7 @@
         }
 
         /// <inheritdoc />
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
-        {
-            get
-            {
-                return ImmutableArray.Create(Descriptor);
-            }
-        }
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ReusableSupportedDescriptors;
 
         /// <inheritdoc />
         public override void Initialize(AnalysisContext context)
@@ -96,27 +108,154 @@
             context.EnableConcurrentExecution();
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze);
 
-            context.RegisterCompilationStartAction(ctxt =>
+            context.RegisterCompilationStartAction(compilationStartContext =>
             {
-                var mainThreadAssertingMethods = CommonInterest.ReadMethods(ctxt, CommonInterest.FileNamePatternForMethodsThatAssertMainThread).ToImmutableArray();
-                var mainThreadSwitchingMethods = CommonInterest.ReadMethods(ctxt, CommonInterest.FileNamePatternForMethodsThatSwitchToMainThread).ToImmutableArray();
-                var typesRequiringMainThread = CommonInterest.ReadTypes(ctxt, CommonInterest.FileNamePatternForTypesRequiringMainThread).ToImmutableArray();
+                var mainThreadAssertingMethods = CommonInterest.ReadMethods(compilationStartContext, CommonInterest.FileNamePatternForMethodsThatAssertMainThread).ToImmutableArray();
+                var mainThreadSwitchingMethods = CommonInterest.ReadMethods(compilationStartContext, CommonInterest.FileNamePatternForMethodsThatSwitchToMainThread).ToImmutableArray();
+                var typesRequiringMainThread = CommonInterest.ReadTypes(compilationStartContext, CommonInterest.FileNamePatternForTypesRequiringMainThread).ToImmutableArray();
 
-                ctxt.RegisterCodeBlockStartAction<SyntaxKind>(ctxt2 =>
+                var methodsDeclaringUIThreadRequirement = new HashSet<IMethodSymbol>();
+                var callerToCalleeMap = new Dictionary<IMethodSymbol, HashSet<IMethodSymbol>>();
+
+                compilationStartContext.RegisterCodeBlockStartAction<SyntaxKind>(codeBlockStartContext =>
                 {
                     var methodAnalyzer = new MethodAnalyzer
                     {
                         MainThreadAssertingMethods = mainThreadAssertingMethods,
                         MainThreadSwitchingMethods = mainThreadSwitchingMethods,
                         TypesRequiringMainThread = typesRequiringMainThread,
+                        MethodsDeclaringUIThreadRequirement = methodsDeclaringUIThreadRequirement,
                     };
-                    ctxt2.RegisterSyntaxNodeAction(Utils.DebuggableWrapper(methodAnalyzer.AnalyzeInvocation), SyntaxKind.InvocationExpression);
-                    ctxt2.RegisterSyntaxNodeAction(Utils.DebuggableWrapper(methodAnalyzer.AnalyzeMemberAccess), SyntaxKind.SimpleMemberAccessExpression);
-                    ctxt2.RegisterSyntaxNodeAction(Utils.DebuggableWrapper(methodAnalyzer.AnalyzeCast), SyntaxKind.CastExpression);
-                    ctxt2.RegisterSyntaxNodeAction(Utils.DebuggableWrapper(methodAnalyzer.AnalyzeAs), SyntaxKind.AsExpression);
-                    ctxt2.RegisterSyntaxNodeAction(Utils.DebuggableWrapper(methodAnalyzer.AnalyzeAs), SyntaxKind.IsExpression);
+                    codeBlockStartContext.RegisterSyntaxNodeAction(Utils.DebuggableWrapper(methodAnalyzer.AnalyzeInvocation), SyntaxKind.InvocationExpression);
+                    codeBlockStartContext.RegisterSyntaxNodeAction(Utils.DebuggableWrapper(methodAnalyzer.AnalyzeMemberAccess), SyntaxKind.SimpleMemberAccessExpression);
+                    codeBlockStartContext.RegisterSyntaxNodeAction(Utils.DebuggableWrapper(methodAnalyzer.AnalyzeCast), SyntaxKind.CastExpression);
+                    codeBlockStartContext.RegisterSyntaxNodeAction(Utils.DebuggableWrapper(methodAnalyzer.AnalyzeAs), SyntaxKind.AsExpression);
+                    codeBlockStartContext.RegisterSyntaxNodeAction(Utils.DebuggableWrapper(methodAnalyzer.AnalyzeAs), SyntaxKind.IsExpression);
+                });
+
+                compilationStartContext.RegisterSyntaxNodeAction(Utils.DebuggableWrapper(c => AddToCallerCalleeMap(c, callerToCalleeMap)), SyntaxKind.InvocationExpression);
+                compilationStartContext.RegisterSyntaxNodeAction(Utils.DebuggableWrapper(c => AddToCallerCalleeMap(c, callerToCalleeMap)), SyntaxKind.SimpleMemberAccessExpression);
+                compilationStartContext.RegisterSyntaxNodeAction(Utils.DebuggableWrapper(c => AddToCallerCalleeMap(c, callerToCalleeMap)), SyntaxKind.IdentifierName);
+
+                compilationStartContext.RegisterCompilationEndAction(compilationEndContext =>
+                {
+                    var calleeToCallerMap = CreateCalleeToCallerMap(callerToCalleeMap);
+                    var transitiveClosureOfMainThreadRequiringMethods = GetTransitiveClosureOfMainThreadRequiringMethods(methodsDeclaringUIThreadRequirement, calleeToCallerMap);
+                    foreach (var implicitUserMethod in transitiveClosureOfMainThreadRequiringMethods.Except(methodsDeclaringUIThreadRequirement))
+                    {
+                        var declarationSyntax = implicitUserMethod.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax(compilationEndContext.CancellationToken);
+                        SyntaxToken memberNameSyntax = default(SyntaxToken);
+                        switch (declarationSyntax)
+                        {
+                            case MethodDeclarationSyntax methodDeclarationSyntax:
+                                memberNameSyntax = methodDeclarationSyntax.Identifier;
+                                break;
+                            case AccessorDeclarationSyntax accessorDeclarationSyntax:
+                                memberNameSyntax = accessorDeclarationSyntax.Keyword;
+                                break;
+                        }
+                        var location = memberNameSyntax.GetLocation();
+                        if (location != null)
+                        {
+                            var exampleAssertingMethod = mainThreadAssertingMethods.FirstOrDefault();
+                            compilationEndContext.ReportDiagnostic(Diagnostic.Create(DescriptorTransitiveMainThreadUser, location, exampleAssertingMethod));
+                        }
+                    }
                 });
             });
+        }
+
+        private static HashSet<IMethodSymbol> GetTransitiveClosureOfMainThreadRequiringMethods(HashSet<IMethodSymbol> methodsRequiringUIThread, Dictionary<IMethodSymbol, HashSet<IMethodSymbol>> calleeToCallerMap)
+        {
+            var result = new HashSet<IMethodSymbol>();
+
+            void MarkMethod(IMethodSymbol method)
+            {
+                if (result.Add(method) && calleeToCallerMap.TryGetValue(method, out var callers))
+                {
+                    foreach (var caller in callers)
+                    {
+                        MarkMethod(caller);
+                    }
+                }
+            }
+
+            foreach (var method in methodsRequiringUIThread)
+            {
+                MarkMethod(method);
+            }
+
+            return result;
+        }
+
+        private static void AddToCallerCalleeMap(SyntaxNodeAnalysisContext context, Dictionary<IMethodSymbol, HashSet<IMethodSymbol>> callerToCalleeMap)
+        {
+            if (Utils.IsWithinNameOf(context.Node))
+            {
+                return;
+            }
+
+            ISymbol targetMethod = null;
+            switch (context.Node)
+            {
+                case InvocationExpressionSyntax invocationExpressionSyntax:
+                    targetMethod = context.SemanticModel.GetSymbolInfo(invocationExpressionSyntax.Expression).Symbol;
+                    break;
+                case MemberAccessExpressionSyntax memberAccessExpressionSyntax:
+                    var targetProperty = context.SemanticModel.GetSymbolInfo(memberAccessExpressionSyntax.Name).Symbol as IPropertySymbol;
+                    if (targetProperty != null)
+                    {
+                        targetMethod = context.Node.Parent is AssignmentExpressionSyntax assignmentSyntax && context.Node == assignmentSyntax.Left
+                            ? targetProperty.SetMethod
+                            : targetProperty.GetMethod;
+                    }
+
+                    break;
+                case IdentifierNameSyntax identifierNameSyntax:
+                    targetProperty = context.SemanticModel.GetSymbolInfo(identifierNameSyntax).Symbol as IPropertySymbol;
+                    if (targetProperty != null)
+                    {
+                        targetMethod = context.Node.Parent is AssignmentExpressionSyntax assignmentSyntax && context.Node == assignmentSyntax.Left
+                            ? targetProperty.SetMethod
+                            : targetProperty.GetMethod;
+                    }
+
+                    break;
+            }
+
+            if (context.ContainingSymbol is IMethodSymbol caller && targetMethod is IMethodSymbol callee)
+            {
+                lock (callerToCalleeMap)
+                {
+                    if (!callerToCalleeMap.TryGetValue(caller, out HashSet<IMethodSymbol> callees))
+                    {
+                        callerToCalleeMap[caller] = callees = new HashSet<IMethodSymbol>();
+                    }
+
+                    callees.Add(callee);
+                }
+            }
+        }
+
+        private static Dictionary<IMethodSymbol, HashSet<IMethodSymbol>> CreateCalleeToCallerMap(Dictionary<IMethodSymbol, HashSet<IMethodSymbol>> callerToCalleeMap)
+        {
+            var result = new Dictionary<IMethodSymbol, HashSet<IMethodSymbol>>();
+
+            foreach (var item in callerToCalleeMap)
+            {
+                var caller = item.Key;
+                foreach (var callee in item.Value)
+                {
+                    if (!result.TryGetValue(callee, out var callers))
+                    {
+                        result[callee] = callers = new HashSet<IMethodSymbol>();
+                    }
+
+                    callers.Add(caller);
+                }
+            }
+
+            return result;
         }
 
         private class MethodAnalyzer
@@ -129,6 +268,8 @@
 
             internal ImmutableArray<CommonInterest.TypeMatchSpec> TypesRequiringMainThread { get; set; }
 
+            internal HashSet<IMethodSymbol> MethodsDeclaringUIThreadRequirement { get; set; }
+
             internal void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
             {
                 var invocationSyntax = (InvocationExpressionSyntax)context.Node;
@@ -140,6 +281,14 @@
                     {
                         if (this.MainThreadAssertingMethods.Contains(invokedMethod) || this.MainThreadSwitchingMethods.Contains(invokedMethod))
                         {
+                            if (context.ContainingSymbol is IMethodSymbol callingMethod)
+                            {
+                                lock (this.MethodsDeclaringUIThreadRequirement)
+                                {
+                                    this.MethodsDeclaringUIThreadRequirement.Add(callingMethod);
+                                }
+                            }
+
                             this.methodDeclarationNodes = this.methodDeclarationNodes.SetItem(methodDeclaration, ThreadingContext.MainThread);
                             return;
                         }
@@ -219,7 +368,7 @@
                         Location location = focusDiagnosticOn ?? context.Node.GetLocation();
                         var exampleAssertingMethod = this.MainThreadAssertingMethods.FirstOrDefault();
                         var descriptor = exampleAssertingMethod.Name != null ? Descriptor : DescriptorNoAssertingMethod;
-                        context.ReportDiagnostic(Diagnostic.Create(descriptor, location, type.Name, exampleAssertingMethod.ToString()));
+                        context.ReportDiagnostic(Diagnostic.Create(descriptor, location, type.Name, exampleAssertingMethod));
                         return true;
                     }
                 }

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD010MainThreadUsageAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD010MainThreadUsageAnalyzer.cs
@@ -195,6 +195,18 @@
                 return;
             }
 
+            IMethodSymbol GetPropertyAccessor(IPropertySymbol propertySymbol)
+            {
+                if (propertySymbol != null)
+                {
+                    return Utils.IsOnLeftHandOfAssignment(context.Node)
+                        ? propertySymbol.SetMethod
+                        : propertySymbol.GetMethod;
+                }
+
+                return null;
+            }
+
             ISymbol targetMethod = null;
             switch (context.Node)
             {
@@ -202,24 +214,10 @@
                     targetMethod = context.SemanticModel.GetSymbolInfo(invocationExpressionSyntax.Expression).Symbol;
                     break;
                 case MemberAccessExpressionSyntax memberAccessExpressionSyntax:
-                    var targetProperty = context.SemanticModel.GetSymbolInfo(memberAccessExpressionSyntax.Name).Symbol as IPropertySymbol;
-                    if (targetProperty != null)
-                    {
-                        targetMethod = context.Node.Parent is AssignmentExpressionSyntax assignmentSyntax && context.Node == assignmentSyntax.Left
-                            ? targetProperty.SetMethod
-                            : targetProperty.GetMethod;
-                    }
-
+                    targetMethod = GetPropertyAccessor(context.SemanticModel.GetSymbolInfo(memberAccessExpressionSyntax.Name).Symbol as IPropertySymbol);
                     break;
                 case IdentifierNameSyntax identifierNameSyntax:
-                    targetProperty = context.SemanticModel.GetSymbolInfo(identifierNameSyntax).Symbol as IPropertySymbol;
-                    if (targetProperty != null)
-                    {
-                        targetMethod = context.Node.Parent is AssignmentExpressionSyntax assignmentSyntax && context.Node == assignmentSyntax.Left
-                            ? targetProperty.SetMethod
-                            : targetProperty.GetMethod;
-                    }
-
+                    targetMethod = GetPropertyAccessor(context.SemanticModel.GetSymbolInfo(identifierNameSyntax).Symbol as IPropertySymbol);
                     break;
             }
 


### PR DESCRIPTION
When A() self-identifies as requiring the main thread, all callers (transitively) are now prompted to do the same.