### PR TITLE
Support for member-level specifications regarding main thread affinity

### DIFF
--- a/doc/analyzers/configuration.md
+++ b/doc/analyzers/configuration.md
@@ -34,7 +34,7 @@ These methods are identified as described below:
 
 **Filename:** `vs-threading.MainThreadAssertingMethods.txt`
 
-**Line format:** `Namespace.TypeName.MethodName`
+**Line format:** `[Namespace.TypeName]::MethodName`
 
 **Sample:** `Microsoft.VisualStudio.Shell.ThreadHelper.ThrowIfNotOnUIThread`
 
@@ -47,19 +47,22 @@ These methods are identified as described below:
 
 **Filename:** `vs-threading.MainThreadSwitchingMethods.txt`
 
-**Line format:** `Namespace.TypeName.MethodName`
+**Line format:** `[Namespace.TypeName]::MethodName`
 
 **Sample:** `Microsoft.VisualStudio.Threading.JoinableTaskFactory.SwitchToMainThreadAsync`
 
-## Types that require the main thread
+## Members that require the main thread
 
-Types that are STA COM objects or otherwise require all invocations to occur on
+Types or members that are STA COM objects or otherwise require all invocations to occur on
 the main thread of the application can be configured into these analyzers so that
 static analysis can help ensure thread safety of the application.
-These types are identified as described below:
+These are identified as described below:
 
-**Filename:** `vs-threading.TypesRequiringMainThread.txt`
+**Filename:** `vs-threading.MembersRequiringMainThread.txt`
 
-**Line format:** `Namespace.TypeName` or `Namespace.*`
+**Line format:** `[Namespace.TypeName]` or `[Namespace.*]` or `[Namespace.TypeName]::MemberName`
 
