### PR TITLE
Implement ICriticalNotifyCompletion on the rest of the awaiters

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Tests/SingleThreadedSynchronizationContext.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/SingleThreadedSynchronizationContext.cs
@@ -168,10 +168,17 @@ namespace Microsoft.VisualStudio.Threading.Tests
                         }
                     }
 
-                    ExecutionContext.Run(
-                        message.Context,
-                        new ContextCallback(message.Callback),
-                        message.State);
+                    if (message.Context != null)
+                    {
+                        ExecutionContext.Run(
+                            message.Context,
+                            new ContextCallback(message.Callback),
+                            message.State);
+                    }
+                    else
+                    {
+                        message.Callback(message.State);
+                    }
                 }
             }
 

--- a/src/Microsoft.VisualStudio.Threading.Tests/TestBase.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/TestBase.cs
@@ -13,7 +13,7 @@
     {
         protected const int AsyncDelay = 500;
 
-        protected const int TestTimeout = 1000;
+        protected const int TestTimeout = 5000;
 
         /// <summary>
         /// The maximum length of time to wait for something that we expect will happen

--- a/src/Microsoft.VisualStudio.Threading/AsyncReaderWriterResourceLock.cs
+++ b/src/Microsoft.VisualStudio.Threading/AsyncReaderWriterResourceLock.cs
@@ -298,7 +298,7 @@ namespace Microsoft.VisualStudio.Threading
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes")]
         [DebuggerDisplay("{awaiter.kind}")]
-        public struct ResourceAwaiter : INotifyCompletion
+        public struct ResourceAwaiter : ICriticalNotifyCompletion
         {
             /// <summary>
             /// The underlying lock awaiter.
@@ -352,6 +352,20 @@ namespace Microsoft.VisualStudio.Threading
                 }
 
                 this.awaiter.OnCompleted(continuation);
+            }
+
+            /// <summary>
+            /// Sets the delegate to execute when the lock is available.
+            /// </summary>
+            /// <param name="continuation">The delegate.</param>
+            public void UnsafeOnCompleted(Action continuation)
+            {
+                if (this.awaiter == null)
+                {
+                    throw new InvalidOperationException();
+                }
+
+                this.awaiter.UnsafeOnCompleted(continuation);
             }
 
             /// <summary>

--- a/src/Microsoft.VisualStudio.Threading/InlineResumable.cs
+++ b/src/Microsoft.VisualStudio.Threading/InlineResumable.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.Threading
     /// <summary>
     /// An awaiter that can be pre-created, and later immediately execute its one scheduled continuation.
     /// </summary>
-    internal class InlineResumable : INotifyCompletion
+    internal class InlineResumable : ICriticalNotifyCompletion
     {
         /// <summary>
         /// The continuation that has been scheduled.
@@ -55,6 +55,20 @@ namespace Microsoft.VisualStudio.Threading
 
             this.capturedSynchronizationContext = SynchronizationContext.Current;
             this.continuation = continuation;
+        }
+
+        /// <summary>
+        /// Stores the continuation for later execution when <see cref="Resume"/> is invoked.
+        /// </summary>
+        /// <param name="continuation">The delegate to execute later.</param>
+        public void UnsafeOnCompleted(Action continuation)
+        {
+            // We don't capture ExecutionContext even in the normal path
+            // as this is a very special case and internal awaiter.
+            // Strictly speaking, we don't have to implement ICriticalNotifyCompletion,
+            // but by implementing it, we show that we don't capture context and avoid
+            // code audits later from spending time asking why this awaiter isn't so optimized.
+            this.OnCompleted(continuation);
         }
 
         /// <summary>


### PR DESCRIPTION
- `JoinableTaskFactory+MainThreadAwaiter`
- `InlineResumable` (an internal type used by `AsyncLazy<T>`)
- `AsyncReaderWriterLock+Awaiter`
- `AsyncReaderWriterResourceLock+ResourceAwaiter`

This and #243 come together to fully address #235 