### PR TITLE
VSTHRD010 calls out transitive UI thread dependencies explicitly

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD010MainThreadUsageAnalyzerTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD010MainThreadUsageAnalyzerTests.cs
@@ -140,7 +140,7 @@ class Test {
     }
 }
 ";
-            this.expect.Locations = new[] { new DiagnosticResultLocation("Test0.cs", 5, 5, 5, 9) };
+            this.expect.Locations = new[] { new DiagnosticResultLocation("Test0.cs", 6, 9, 6, 12) };
             this.VerifyCSharpDiagnostic(test, this.expect);
         }
 
@@ -293,6 +293,43 @@ class Test {
         }
 
         [Fact]
+        public void RequiresUIThreadTransitive_MultipleInMember()
+        {
+            var test = @"
+using System;
+using Microsoft.VisualStudio.Shell.Interop;
+
+class Test {
+    void F() {
+        VerifyOnUIThread();
+        IVsSolution sln = null;
+        sln.SetProperty(1000, null);
+    }
+
+    void G() {
+        VerifyOnUIThread();
+        IVsSolution sln = null;
+        sln.SetProperty(1000, null);
+    }
+
+    void H() {
+        F();
+        G();
+    }
+
+    void VerifyOnUIThread() { }
+}
+";
+
+            var expect = new DiagnosticResult[]
+            {
+                this.CreateDiagnostic(19, 9, 19, 10),
+                this.CreateDiagnostic(20, 9, 20, 10),
+            };
+            this.VerifyCSharpDiagnostic(test, expect);
+        }
+
+        [Fact]
         public void RequiresUIThreadTransitive()
         {
             var test = @"
@@ -353,27 +390,18 @@ class Test {
     }
 }
 ";
-            DiagnosticResult CreateDiagnostic(int line, int column, int endLine, int endColumn) =>
-                new DiagnosticResult
-                {
-                    Id = this.expect.Id,
-                    Message = this.expect.Message,
-                    SkipVerifyMessage = this.expect.SkipVerifyMessage,
-                    Severity = this.expect.Severity,
-                    Locations = new[] { new DiagnosticResultLocation("Test0.cs", line, column, endLine, endColumn) },
-                };
             var expect = new DiagnosticResult[]
             {
-                CreateDiagnostic(12, 10, 12, 11),
-                CreateDiagnostic(16, 10, 16, 11),
-                CreateDiagnostic(21, 9, 21, 12),
-                CreateDiagnostic(32, 9, 32, 12),
-                CreateDiagnostic(35, 9, 35, 33),
-                CreateDiagnostic(36, 9, 36, 34),
-                CreateDiagnostic(37, 9, 37, 34),
-                CreateDiagnostic(43, 9, 43, 33),
-                CreateDiagnostic(44, 9, 44, 34),
-                CreateDiagnostic(45, 9, 45, 34),
+                this.CreateDiagnostic(13, 9, 13, 10),
+                this.CreateDiagnostic(17, 9, 17, 10),
+                this.CreateDiagnostic(22, 13, 22, 14),
+                this.CreateDiagnostic(32, 16, 32, 17),
+                this.CreateDiagnostic(35, 39, 35, 55),
+                this.CreateDiagnostic(36, 40, 36, 61),
+                this.CreateDiagnostic(37, 40, 37, 69),
+                this.CreateDiagnostic(43, 39, 43, 55),
+                this.CreateDiagnostic(44, 40, 44, 61),
+                this.CreateDiagnostic(45, 40, 45, 69),
             };
             this.VerifyCSharpDiagnostic(test, expect);
         }
@@ -1003,5 +1031,15 @@ class A
             };
             this.VerifyCSharpDiagnostic(test, expect);
         }
+
+        private DiagnosticResult CreateDiagnostic(int line, int column, int endLine, int endColumn) =>
+            new DiagnosticResult
+            {
+                Id = this.expect.Id,
+                Message = this.expect.Message,
+                SkipVerifyMessage = this.expect.SkipVerifyMessage,
+                Severity = this.expect.Severity,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", line, column, endLine, endColumn) },
+            };
     }
 }

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD010MainThreadUsageAnalyzerTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD010MainThreadUsageAnalyzerTests.cs
@@ -120,6 +120,31 @@ class Test {
         }
 
         [Fact]
