### PR TITLE
Fix VSTHRD010 transitivity to not mis-fire when invoking async methods

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD010MainThreadUsageAnalyzerTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD010MainThreadUsageAnalyzerTests.cs
@@ -398,6 +398,32 @@ class Test {
         }
 
         [Fact]
+        public void RequiresUIThread_NotTransitiveThroughAsyncCalls()
+        {
+            var test = @"
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
+
+class Test {
+    private JoinableTaskFactory jtf;
+
+    private void ShowToolWindow(object sender, EventArgs e) {
+        jtf.RunAsync(async delegate {
+            await FooAsync(); // this line is what adds the VSTHRD010 diagnostic
+        });
+    }
+
+    private async Task FooAsync() {
+        await jtf.SwitchToMainThreadAsync();
+    }
+}
+";
+
+            this.VerifyCSharpDiagnostic(test);
+        }
+
+        [Fact]
         public void InvokeVsSolutionAfterSwitchedToMainThreadAsync()
         {
             var test = @"


### PR DESCRIPTION
Prior to this change VSTHRD010 would transitively mark all methods that called a method that showed a UI thread requirement, including when leaf methods were async and used `SwitchToMainThreadAsync`. This would then make their async caller have to call `ThrowIfNotOnUIThread()` which of course is silly since their caller doesn't need to know the threading affinity of the async methods they invoke.

With this change, instead of marking all callers of all UI thread requiring methods, we only mark callers of methods that _throw_ if not invoked on the right thread.

Fixes #226