-**Sample:** `Microsoft.VisualStudio.Shell.Interop.*`
+**Sample:** `Microsoft.VisualStudio.Shell.Interop.*` or `[Microsoft.VisualStudio.Shell.Package]::GetService`
+
+Properties are specified by their name, not the name of their accessors.
+For example, a property should be specified by `PropertyName`, not `get_PropertyName`.

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/AdditionalFiles/vs-threading.MainThreadAssertingMethods.mocks.txt
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/AdditionalFiles/vs-threading.MainThreadAssertingMethods.mocks.txt
@@ -1,2 +1,2 @@
-﻿Test.VerifyOnUIThread
-Microsoft.VisualStudio.Shell.ThreadHelper.ThrowIfNotOnUIThread
+﻿[Test]::VerifyOnUIThread
+[Microsoft.VisualStudio.Shell.ThreadHelper]::ThrowIfNotOnUIThread

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/AdditionalFiles/vs-threading.MembersRequiringMainThread.mocks.txt
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/AdditionalFiles/vs-threading.MembersRequiringMainThread.mocks.txt
@@ -1,0 +1,12 @@
+﻿[TestNS.*]
+![TestNS.FreeThreadedType]
+![TestNS2.FreeThreadedType]
+[TestNS2.*]
+[Microsoft.VisualStudio.Shell.Interop.*]
+[Microsoft.VisualStudio.OLE.Interop.*]
+[Microsoft.Internal.VisualStudio.Shell.Interop.*]
+![Microsoft.VisualStudio.Shell.Interop.IAsyncServiceProvider]
+[Microsoft.VisualStudio.Shell.Package]::GetService
+[Microsoft.VisualStudio.Shell.ServiceProvider]
+![TestNS2.A]::FreeThreadedMethod
+[A]::UIPropertyName

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/AdditionalFiles/vs-threading.TypesRequiringMainThread.mocks.txt
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/AdditionalFiles/vs-threading.TypesRequiringMainThread.mocks.txt
@@ -1,8 +1,0 @@
-﻿TestNS.*
-!TestNS.FreeThreadedType
-!TestNS2.FreeThreadedType
-TestNS2.*
-Microsoft.VisualStudio.Shell.Interop.* 
-Microsoft.VisualStudio.OLE.Interop.* 
-Microsoft.Internal.VisualStudio.Shell.Interop.* 
-!Microsoft.VisualStudio.Shell.Interop.IAsyncServiceProvider

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD010MainThreadUsageAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD010MainThreadUsageAnalyzer.cs
@@ -112,7 +112,7 @@
             {
                 var mainThreadAssertingMethods = CommonInterest.ReadMethods(compilationStartContext, CommonInterest.FileNamePatternForMethodsThatAssertMainThread).ToImmutableArray();
                 var mainThreadSwitchingMethods = CommonInterest.ReadMethods(compilationStartContext, CommonInterest.FileNamePatternForMethodsThatSwitchToMainThread).ToImmutableArray();
-                var typesRequiringMainThread = CommonInterest.ReadTypes(compilationStartContext, CommonInterest.FileNamePatternForTypesRequiringMainThread).ToImmutableArray();
+                var membersRequiringMainThread = CommonInterest.ReadTypesAndMembers(compilationStartContext, CommonInterest.FileNamePatternForMembersRequiringMainThread).ToImmutableArray();
 
                 var methodsDeclaringUIThreadRequirement = new HashSet<IMethodSymbol>();
                 var methodsAssertingUIThreadRequirement = new HashSet<IMethodSymbol>();
@@ -124,7 +124,7 @@
                     {
                         MainThreadAssertingMethods = mainThreadAssertingMethods,
                         MainThreadSwitchingMethods = mainThreadSwitchingMethods,
-                        TypesRequiringMainThread = typesRequiringMainThread,
+                        MembersRequiringMainThread = membersRequiringMainThread,
                         MethodsDeclaringUIThreadRequirement = methodsDeclaringUIThreadRequirement,
                         MethodsAssertingUIThreadRequirement = methodsAssertingUIThreadRequirement,
                     };
@@ -266,7 +266,7 @@
 
             internal ImmutableArray<CommonInterest.QualifiedMember> MainThreadSwitchingMethods { get; set; }
 
-            internal ImmutableArray<CommonInterest.TypeMatchSpec> TypesRequiringMainThread { get; set; }
+            internal ImmutableArray<CommonInterest.TypeMatchSpec> MembersRequiringMainThread { get; set; }
 
             internal HashSet<IMethodSymbol> MethodsDeclaringUIThreadRequirement { get; set; }
 
@@ -362,9 +362,7 @@
                 }
 
                 bool requiresUIThread = (type.TypeKind == TypeKind.Interface || type.TypeKind == TypeKind.Class)
-                    && this.TypesRequiringMainThread.Contains(type);
-                requiresUIThread |= symbol?.Name == "GetService" && type.Name == "Package" && type.BelongsToNamespace(Namespaces.MicrosoftVisualStudioShell);
-                requiresUIThread |= symbol != null && !symbol.IsStatic && type.Name == "ServiceProvider" && type.BelongsToNamespace(Namespaces.MicrosoftVisualStudioShell);
+                    && this.MembersRequiringMainThread.Contains(type, symbol);
 
                 if (requiresUIThread)
                 {

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/build/AdditionalFiles/vs-threading.MainThreadAssertingMethods.txt
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/build/AdditionalFiles/vs-threading.MainThreadAssertingMethods.txt
@@ -1,1 +1,1 @@
-﻿System.Windows.Threading.Dispatcher.VerifyAccess
+﻿[System.Windows.Threading.Dispatcher]::VerifyAccess

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/build/AdditionalFiles/vs-threading.MainThreadSwitchingMethods.txt
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/build/AdditionalFiles/vs-threading.MainThreadSwitchingMethods.txt
@@ -1,1 +1,1 @@
-﻿Microsoft.VisualStudio.Threading.JoinableTaskFactory.SwitchToMainThreadAsync
+﻿[Microsoft.VisualStudio.Threading.JoinableTaskFactory]::SwitchToMainThreadAsync


### PR DESCRIPTION
This allows us to remove the last hard-coded VS API checks from VSTHRD010.

Fixes #230