### PR TITLE
Implement ICriticalNotifyCompletion on a few awaiters

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Tests/AwaitExtensionsTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/AwaitExtensionsTests.cs
@@ -218,7 +218,9 @@ namespace Microsoft.VisualStudio.Threading.Tests
             }).GetAwaiter().GetResult();
         }
 
+#if !NETCOREAPP1_0 // .NET Core 1.0 doesn't offer a way to avoid flowing ExecutionContext
         [Fact]
+#endif
         public async Task AwaitTaskScheduler_UnsafeOnCompleted_DoesNotCaptureExecutionContext()
         {
             var taskResultSource = new TaskCompletionSource<object>();

--- a/src/Microsoft.VisualStudio.Threading.Tests/AwaitExtensionsTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/AwaitExtensionsTests.cs
@@ -133,6 +133,28 @@ namespace Microsoft.VisualStudio.Threading.Tests
                 }).GetAwaiter().GetResult();
         }
 
+        [Theory, CombinatorialData]
+        public async Task TaskYield_ConfigureAwait_OnCompleted_CapturesExecutionContext(bool captureContext)
+        {
+            var taskResultSource = new TaskCompletionSource<object>();
+            AsyncLocal<object> asyncLocal = new AsyncLocal<object>();
+            asyncLocal.Value = "expected";
+            Task.Yield().ConfigureAwait(captureContext).GetAwaiter().OnCompleted(delegate
+            {
+                try
+                {
+                    Assert.Equal("expected", asyncLocal.Value);
+                    taskResultSource.SetResult(null);
+                }
+                catch (Exception ex)
+                {
+                    taskResultSource.SetException(ex);
+                }
+            });
+            asyncLocal.Value = null;
+            await taskResultSource.Task;
+        }
+
         [Fact]
         public void AwaitCustomTaskScheduler()
         {

--- a/src/Microsoft.VisualStudio.Threading/AwaitExtensions.cs
+++ b/src/Microsoft.VisualStudio.Threading/AwaitExtensions.cs
@@ -532,7 +532,6 @@ namespace Microsoft.VisualStudio.Threading
             /// without capturing the ExecutionContext.
             /// </summary>
             /// <param name="continuation">The action.</param>
-            [SecurityCritical]
             public void UnsafeOnCompleted(Action continuation)
             {
                 if (this.scheduler == TaskScheduler.Default)
@@ -637,7 +636,6 @@ namespace Microsoft.VisualStudio.Threading
             /// without capturing the ExecutionContext.
             /// </summary>
             /// <param name="continuation">The action.</param>
-            [SecurityCritical]
             public void UnsafeOnCompleted(Action continuation)
             {
                 if (this.continueOnCapturedContext)

--- a/src/Microsoft.VisualStudio.Threading/TplExtensions.cs
+++ b/src/Microsoft.VisualStudio.Threading/TplExtensions.cs
@@ -746,7 +746,6 @@ namespace Microsoft.VisualStudio.Threading
             /// without capturing the ExecutionContext.
             /// </summary>
             /// <param name="continuation">The action.</param>
-            [SecurityCritical]
             public void UnsafeOnCompleted(Action continuation)
             {
                 this.task.ConfigureAwait(this.captureContext).GetAwaiter().UnsafeOnCompleted(continuation);

--- a/src/Microsoft.VisualStudio.Threading/TplExtensions.cs
+++ b/src/Microsoft.VisualStudio.Threading/TplExtensions.cs
@@ -9,6 +9,7 @@ namespace Microsoft.VisualStudio.Threading
     using System;
     using System.Collections.Generic;
     using System.Runtime.CompilerServices;
+    using System.Security;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -699,7 +700,7 @@ namespace Microsoft.VisualStudio.Threading
         /// An awaiter that wraps a task and never throws an exception when waited on.
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes")]
-        public struct NoThrowTaskAwaiter : INotifyCompletion
+        public struct NoThrowTaskAwaiter : ICriticalNotifyCompletion
         {
             /// <summary>
             /// The task
@@ -738,6 +739,17 @@ namespace Microsoft.VisualStudio.Threading
             public void OnCompleted(Action continuation)
             {
                 this.task.ConfigureAwait(this.captureContext).GetAwaiter().OnCompleted(continuation);
+            }
+
+            /// <summary>
+            /// Schedules a delegate for execution at the conclusion of a task's execution
+            /// without capturing the ExecutionContext.
+            /// </summary>
+            /// <param name="continuation">The action.</param>
+            [SecurityCritical]
+            public void UnsafeOnCompleted(Action continuation)
+            {
+                this.task.ConfigureAwait(this.captureContext).GetAwaiter().UnsafeOnCompleted(continuation);
             }
 
             /// <summary>


### PR DESCRIPTION
- `NoThrowTaskAwaiter`
- `ConfiguredTaskYieldAwaiter`
- `TaskSchedulerAwaiter`

Resolves some of #235. See that issue for a discussion on the merits of this change.