+        public void TransitiveNoCheck_InCtor()
+        {
+            var test = @"
+using Microsoft.VisualStudio.Shell.Interop;
+
+class Test {
+    Test() {
+        Foo();
+    }
+
+    void Foo() {
+        VerifyOnUIThread();
+        IVsSolution sln = null;
+        sln.SetProperty(1000, null);
+    }
+
+    void VerifyOnUIThread() {
+    }
+}
+";
+            this.expect.Locations = new[] { new DiagnosticResultLocation("Test0.cs", 5, 5, 5, 9) };
+            this.VerifyCSharpDiagnostic(test, this.expect);
+        }
+
+        [Fact]
         public void InvokeVsSolutionWithCheck_InCtor()
         {
             var test = @"

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.cs.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.cs.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="cs" original="MICROSOFT.VISUALSTUDIO.THREADING.ANALYZERS/STRINGS.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -191,9 +191,10 @@ Nejprve použijte await JoinableTaskFactory.SwitchToMainThreadAsync().</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is a type name and {1} is the name of a method that throws if not called from the main thread.</note>
         </trans-unit>
         <trans-unit id="VSTHRD010_MessageFormat_TransitiveMainThreadUser" translate="yes" xml:space="preserve">
-          <source>Add call to {0}() at start of member body because this member invokes other members that require the main thread.</source>
-          <target state="translated">Přidejte volání metody {0}() na začátek těla člena, protože tento člen volá jiné členy vyžadující hlavní vlákno.</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a method name.</note>
+          <source>Accessing this type or member must be done on the main thread. "{0}" should start with a statement to assert this condition. For example: "{1}();"</source>
+          <target state="needs-review-translation">Přidejte volání metody {0}() na začátek těla člena, protože tento člen volá jiné členy vyžadující hlavní vlákno.</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
+          <note from="MultilingualBuild" annotates="source" priority="2">All placeholders are to type or member names.</note>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.de.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.de.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="de" original="MICROSOFT.VISUALSTUDIO.THREADING.ANALYZERS/STRINGS.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -191,9 +191,10 @@ Rufen Sie zuerst "await JoinableTaskFactory.SwitchToMainThreadAsync()" auf.</tar
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is a type name and {1} is the name of a method that throws if not called from the main thread.</note>
         </trans-unit>
         <trans-unit id="VSTHRD010_MessageFormat_TransitiveMainThreadUser" translate="yes" xml:space="preserve">
-          <source>Add call to {0}() at start of member body because this member invokes other members that require the main thread.</source>
-          <target state="translated">Fügen Sie den Aufruf an "{0}()" am Beginn des Elementtexts hinzu, weil dieses Element andere Elemente aufruft, für die der Hauptthread erforderlich ist.</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a method name.</note>
+          <source>Accessing this type or member must be done on the main thread. "{0}" should start with a statement to assert this condition. For example: "{1}();"</source>
+          <target state="needs-review-translation">Fügen Sie den Aufruf an "{0}()" am Beginn des Elementtexts hinzu, weil dieses Element andere Elemente aufruft, für die der Hauptthread erforderlich ist.</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
+          <note from="MultilingualBuild" annotates="source" priority="2">All placeholders are to type or member names.</note>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.es.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.es.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="es" original="MICROSOFT.VISUALSTUDIO.THREADING.ANALYZERS/STRINGS.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -191,9 +191,10 @@ Use await JoinableTaskFactory.SwitchToMainThreadAsync() primero.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is a type name and {1} is the name of a method that throws if not called from the main thread.</note>
         </trans-unit>
         <trans-unit id="VSTHRD010_MessageFormat_TransitiveMainThreadUser" translate="yes" xml:space="preserve">
-          <source>Add call to {0}() at start of member body because this member invokes other members that require the main thread.</source>
-          <target state="translated">Agregue la llamada a {0}() al inicio del cuerpo del miembro porque este miembro invoca a otros medios que requieren el subproceso principal.</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a method name.</note>
+          <source>Accessing this type or member must be done on the main thread. "{0}" should start with a statement to assert this condition. For example: "{1}();"</source>
+          <target state="needs-review-translation">Agregue la llamada a {0}() al inicio del cuerpo del miembro porque este miembro invoca a otros medios que requieren el subproceso principal.</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
+          <note from="MultilingualBuild" annotates="source" priority="2">All placeholders are to type or member names.</note>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.fr.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.fr.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="fr" original="MICROSOFT.VISUALSTUDIO.THREADING.ANALYZERS/STRINGS.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -191,9 +191,10 @@ Attendez d’abord JoinableTaskFactory.SwitchToMainThreadAsync().</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is a type name and {1} is the name of a method that throws if not called from the main thread.</note>
         </trans-unit>
         <trans-unit id="VSTHRD010_MessageFormat_TransitiveMainThreadUser" translate="yes" xml:space="preserve">
-          <source>Add call to {0}() at start of member body because this member invokes other members that require the main thread.</source>
-          <target state="translated">Ajoutez un appel à {0}() au début du corps du membre parce que ce membre appelle d’autres membres qui nécessitent le thread principal.</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a method name.</note>
+          <source>Accessing this type or member must be done on the main thread. "{0}" should start with a statement to assert this condition. For example: "{1}();"</source>
+          <target state="needs-review-translation">Ajoutez un appel à {0}() au début du corps du membre parce que ce membre appelle d’autres membres qui nécessitent le thread principal.</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
+          <note from="MultilingualBuild" annotates="source" priority="2">All placeholders are to type or member names.</note>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.it.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.it.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="it" original="MICROSOFT.VISUALSTUDIO.THREADING.ANALYZERS/STRINGS.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -191,9 +191,10 @@ Attendere prima JoinableTaskFactory.SwitchToMainThreadAsync().</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is a type name and {1} is the name of a method that throws if not called from the main thread.</note>
         </trans-unit>
         <trans-unit id="VSTHRD010_MessageFormat_TransitiveMainThreadUser" translate="yes" xml:space="preserve">
-          <source>Add call to {0}() at start of member body because this member invokes other members that require the main thread.</source>
-          <target state="translated">Aggiungere la chiamata a {0}() all'inizio del corpo del membro perché questo membro richiama altri membri che richiedono il thread principale.</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a method name.</note>
+          <source>Accessing this type or member must be done on the main thread. "{0}" should start with a statement to assert this condition. For example: "{1}();"</source>
+          <target state="needs-review-translation">Aggiungere la chiamata a {0}() all'inizio del corpo del membro perché questo membro richiama altri membri che richiedono il thread principale.</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
+          <note from="MultilingualBuild" annotates="source" priority="2">All placeholders are to type or member names.</note>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.ja.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.ja.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="ja" original="MICROSOFT.VISUALSTUDIO.THREADING.ANALYZERS/STRINGS.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -191,9 +191,10 @@ Await JoinableTaskFactory.SwitchToMainThreadAsync() first.</source>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is a type name and {1} is the name of a method that throws if not called from the main thread.</note>
         </trans-unit>
         <trans-unit id="VSTHRD010_MessageFormat_TransitiveMainThreadUser" translate="yes" xml:space="preserve">
-          <source>Add call to {0}() at start of member body because this member invokes other members that require the main thread.</source>
-          <target state="translated">メンバー本体の開始時に {0}() への呼び出しを追加します。このメンバーによって、メイン スレッドを必要とする他のメンバーが呼び出されるためです。</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a method name.</note>
+          <source>Accessing this type or member must be done on the main thread. "{0}" should start with a statement to assert this condition. For example: "{1}();"</source>
+          <target state="needs-review-translation">メンバー本体の開始時に {0}() への呼び出しを追加します。このメンバーによって、メイン スレッドを必要とする他のメンバーが呼び出されるためです。</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
+          <note from="MultilingualBuild" annotates="source" priority="2">All placeholders are to type or member names.</note>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.ko.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.ko.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="ko" original="MICROSOFT.VISUALSTUDIO.THREADING.ANALYZERS/STRINGS.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -191,9 +191,10 @@ Await JoinableTaskFactory.SwitchToMainThreadAsync() first.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is a type name and {1} is the name of a method that throws if not called from the main thread.</note>
         </trans-unit>
         <trans-unit id="VSTHRD010_MessageFormat_TransitiveMainThreadUser" translate="yes" xml:space="preserve">
-          <source>Add call to {0}() at start of member body because this member invokes other members that require the main thread.</source>
-          <target state="translated">이 멤버는 주 스레드가 필요한 다른 멤버를 호출하므로 멤버 본문 시작에 {0}()에 대한 호출을 추가합니다.</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a method name.</note>
+          <source>Accessing this type or member must be done on the main thread. "{0}" should start with a statement to assert this condition. For example: "{1}();"</source>
+          <target state="needs-review-translation">이 멤버는 주 스레드가 필요한 다른 멤버를 호출하므로 멤버 본문 시작에 {0}()에 대한 호출을 추가합니다.</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
+          <note from="MultilingualBuild" annotates="source" priority="2">All placeholders are to type or member names.</note>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.pl.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.pl.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="pl" original="MICROSOFT.VISUALSTUDIO.THREADING.ANALYZERS/STRINGS.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -191,9 +191,10 @@ Najpierw zaczekaj na metodę JoinableTaskFactory.SwitchToMainThreadAsync().</tar
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is a type name and {1} is the name of a method that throws if not called from the main thread.</note>
         </trans-unit>
         <trans-unit id="VSTHRD010_MessageFormat_TransitiveMainThreadUser" translate="yes" xml:space="preserve">
-          <source>Add call to {0}() at start of member body because this member invokes other members that require the main thread.</source>
-          <target state="translated">Dodaj wywołanie metody {0}() na początku treści składowej, ponieważ ta składowa wywołuje inne składowe wymagające wątku głównego.</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a method name.</note>
+          <source>Accessing this type or member must be done on the main thread. "{0}" should start with a statement to assert this condition. For example: "{1}();"</source>
+          <target state="needs-review-translation">Dodaj wywołanie metody {0}() na początku treści składowej, ponieważ ta składowa wywołuje inne składowe wymagające wątku głównego.</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
+          <note from="MultilingualBuild" annotates="source" priority="2">All placeholders are to type or member names.</note>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.pt-BR.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="pt-BR" original="MICROSOFT.VISUALSTUDIO.THREADING.ANALYZERS/STRINGS.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -191,9 +191,10 @@ Await JoinableTaskFactory.SwitchToMainThreadAsync() primeiro.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is a type name and {1} is the name of a method that throws if not called from the main thread.</note>
         </trans-unit>
         <trans-unit id="VSTHRD010_MessageFormat_TransitiveMainThreadUser" translate="yes" xml:space="preserve">
-          <source>Add call to {0}() at start of member body because this member invokes other members that require the main thread.</source>
-          <target state="translated">Adicione uma chamada a {0}() no início do corpo do membro porque esse membro invoca outros membros que exigem o thread principal.</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a method name.</note>
+          <source>Accessing this type or member must be done on the main thread. "{0}" should start with a statement to assert this condition. For example: "{1}();"</source>
+          <target state="needs-review-translation">Adicione uma chamada a {0}() no início do corpo do membro porque esse membro invoca outros membros que exigem o thread principal.</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
+          <note from="MultilingualBuild" annotates="source" priority="2">All placeholders are to type or member names.</note>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.ru.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.ru.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="ru" original="MICROSOFT.VISUALSTUDIO.THREADING.ANALYZERS/STRINGS.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -191,9 +191,10 @@ Await JoinableTaskFactory.SwitchToMainThreadAsync() first.</source>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is a type name and {1} is the name of a method that throws if not called from the main thread.</note>
         </trans-unit>
         <trans-unit id="VSTHRD010_MessageFormat_TransitiveMainThreadUser" translate="yes" xml:space="preserve">
-          <source>Add call to {0}() at start of member body because this member invokes other members that require the main thread.</source>
-          <target state="translated">Добавьте вызов {0}() в начале тела элемента, так как он вызывает другие элементы, которым требуется основной поток.</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a method name.</note>
+          <source>Accessing this type or member must be done on the main thread. "{0}" should start with a statement to assert this condition. For example: "{1}();"</source>
+          <target state="needs-review-translation">Добавьте вызов {0}() в начале тела элемента, так как он вызывает другие элементы, которым требуется основной поток.</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
+          <note from="MultilingualBuild" annotates="source" priority="2">All placeholders are to type or member names.</note>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.tr.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.tr.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="tr" original="MICROSOFT.VISUALSTUDIO.THREADING.ANALYZERS/STRINGS.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -191,9 +191,10 @@ Await JoinableTaskFactory.SwitchToMainThreadAsync() first.</source>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is a type name and {1} is the name of a method that throws if not called from the main thread.</note>
         </trans-unit>
         <trans-unit id="VSTHRD010_MessageFormat_TransitiveMainThreadUser" translate="yes" xml:space="preserve">
-          <source>Add call to {0}() at start of member body because this member invokes other members that require the main thread.</source>
-          <target state="translated">Bu üye, ana iş parçacığını gerektiren diğer üyeleri çağırdığından üye gövdesinin başına {0}() araması ekleyin.</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a method name.</note>
+          <source>Accessing this type or member must be done on the main thread. "{0}" should start with a statement to assert this condition. For example: "{1}();"</source>
+          <target state="needs-review-translation">Bu üye, ana iş parçacığını gerektiren diğer üyeleri çağırdığından üye gövdesinin başına {0}() araması ekleyin.</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
+          <note from="MultilingualBuild" annotates="source" priority="2">All placeholders are to type or member names.</note>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.zh-Hans.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="zh-Hans" original="MICROSOFT.VISUALSTUDIO.THREADING.ANALYZERS/STRINGS.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -191,9 +191,10 @@ Await JoinableTaskFactory.SwitchToMainThreadAsync() first.</source>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is a type name and {1} is the name of a method that throws if not called from the main thread.</note>
         </trans-unit>
         <trans-unit id="VSTHRD010_MessageFormat_TransitiveMainThreadUser" translate="yes" xml:space="preserve">
-          <source>Add call to {0}() at start of member body because this member invokes other members that require the main thread.</source>
-          <target state="translated">在成员体的开头添加对 {0}() 的调用，因为此成员调用其他需要主线程的成员。</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a method name.</note>
+          <source>Accessing this type or member must be done on the main thread. "{0}" should start with a statement to assert this condition. For example: "{1}();"</source>
+          <target state="needs-review-translation">在成员体的开头添加对 {0}() 的调用，因为此成员调用其他需要主线程的成员。</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
+          <note from="MultilingualBuild" annotates="source" priority="2">All placeholders are to type or member names.</note>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.zh-Hant.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="zh-Hant" original="MICROSOFT.VISUALSTUDIO.THREADING.ANALYZERS/STRINGS.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -191,9 +191,10 @@ Await JoinableTaskFactory.SwitchToMainThreadAsync() first.</source>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is a type name and {1} is the name of a method that throws if not called from the main thread.</note>
         </trans-unit>
         <trans-unit id="VSTHRD010_MessageFormat_TransitiveMainThreadUser" translate="yes" xml:space="preserve">
-          <source>Add call to {0}() at start of member body because this member invokes other members that require the main thread.</source>
-          <target state="translated">因為此成員會叫用其他需要主執行緒的成員，所以請在成員主體開頭新增對 {0}() 的呼叫。</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a method name.</note>
+          <source>Accessing this type or member must be done on the main thread. "{0}" should start with a statement to assert this condition. For example: "{1}();"</source>
+          <target state="needs-review-translation">因為此成員會叫用其他需要主執行緒的成員，所以請在成員主體開頭新增對 {0}() 的呼叫。</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
+          <note from="MultilingualBuild" annotates="source" priority="2">All placeholders are to type or member names.</note>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.Designer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.Designer.cs
@@ -164,7 +164,7 @@ namespace Microsoft.VisualStudio.Threading.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Add call to {0}() at start of member body because this member invokes other members that require the main thread..
+        ///   Looks up a localized string similar to Accessing this type or member must be done on the main thread. &quot;{0}&quot; should start with a statement to assert this condition. For example: &quot;{1}();&quot;.
         /// </summary>
         internal static string VSTHRD010_MessageFormat_TransitiveMainThreadUser {
             get {

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.cs.resx
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.cs.resx
@@ -154,6 +154,6 @@ Nejprve použijte await JoinableTaskFactory.SwitchToMainThreadAsync().</value>
   </data>
   <data name="VSTHRD010_MessageFormat_TransitiveMainThreadUser" xml:space="preserve">
     <value>Přidejte volání metody {0}() na začátek těla člena, protože tento člen volá jiné členy vyžadující hlavní vlákno.</value>
-    <comment>{0} is a method name.</comment>
+    <comment>All placeholders are to type or member names.</comment>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.de.resx
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.de.resx
@@ -154,6 +154,6 @@ Rufen Sie zuerst "await JoinableTaskFactory.SwitchToMainThreadAsync()" auf.</val
   </data>
   <data name="VSTHRD010_MessageFormat_TransitiveMainThreadUser" xml:space="preserve">
     <value>Fügen Sie den Aufruf an "{0}()" am Beginn des Elementtexts hinzu, weil dieses Element andere Elemente aufruft, für die der Hauptthread erforderlich ist.</value>
-    <comment>{0} is a method name.</comment>
+    <comment>All placeholders are to type or member names.</comment>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.es.resx
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.es.resx
@@ -154,6 +154,6 @@ Use await JoinableTaskFactory.SwitchToMainThreadAsync() primero.</value>
   </data>
   <data name="VSTHRD010_MessageFormat_TransitiveMainThreadUser" xml:space="preserve">
     <value>Agregue la llamada a {0}() al inicio del cuerpo del miembro porque este miembro invoca a otros medios que requieren el subproceso principal.</value>
-    <comment>{0} is a method name.</comment>
+    <comment>All placeholders are to type or member names.</comment>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.fr.resx
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.fr.resx
@@ -154,6 +154,6 @@ Attendez d’abord JoinableTaskFactory.SwitchToMainThreadAsync().</value>
   </data>
   <data name="VSTHRD010_MessageFormat_TransitiveMainThreadUser" xml:space="preserve">
     <value>Ajoutez un appel à {0}() au début du corps du membre parce que ce membre appelle d’autres membres qui nécessitent le thread principal.</value>
-    <comment>{0} is a method name.</comment>
+    <comment>All placeholders are to type or member names.</comment>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.it.resx
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.it.resx
@@ -154,6 +154,6 @@ Attendere prima JoinableTaskFactory.SwitchToMainThreadAsync().</value>
   </data>
   <data name="VSTHRD010_MessageFormat_TransitiveMainThreadUser" xml:space="preserve">
     <value>Aggiungere la chiamata a {0}() all'inizio del corpo del membro perché questo membro richiama altri membri che richiedono il thread principale.</value>
-    <comment>{0} is a method name.</comment>
+    <comment>All placeholders are to type or member names.</comment>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.ja.resx
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.ja.resx
@@ -154,6 +154,6 @@
   </data>
   <data name="VSTHRD010_MessageFormat_TransitiveMainThreadUser" xml:space="preserve">
     <value>メンバー本体の開始時に {0}() への呼び出しを追加します。このメンバーによって、メイン スレッドを必要とする他のメンバーが呼び出されるためです。</value>
-    <comment>{0} is a method name.</comment>
+    <comment>All placeholders are to type or member names.</comment>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.ko.resx
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.ko.resx
@@ -154,6 +154,6 @@ Await JoinableTaskFactory.SwitchToMainThreadAsync() first.</value>
   </data>
   <data name="VSTHRD010_MessageFormat_TransitiveMainThreadUser" xml:space="preserve">
     <value>이 멤버는 주 스레드가 필요한 다른 멤버를 호출하므로 멤버 본문 시작에 {0}()에 대한 호출을 추가합니다.</value>
-    <comment>{0} is a method name.</comment>
+    <comment>All placeholders are to type or member names.</comment>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.pl.resx
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.pl.resx
@@ -154,6 +154,6 @@ Najpierw zaczekaj na metodę JoinableTaskFactory.SwitchToMainThreadAsync().</val
   </data>
   <data name="VSTHRD010_MessageFormat_TransitiveMainThreadUser" xml:space="preserve">
     <value>Dodaj wywołanie metody {0}() na początku treści składowej, ponieważ ta składowa wywołuje inne składowe wymagające wątku głównego.</value>
-    <comment>{0} is a method name.</comment>
+    <comment>All placeholders are to type or member names.</comment>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.pt-BR.resx
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.pt-BR.resx
@@ -154,6 +154,6 @@ Await JoinableTaskFactory.SwitchToMainThreadAsync() primeiro.</value>
   </data>
   <data name="VSTHRD010_MessageFormat_TransitiveMainThreadUser" xml:space="preserve">
     <value>Adicione uma chamada a {0}() no início do corpo do membro porque esse membro invoca outros membros que exigem o thread principal.</value>
-    <comment>{0} is a method name.</comment>
+    <comment>All placeholders are to type or member names.</comment>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.resx
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.resx
@@ -258,7 +258,7 @@ Await JoinableTaskFactory.SwitchToMainThreadAsync() first.</value>
     <comment>{0} is a type name and {1} is the name of a method that throws if not called from the main thread.</comment>
   </data>
   <data name="VSTHRD010_MessageFormat_TransitiveMainThreadUser" xml:space="preserve">
-    <value>Add call to {0}() at start of member body because this member invokes other members that require the main thread.</value>
-    <comment>{0} is a method name.</comment>
+    <value>Accessing this type or member must be done on the main thread. "{0}" should start with a statement to assert this condition. For example: "{1}();"</value>
+    <comment>All placeholders are to type or member names.</comment>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.ru.resx
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.ru.resx
@@ -154,6 +154,6 @@
   </data>
   <data name="VSTHRD010_MessageFormat_TransitiveMainThreadUser" xml:space="preserve">
     <value>Добавьте вызов {0}() в начале тела элемента, так как он вызывает другие элементы, которым требуется основной поток.</value>
-    <comment>{0} is a method name.</comment>
+    <comment>All placeholders are to type or member names.</comment>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.tr.resx
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.tr.resx
@@ -154,6 +154,6 @@ Bunun yerine AsyncLazy&lt;T&gt; kullanın.</value>
   </data>
   <data name="VSTHRD010_MessageFormat_TransitiveMainThreadUser" xml:space="preserve">
     <value>Bu üye, ana iş parçacığını gerektiren diğer üyeleri çağırdığından üye gövdesinin başına {0}() araması ekleyin.</value>
-    <comment>{0} is a method name.</comment>
+    <comment>All placeholders are to type or member names.</comment>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.zh-Hans.resx
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.zh-Hans.resx
@@ -154,6 +154,6 @@
   </data>
   <data name="VSTHRD010_MessageFormat_TransitiveMainThreadUser" xml:space="preserve">
     <value>在成员体的开头添加对 {0}() 的调用，因为此成员调用其他需要主线程的成员。</value>
-    <comment>{0} is a method name.</comment>
+    <comment>All placeholders are to type or member names.</comment>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.zh-Hant.resx
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.zh-Hant.resx
@@ -154,6 +154,6 @@
   </data>
   <data name="VSTHRD010_MessageFormat_TransitiveMainThreadUser" xml:space="preserve">
     <value>因為此成員會叫用其他需要主執行緒的成員，所以請在成員主體開頭新增對 {0}() 的呼叫。</value>
-    <comment>{0} is a method name.</comment>
+    <comment>All placeholders are to type or member names.</comment>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Utils.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Utils.cs
@@ -13,6 +13,7 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Linq;
+    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
     using CodeAnalysis.CSharp;
@@ -622,6 +623,34 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
             }
 
             return SyntaxFactory.QualifiedName(result, simpleName);
+        }
+
+        internal static string GetFullName(ISymbol symbol)
+        {
+            if (symbol == null)
+            {
+                throw new ArgumentNullException(nameof(symbol));
+            }
+
+            var sb = new StringBuilder();
+            sb.Append(symbol.Name);
+            while (symbol.ContainingType != null)
+            {
+                sb.Insert(0, symbol.ContainingType.Name + ".");
+                symbol = symbol.ContainingType;
+            }
+
+            while (symbol.ContainingNamespace != null)
+            {
+                if (!string.IsNullOrEmpty(symbol.ContainingNamespace.Name))
+                {
+                    sb.Insert(0, symbol.ContainingNamespace.Name + ".");
+                }
+
+                symbol = symbol.ContainingNamespace;
+            }
+
+            return sb.ToString();
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD010MainThreadUsageAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD010MainThreadUsageAnalyzer.cs
@@ -116,7 +116,7 @@
 
                 var methodsDeclaringUIThreadRequirement = new HashSet<IMethodSymbol>();
                 var methodsAssertingUIThreadRequirement = new HashSet<IMethodSymbol>();
-                var callerToCalleeMap = new Dictionary<IMethodSymbol, HashSet<IMethodSymbol>>();
+                var callerToCalleeMap = new Dictionary<IMethodSymbol, List<CallInfo>>();
 
                 compilationStartContext.RegisterCodeBlockStartAction<SyntaxKind>(codeBlockStartContext =>
                 {
@@ -145,32 +145,26 @@
                     var transitiveClosureOfMainThreadRequiringMethods = GetTransitiveClosureOfMainThreadRequiringMethods(methodsAssertingUIThreadRequirement, calleeToCallerMap);
                     foreach (var implicitUserMethod in transitiveClosureOfMainThreadRequiringMethods.Except(methodsDeclaringUIThreadRequirement))
                     {
-                        var declarationSyntax = implicitUserMethod.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax(compilationEndContext.CancellationToken);
-                        SyntaxToken memberNameSyntax = default(SyntaxToken);
-                        switch (declarationSyntax)
-                        {
-                            case MethodDeclarationSyntax methodDeclarationSyntax:
-                                memberNameSyntax = methodDeclarationSyntax.Identifier;
-                                break;
-                            case AccessorDeclarationSyntax accessorDeclarationSyntax:
-                                memberNameSyntax = accessorDeclarationSyntax.Keyword;
-                                break;
-                            case ConstructorDeclarationSyntax constructorDeclarationSyntax:
-                                memberNameSyntax = constructorDeclarationSyntax.Identifier;
-                                break;
-                        }
-                        var location = memberNameSyntax.GetLocation();
-                        if (location != null)
+                        var locations = from info in callerToCalleeMap[implicitUserMethod]
+                                        where transitiveClosureOfMainThreadRequiringMethods.Contains(info.MethodSymbol)
+                                        group info by info.MethodSymbol into bySymbol
+                                        select bySymbol.First().InvocationSyntax.GetLocation();
+                        foreach (var primaryLocation in locations)
                         {
                             var exampleAssertingMethod = mainThreadAssertingMethods.FirstOrDefault();
-                            compilationEndContext.ReportDiagnostic(Diagnostic.Create(DescriptorTransitiveMainThreadUser, location, exampleAssertingMethod));
+                            Diagnostic diagnostic = Diagnostic.Create(
+                                DescriptorTransitiveMainThreadUser,
+                                primaryLocation,
+                                Utils.GetFullName(implicitUserMethod),
+                                exampleAssertingMethod);
+                            compilationEndContext.ReportDiagnostic(diagnostic);
                         }
                     }
                 });
             });
         }
 
-        private static HashSet<IMethodSymbol> GetTransitiveClosureOfMainThreadRequiringMethods(HashSet<IMethodSymbol> methodsRequiringUIThread, Dictionary<IMethodSymbol, HashSet<IMethodSymbol>> calleeToCallerMap)
+        private static HashSet<IMethodSymbol> GetTransitiveClosureOfMainThreadRequiringMethods(HashSet<IMethodSymbol> methodsRequiringUIThread, Dictionary<IMethodSymbol, List<CallInfo>> calleeToCallerMap)
         {
             var result = new HashSet<IMethodSymbol>();
 
@@ -180,7 +174,7 @@
                 {
                     foreach (var caller in callers)
                     {
-                        MarkMethod(caller);
+                        MarkMethod(caller.MethodSymbol);
                     }
                 }
             }
@@ -193,7 +187,7 @@
             return result;
         }
 
-        private static void AddToCallerCalleeMap(SyntaxNodeAnalysisContext context, Dictionary<IMethodSymbol, HashSet<IMethodSymbol>> callerToCalleeMap)
+        private static void AddToCallerCalleeMap(SyntaxNodeAnalysisContext context, Dictionary<IMethodSymbol, List<CallInfo>> callerToCalleeMap)
         {
             if (Utils.IsWithinNameOf(context.Node))
             {
@@ -213,10 +207,12 @@
             }
 
             ISymbol targetMethod = null;
+            SyntaxNode locationToBlame = context.Node;
             switch (context.Node)
             {
                 case InvocationExpressionSyntax invocationExpressionSyntax:
                     targetMethod = context.SemanticModel.GetSymbolInfo(invocationExpressionSyntax.Expression).Symbol;
+                    locationToBlame = invocationExpressionSyntax.Expression;
                     break;
                 case MemberAccessExpressionSyntax memberAccessExpressionSyntax:
                     targetMethod = GetPropertyAccessor(context.SemanticModel.GetSymbolInfo(memberAccessExpressionSyntax.Name).Symbol as IPropertySymbol);
@@ -230,35 +226,42 @@
             {
                 lock (callerToCalleeMap)
                 {
-                    if (!callerToCalleeMap.TryGetValue(caller, out HashSet<IMethodSymbol> callees))
+                    if (!callerToCalleeMap.TryGetValue(caller, out List<CallInfo> callees))
                     {
-                        callerToCalleeMap[caller] = callees = new HashSet<IMethodSymbol>();
+                        callerToCalleeMap[caller] = callees = new List<CallInfo>();
                     }
 
-                    callees.Add(callee);
+                    callees.Add(new CallInfo { MethodSymbol = callee, InvocationSyntax = locationToBlame });
                 }
             }
         }
 
-        private static Dictionary<IMethodSymbol, HashSet<IMethodSymbol>> CreateCalleeToCallerMap(Dictionary<IMethodSymbol, HashSet<IMethodSymbol>> callerToCalleeMap)
+        private static Dictionary<IMethodSymbol, List<CallInfo>> CreateCalleeToCallerMap(Dictionary<IMethodSymbol, List<CallInfo>> callerToCalleeMap)
         {
-            var result = new Dictionary<IMethodSymbol, HashSet<IMethodSymbol>>();
+            var result = new Dictionary<IMethodSymbol, List<CallInfo>>();
 
             foreach (var item in callerToCalleeMap)
             {
                 var caller = item.Key;
                 foreach (var callee in item.Value)
                 {
-                    if (!result.TryGetValue(callee, out var callers))
+                    if (!result.TryGetValue(callee.MethodSymbol, out var callers))
                     {
-                        result[callee] = callers = new HashSet<IMethodSymbol>();
+                        result[callee.MethodSymbol] = callers = new List<CallInfo>();
                     }
 
-                    callers.Add(caller);
+                    callers.Add(new CallInfo { MethodSymbol = caller, InvocationSyntax = callee.InvocationSyntax });
                 }
             }
 
             return result;
+        }
+
+        private struct CallInfo
+        {
+            public IMethodSymbol MethodSymbol { get; set; }
+
+            public SyntaxNode InvocationSyntax { get; set; }
         }
 
         private class MethodAnalyzer

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD010MainThreadUsageAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD010MainThreadUsageAnalyzer.cs
@@ -155,6 +155,9 @@
                             case AccessorDeclarationSyntax accessorDeclarationSyntax:
                                 memberNameSyntax = accessorDeclarationSyntax.Keyword;
                                 break;
+                            case ConstructorDeclarationSyntax constructorDeclarationSyntax:
+                                memberNameSyntax = constructorDeclarationSyntax.Identifier;
+                                break;
                         }
                         var location = memberNameSyntax.GetLocation();
                         if (location != null)


### PR DESCRIPTION
Instead of indicating the method name that needs to declare its dependency on the UI thread, we now call out the invocation within the method that leads to that requirement. This makes it easier to understand _why_ a method must run on the UI thread.

Fixes #247 