### PR TITLE
Add VSTHRD010 code fix provider

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <ItemGroup Condition=" '$(MSBuildProjectExtension)' != '.vcxproj' ">
     <PackageReference Include="Nerdbank.GitVersioning" Version="2.1.23" PrivateAssets="all" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="all" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta006" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" />

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/AdditionalFiles/vs-threading.MainThreadSwitchingMethods.mocks.txt
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/AdditionalFiles/vs-threading.MainThreadSwitchingMethods.mocks.txt
@@ -1,0 +1,1 @@
+﻿[Test]::MySwitchingMethodAsync

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/Helpers/CodeFixVerifier.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/Helpers/CodeFixVerifier.cs
@@ -2,6 +2,7 @@
 
 namespace Microsoft.VisualStudio.Threading.Analyzers.Tests
 {
+    using System;
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Linq;
@@ -48,12 +49,12 @@ namespace Microsoft.VisualStudio.Threading.Analyzers.Tests
         /// </summary>
         /// <param name="oldSource">A class in the form of a string before the CodeFix was applied to it</param>
         /// <param name="newSource">A class in the form of a string after the CodeFix was applied to it</param>
-        /// <param name="codeFixIndex">Index determining which codefix to apply if there are multiple</param>
+        /// <param name="codeFixChooser">Predicate to determine which codefix to apply if there are multiple</param>
         /// <param name="allowNewCompilerDiagnostics">A bool controlling whether or not the test will fail if the CodeFix introduces other warnings after being applied</param>
         /// <param name="hasEntrypoint"><c>true</c> to set the compiler in a mode as if it were compiling an exe (as opposed to a dll).</param>
-        protected void VerifyCSharpFix(string oldSource, string newSource, int? codeFixIndex = null, bool allowNewCompilerDiagnostics = false, bool hasEntrypoint = false)
+        protected void VerifyCSharpFix(string oldSource, string newSource, Func<CodeAction, bool> codeFixChooser = null, bool allowNewCompilerDiagnostics = false, bool hasEntrypoint = false)
         {
-            this.VerifyFix(LanguageNames.CSharp, this.GetCSharpDiagnosticAnalyzer(), this.GetCSharpCodeFixProvider(), new[] { oldSource }, new[] { newSource }, codeFixIndex, allowNewCompilerDiagnostics, hasEntrypoint);
+            this.VerifyFix(LanguageNames.CSharp, this.GetCSharpDiagnosticAnalyzer(), this.GetCSharpCodeFixProvider(), new[] { oldSource }, new[] { newSource }, codeFixChooser, allowNewCompilerDiagnostics, hasEntrypoint);
         }
 
         /// <summary>
@@ -61,12 +62,12 @@ namespace Microsoft.VisualStudio.Threading.Analyzers.Tests
         /// </summary>
         /// <param name="oldSources">Code files, each in the form of a string before the CodeFix was applied to it</param>
         /// <param name="newSources">Code files, each in the form of a string after the CodeFix was applied to it</param>
-        /// <param name="codeFixIndex">Index determining which codefix to apply if there are multiple</param>
+        /// <param name="codeFixChooser">Predicate to determine which codefix to apply if there are multiple</param>
         /// <param name="allowNewCompilerDiagnostics">A bool controlling whether or not the test will fail if the CodeFix introduces other warnings after being applied</param>
         /// <param name="hasEntrypoint"><c>true</c> to set the compiler in a mode as if it were compiling an exe (as opposed to a dll).</param>
-        protected void VerifyCSharpFix(string[] oldSources, string[] newSources, int? codeFixIndex = null, bool allowNewCompilerDiagnostics = false, bool hasEntrypoint = false)
+        protected void VerifyCSharpFix(string[] oldSources, string[] newSources, Func<CodeAction, bool> codeFixChooser = null, bool allowNewCompilerDiagnostics = false, bool hasEntrypoint = false)
         {
-            this.VerifyFix(LanguageNames.CSharp, this.GetCSharpDiagnosticAnalyzer(), this.GetCSharpCodeFixProvider(), oldSources, newSources, codeFixIndex, allowNewCompilerDiagnostics, hasEntrypoint);
+            this.VerifyFix(LanguageNames.CSharp, this.GetCSharpDiagnosticAnalyzer(), this.GetCSharpCodeFixProvider(), oldSources, newSources, codeFixChooser, allowNewCompilerDiagnostics, hasEntrypoint);
         }
 
         /// <summary>
@@ -74,12 +75,12 @@ namespace Microsoft.VisualStudio.Threading.Analyzers.Tests
         /// </summary>
         /// <param name="oldSource">A class in the form of a string before the CodeFix was applied to it</param>
         /// <param name="newSource">A class in the form of a string after the CodeFix was applied to it</param>
-        /// <param name="codeFixIndex">Index determining which codefix to apply if there are multiple in the same location</param>
+        /// <param name="codeFixChooser">Predicate to determine which codefix to apply if there are multiple</param>
         /// <param name="allowNewCompilerDiagnostics">A bool controlling whether or not the test will fail if the CodeFix introduces other warnings after being applied</param>
         /// <param name="hasEntrypoint"><c>true</c> to set the compiler in a mode as if it were compiling an exe (as opposed to a dll).</param>
-        protected void VerifyBasicFix(string oldSource, string newSource, int? codeFixIndex = null, bool allowNewCompilerDiagnostics = false, bool hasEntrypoint = false)
+        protected void VerifyBasicFix(string oldSource, string newSource, Func<CodeAction, bool> codeFixChooser = null, bool allowNewCompilerDiagnostics = false, bool hasEntrypoint = false)
         {
-            this.VerifyFix(LanguageNames.VisualBasic, this.GetBasicDiagnosticAnalyzer(), this.GetBasicCodeFixProvider(), new[] { oldSource }, new[] { newSource }, codeFixIndex, allowNewCompilerDiagnostics, hasEntrypoint);
+            this.VerifyFix(LanguageNames.VisualBasic, this.GetBasicDiagnosticAnalyzer(), this.GetBasicCodeFixProvider(), new[] { oldSource }, new[] { newSource }, codeFixChooser, allowNewCompilerDiagnostics, hasEntrypoint);
         }
 
         protected void VerifyNoCSharpFixOffered(string oldSource, bool hasEntrypoint = false)
@@ -114,10 +115,10 @@ namespace Microsoft.VisualStudio.Threading.Analyzers.Tests
         /// <param name="codeFixProvider">The codefix to be applied to the code wherever the relevant Diagnostic is found</param>
         /// <param name="oldSources">Code files, each in the form of a string before the CodeFix was applied to it</param>
         /// <param name="newSources">Code files, each in the form of a string after the CodeFix was applied to it</param>
-        /// <param name="codeFixIndex">Index determining which codefix to apply if there are multiple in the same location</param>
+        /// <param name="codeFixChooser">Predicate to determine which codefix to apply if there are multiple</param>
         /// <param name="allowNewCompilerDiagnostics">A bool controlling whether or not the test will fail if the CodeFix introduces other warnings after being applied</param>
         /// <param name="hasEntrypoint"><c>true</c> to set the compiler in a mode as if it were compiling an exe (as opposed to a dll).</param>
-        private void VerifyFix(string language, DiagnosticAnalyzer analyzer, CodeFixProvider codeFixProvider, string[] oldSources, string[] newSources, int? codeFixIndex, bool allowNewCompilerDiagnostics, bool hasEntrypoint)
+        private void VerifyFix(string language, DiagnosticAnalyzer analyzer, CodeFixProvider codeFixProvider, string[] oldSources, string[] newSources, Func<CodeAction, bool> codeFixChooser, bool allowNewCompilerDiagnostics, bool hasEntrypoint)
         {
             var project = CreateProject(oldSources, language, hasEntrypoint);
             var analyzerDiagnostics = GetSortedDiagnosticsFromDocuments(ImmutableArray.Create(analyzer), project.Documents.ToArray(), hasEntrypoint);
@@ -137,7 +138,8 @@ namespace Microsoft.VisualStudio.Threading.Analyzers.Tests
                     continue;
                 }
 
-                document = ApplyFix(document, actions[codeFixIndex ?? 0]);
+                var action = codeFixChooser != null ? actions.Single(codeFixChooser) : actions.Single();
+                document = ApplyFix(document, action);
                 project = document.Project;
 
                 this.logger.WriteLine("Code after fix:\n{0}", document.GetSyntaxRootAsync().Result.ToFullString());

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/Helpers/DiagnosticVerifier.Helper.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/Helpers/DiagnosticVerifier.Helper.cs
@@ -207,7 +207,14 @@ namespace Microsoft.VisualStudio.Threading.Analyzers.Tests
                 .AddMetadataReference(projectId, ThreadingReference)
                 .AddMetadataReference(projectId, WindowsBaseReference)
                 .AddMetadataReference(projectId, OleInteropReference)
-                .WithProjectCompilationOptions(projectId, new CSharpCompilationOptions(hasEntrypoint ? OutputKind.ConsoleApplication : OutputKind.DynamicallyLinkedLibrary))
+                .WithProjectCompilationOptions(
+                    projectId,
+                    new CSharpCompilationOptions(
+                        hasEntrypoint ? OutputKind.ConsoleApplication : OutputKind.DynamicallyLinkedLibrary,
+                        specificDiagnosticOptions: new Dictionary<string, ReportDiagnostic>
+                        {
+                            { "CS1701", ReportDiagnostic.Suppress }, // we don't reference mscorlib, which can cause assembly reference ambiguities
+                        }))
                 .WithProjectParseOptions(projectId, new CSharpParseOptions(LanguageVersion.Latest));
 
             var pathToLibs = ToolLocationHelper.GetPathToStandardLibraries(".NETFramework", "v4.5.1", string.Empty);

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD010MainThreadUsageAnalyzerTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD010MainThreadUsageAnalyzerTests.cs
@@ -1222,6 +1222,7 @@ class Test : AsyncPackage {
     }
 }
 ";
+#pragma warning disable CS0219 // Variable is assigned but its value is never used
             var fix = @"
 using System;
 using System.Threading.Tasks;
@@ -1238,7 +1239,9 @@ class Test : AsyncPackage {
         var shell = asp.GetServiceAsync(typeof(SVsShell)) as IVsShell;
     }
 }
-";
+"
+#pragma warning restore CS0219 // Variable is assigned but its value is never used
+;
             this.expect.Locations = new[] { new DiagnosticResultLocation("Test0.cs", 13, 59, 13, 70) };
             this.VerifyCSharpDiagnostic(test, this.expect);
             this.VerifyNoCSharpFixOffered(test); // till we have it implemented.

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/CommonInterest.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/CommonInterest.cs
@@ -354,7 +354,7 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
                     && symbol.BelongsToNamespace(this.Namespace);
             }
 
-            public override string ToString() => string.Join(".", this.Namespace) + "." + this.Name;
+            public override string ToString() => string.Join(".", this.Namespace.Concat(new[] { this.Name }));
         }
 
         internal struct QualifiedMember

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Utils.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Utils.cs
@@ -171,39 +171,39 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
         /// </summary>
         /// <param name="syntaxNode">The syntax node to begin the search from.</param>
         /// <returns>The containing function, and metadata for it.</returns>
-        internal static (CSharpSyntaxNode Function, bool IsAsync, CSharpSyntaxNode BlockOrExpression) GetContainingFunction(CSharpSyntaxNode syntaxNode)
+        internal static (CSharpSyntaxNode Function, bool IsAsync, ParameterListSyntax ParameterList, CSharpSyntaxNode BlockOrExpression) GetContainingFunction(CSharpSyntaxNode syntaxNode)
         {
             while (syntaxNode != null)
             {
                 if (syntaxNode is SimpleLambdaExpressionSyntax simpleLambda)
                 {
-                    return (simpleLambda, simpleLambda.AsyncKeyword != default(SyntaxToken), simpleLambda.Body);
+                    return (simpleLambda, simpleLambda.AsyncKeyword != default(SyntaxToken), SyntaxFactory.ParameterList().AddParameters(simpleLambda.Parameter), simpleLambda.Body);
                 }
 
                 if (syntaxNode is AnonymousMethodExpressionSyntax anonymousMethod)
                 {
-                    return (anonymousMethod, anonymousMethod.AsyncKeyword != default(SyntaxToken), anonymousMethod.Body);
+                    return (anonymousMethod, anonymousMethod.AsyncKeyword != default(SyntaxToken), anonymousMethod.ParameterList, anonymousMethod.Body);
                 }
 
                 if (syntaxNode is ParenthesizedLambdaExpressionSyntax lambda)
                 {
-                    return (lambda, lambda.AsyncKeyword != default(SyntaxToken), lambda.Body);
+                    return (lambda, lambda.AsyncKeyword != default(SyntaxToken), lambda.ParameterList, lambda.Body);
                 }
 
                 if (syntaxNode is AccessorDeclarationSyntax accessor)
                 {
-                    return (accessor, false, accessor.Body);
+                    return (accessor, false, SyntaxFactory.ParameterList(), accessor.Body);
                 }
 
                 if (syntaxNode is BaseMethodDeclarationSyntax method)
                 {
-                    return (method, method.Modifiers.Any(SyntaxKind.AsyncKeyword), method.Body);
+                    return (method, method.Modifiers.Any(SyntaxKind.AsyncKeyword), method.ParameterList, method.Body);
                 }
 
                 syntaxNode = (CSharpSyntaxNode)syntaxNode.Parent;
             }
 
-            return (null, false, null);
+            return (null, false, null, null);
         }
 
         internal static bool HasAsyncCompatibleReturnType(this IMethodSymbol methodSymbol)

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD010MainThreadUsageAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD010MainThreadUsageAnalyzer.cs
@@ -130,6 +130,7 @@
                         MembersRequiringMainThread = membersRequiringMainThread,
                         MethodsDeclaringUIThreadRequirement = methodsDeclaringUIThreadRequirement,
                         MethodsAssertingUIThreadRequirement = methodsAssertingUIThreadRequirement,
+                        DiagnosticProperties = diagnosticProperties,
                     };
                     codeBlockStartContext.RegisterSyntaxNodeAction(Utils.DebuggableWrapper(methodAnalyzer.AnalyzeInvocation), SyntaxKind.InvocationExpression);
                     codeBlockStartContext.RegisterSyntaxNodeAction(Utils.DebuggableWrapper(methodAnalyzer.AnalyzeMemberAccess), SyntaxKind.SimpleMemberAccessExpression);
@@ -282,6 +283,8 @@
 
             internal HashSet<IMethodSymbol> MethodsAssertingUIThreadRequirement { get; set; }
 
+            internal ImmutableDictionary<string, string> DiagnosticProperties { get; set; }
+
             internal void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
             {
                 var invocationSyntax = (InvocationExpressionSyntax)context.Node;
@@ -388,7 +391,7 @@
                         Location location = focusDiagnosticOn ?? context.Node.GetLocation();
                         var exampleAssertingMethod = this.MainThreadAssertingMethods.FirstOrDefault();
                         var descriptor = exampleAssertingMethod.Name != null ? Descriptor : DescriptorNoAssertingMethod;
-                        context.ReportDiagnostic(Diagnostic.Create(descriptor, location, type.Name, exampleAssertingMethod));
+                        context.ReportDiagnostic(Diagnostic.Create(descriptor, location, this.DiagnosticProperties, type.Name,  exampleAssertingMethod));
                         return true;
                     }
                 }

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD010MainThreadUsageCodeFix.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD010MainThreadUsageCodeFix.cs
@@ -165,20 +165,20 @@
             bool IsCancellationTokenParameter(IParameterSymbol parameterSymbol) => parameterSymbol.Type.Name == nameof(CancellationToken) && parameterSymbol.Type.BelongsToNamespace(Namespaces.SystemThreading);
         }
 
-        private static (string, string) SplitOffLastElement(string qualifiedName)
+        private static Tuple<string, string> SplitOffLastElement(string qualifiedName)
         {
             if (qualifiedName == null)
             {
-                return (null, null);
+                return Tuple.Create<string, string>(null, null);
             }
 
             int lastPeriod = qualifiedName.LastIndexOf('.');
             if (lastPeriod < 0)
             {
-                return (null, qualifiedName);
+                return Tuple.Create<string, string>(null, qualifiedName);
             }
 
-            return (qualifiedName.Substring(0, lastPeriod), qualifiedName.Substring(lastPeriod + 1));
+            return Tuple.Create(qualifiedName.Substring(0, lastPeriod), qualifiedName.Substring(lastPeriod + 1));
         }
     }
 }

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD010MainThreadUsageCodeFix.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD010MainThreadUsageCodeFix.cs
@@ -35,59 +35,116 @@
             var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
             var syntaxNode = (ExpressionSyntax)root.FindNode(diagnostic.Location.SourceSpan);
 
-            // TODO: test this for anonymous delegates declared as fields, or within members (see that the async flag is seen at the appropriately level).
-            var containingAccessor = syntaxNode.FirstAncestorOrSelf<AccessorDeclarationSyntax>();
-            var containingMember = syntaxNode.FirstAncestorOrSelf<MemberDeclarationSyntax>();
-            var containingMethod = syntaxNode.FirstAncestorOrSelf<BaseMethodDeclarationSyntax>();
-            BlockSyntax memberLevelBlock = containingAccessor?.Body ?? containingMethod?.Body;
-            if (memberLevelBlock == null)
+            var container = Utils.GetContainingFunction(syntaxNode);
+            if (container.BlockOrExpression == null)
             {
                 return;
             }
 
             // TODO: even if it isn't async, if the returned type is Task or Task<T>, we should *make* it async
-            bool isAsyncMember = containingMethod?.Modifiers.Any(SyntaxKind.AsyncKeyword) ?? false;
-            Regex lookupKey = isAsyncMember ? CommonInterest.FileNamePatternForMethodsThatSwitchToMainThread : CommonInterest.FileNamePatternForMethodsThatAssertMainThread;
+            Regex lookupKey = container.IsAsync ? CommonInterest.FileNamePatternForMethodsThatSwitchToMainThread : CommonInterest.FileNamePatternForMethodsThatAssertMainThread;
             string[] options = diagnostic.Properties[lookupKey.ToString()].Split('\n');
             if (options.Length > 0)
             {
                 var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+                var enclosingSymbol = semanticModel.GetEnclosingSymbol(diagnostic.Location.SourceSpan.Start, context.CancellationToken);
                 foreach (var option in options)
                 {
-                    // We can only offer fixes when they involve adding calls to static methods, since otherwise we don't know
-                    // where to find the instance on which to invoke the method.
-                    // TODO: find static fields/properties that return the matching type from other (non-generic) types.
-                    // TODO: also, if we're in an instance member, check instance fields/properties on `this`
-                    var (typeName, methodName) = SplitTypeAndMethodNames(option);
-                    var proposedType = semanticModel.Compilation.GetTypeByMetadataName(typeName);
-                    var proposedMethod = proposedType?.GetMembers(methodName).OfType<IMethodSymbol>().FirstOrDefault(m => !m.Parameters.Any(p => !p.HasExplicitDefaultValue));
-                    if (proposedMethod?.IsStatic ?? false)
+                    var (fullTypeName, methodName) = SplitOffLastElement(option);
+                    var (ns, leafTypeName) = SplitOffLastElement(fullTypeName);
+                    string[] namespaces = ns?.Split('.');
+                    if (fullTypeName == null)
                     {
-                        Func<CancellationToken, Task<Document>> fix = cancellationToken =>
-                        {
-                            var invocationExpression = SyntaxFactory.InvocationExpression(SyntaxFactory.ParseName(option));
-                            ExpressionSyntax awaitExpression = isAsyncMember ? SyntaxFactory.AwaitExpression(invocationExpression) : null;
-                            var addedStatement = SyntaxFactory.ExpressionStatement(awaitExpression ?? invocationExpression)
-                                .WithAdditionalAnnotations(Simplifier.Annotation, Formatter.Annotation);
-                            var newBlock = memberLevelBlock.WithStatements(memberLevelBlock.Statements.Insert(0, addedStatement));
-                            return Task.FromResult(context.Document.WithSyntaxRoot(root.ReplaceNode(memberLevelBlock, newBlock)));
-                        };
+                        continue;
+                    }
 
-                        context.RegisterCodeFix(CodeAction.Create($"Add call to {option}", fix, $"{memberLevelBlock.GetLocation()}-{option}"), context.Diagnostics);
+                    var proposedType = semanticModel.Compilation.GetTypeByMetadataName(fullTypeName);
+                    var proposedMethod = proposedType?.GetMembers(methodName).OfType<IMethodSymbol>().FirstOrDefault(m => !m.Parameters.Any(p => !p.HasExplicitDefaultValue));
+                    if (proposedMethod == null)
+                    {
+                        // We can't find it, so don't offer to use it.
+                        continue;
+                    }
+
+                    if (proposedMethod.IsStatic)
+                    {
+                        OfferFix(option);
+                    }
+                    else
+                    {
+                        // Search fields on the declaring type.
+                        // Don't search local variables, since we'd need to dereference it at the top of the function (before they're initialized).
+                        ITypeSymbol enclosingTypeSymbol = enclosingSymbol as ITypeSymbol ?? enclosingSymbol.ContainingType;
+                        if (enclosingTypeSymbol != null)
+                        {
+                            var candidateMembers = from symbol in semanticModel.LookupSymbols(diagnostic.Location.SourceSpan.Start, enclosingTypeSymbol)
+                                                   where symbol.IsStatic || !enclosingSymbol.IsStatic
+                                                   where IsSymbolTheRightType(symbol)
+                                                   select symbol;
+                            foreach (var candidate in candidateMembers)
+                            {
+                                OfferFix($"{candidate.Name}.{methodName}");
+                            }
+                        }
+
+                        // Find static fields/properties that return the matching type from other public, non-generic types.
+                        var candidateStatics = from offering in semanticModel.LookupStaticMembers(diagnostic.Location.SourceSpan.Start).OfType<ITypeSymbol>()
+                                               from symbol in offering.GetMembers()
+                                               where symbol.IsStatic && symbol.CanBeReferencedByName && IsSymbolTheRightType(symbol)
+                                               select symbol;
+                        foreach (var candidate in candidateStatics)
+                        {
+                            OfferFix($"{candidate.ContainingNamespace}.{candidate.ContainingType.Name}.{candidate.Name}.{methodName}");
+                        }
+                    }
+
+                    bool IsSymbolTheRightType(ISymbol symbol)
+                    {
+                        var fieldSymbol = symbol as IFieldSymbol;
+                        var propertySymbol = symbol as IPropertySymbol;
+                        var memberType = fieldSymbol?.Type ?? propertySymbol?.Type;
+                        return memberType?.Name == leafTypeName && memberType.BelongsToNamespace(namespaces);
                     }
                 }
             }
-        }
 
-        private static (string, string) SplitTypeAndMethodNames(string typeAndMethodName)
-        {
-            int lastPeriod = typeAndMethodName.LastIndexOf('.');
-            if (lastPeriod < 0)
+            void OfferFix(string option)
             {
-                throw new ArgumentException("No type name found.", nameof(typeAndMethodName));
+                context.RegisterCodeFix(CodeAction.Create($"Add call to {option}", ct => Fix(option, ct), $"{container.BlockOrExpression.GetLocation()}-{option}"), context.Diagnostics);
             }
 
-            return (typeAndMethodName.Substring(0, lastPeriod), typeAndMethodName.Substring(lastPeriod + 1));
+            Task<Document> Fix(string option, CancellationToken cancellationToken)
+            {
+                var invocationExpression = SyntaxFactory.InvocationExpression(SyntaxFactory.ParseName(option));
+                ExpressionSyntax awaitExpression = container.IsAsync ? SyntaxFactory.AwaitExpression(invocationExpression) : null;
+                var addedStatement = SyntaxFactory.ExpressionStatement(awaitExpression ?? invocationExpression)
+                    .WithAdditionalAnnotations(Simplifier.Annotation, Formatter.Annotation);
+                var initialBlockSyntax = container.BlockOrExpression as BlockSyntax;
+                if (initialBlockSyntax == null)
+                {
+                    initialBlockSyntax = SyntaxFactory.Block(SyntaxFactory.ReturnStatement((ExpressionSyntax)container.BlockOrExpression))
+                        .WithAdditionalAnnotations(Formatter.Annotation);
+                }
+
+                var newBlock = initialBlockSyntax.WithStatements(initialBlockSyntax.Statements.Insert(0, addedStatement));
+                return Task.FromResult(context.Document.WithSyntaxRoot(root.ReplaceNode(container.BlockOrExpression, newBlock)));
+            }
+        }
+
+        private static (string, string) SplitOffLastElement(string qualifiedName)
+        {
+            if (qualifiedName == null)
+            {
+                return (null, null);
+            }
+
+            int lastPeriod = qualifiedName.LastIndexOf('.');
+            if (lastPeriod < 0)
+            {
+                return (null, qualifiedName);
+            }
+
+            return (qualifiedName.Substring(0, lastPeriod), qualifiedName.Substring(lastPeriod + 1));
         }
     }
 }

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD010MainThreadUsageCodeFix.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD010MainThreadUsageCodeFix.cs
@@ -1,0 +1,91 @@
+﻿namespace Microsoft.VisualStudio.Threading.Analyzers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Linq;
+    using System.Text;
+    using System.Text.RegularExpressions;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CodeActions;
+    using Microsoft.CodeAnalysis.CodeFixes;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Formatting;
+    using Microsoft.CodeAnalysis.Simplification;
+    using Microsoft.VisualStudio.Threading;
+
+    [ExportCodeFixProvider(LanguageNames.CSharp)]
+    public class VSTHRD010MainThreadUsageCodeFix : CodeFixProvider
+    {
+        private static readonly ImmutableArray<string> ReusableFixableDiagnosticIds = ImmutableArray.Create(
+          VSTHRD010MainThreadUsageAnalyzer.Id);
+
+        public override ImmutableArray<string> FixableDiagnosticIds => ReusableFixableDiagnosticIds;
+
+        /// <inheritdoc />
+        public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var diagnostic = context.Diagnostics.First();
+
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+            var syntaxNode = (ExpressionSyntax)root.FindNode(diagnostic.Location.SourceSpan);
+
+            // TODO: test this for anonymous delegates declared as fields, or within members (see that the async flag is seen at the appropriately level).
+            var containingAccessor = syntaxNode.FirstAncestorOrSelf<AccessorDeclarationSyntax>();
+            var containingMember = syntaxNode.FirstAncestorOrSelf<MemberDeclarationSyntax>();
+            var containingMethod = syntaxNode.FirstAncestorOrSelf<BaseMethodDeclarationSyntax>();
+            BlockSyntax memberLevelBlock = containingAccessor?.Body ?? containingMethod?.Body;
+            if (memberLevelBlock == null)
+            {
+                return;
+            }
+
+            // TODO: even if it isn't async, if the returned type is Task or Task<T>, we should *make* it async
+            bool isAsyncMember = containingMethod?.Modifiers.Any(SyntaxKind.AsyncKeyword) ?? false;
+            Regex lookupKey = isAsyncMember ? CommonInterest.FileNamePatternForMethodsThatSwitchToMainThread : CommonInterest.FileNamePatternForMethodsThatAssertMainThread;
+            string[] options = diagnostic.Properties[lookupKey.ToString()].Split('\n');
+            if (options.Length > 0)
+            {
+                var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+                foreach (var option in options)
+                {
+                    // We can only offer fixes when they involve adding calls to static methods, since otherwise we don't know
+                    // where to find the instance on which to invoke the method.
+                    var (typeName, methodName) = SplitTypeAndMethodNames(option);
+                    var proposedType = semanticModel.Compilation.GetTypeByMetadataName(typeName);
+                    var proposedMethod = proposedType?.GetMembers(methodName).FirstOrDefault();
+                    if (proposedMethod?.IsStatic ?? false)
+                    {
+                        Func<CancellationToken, Task<Document>> fix = cancellationToken =>
+                        {
+                            var invocationExpression = SyntaxFactory.InvocationExpression(SyntaxFactory.ParseName(option));
+                            ExpressionSyntax awaitExpression = isAsyncMember ? SyntaxFactory.AwaitExpression(invocationExpression) : null;
+                            var addedStatement = SyntaxFactory.ExpressionStatement(awaitExpression ?? invocationExpression)
+                                .WithAdditionalAnnotations(Simplifier.Annotation, Formatter.Annotation);
+                            var newBlock = memberLevelBlock.WithStatements(memberLevelBlock.Statements.Insert(0, addedStatement));
+                            return Task.FromResult(context.Document.WithSyntaxRoot(root.ReplaceNode(memberLevelBlock, newBlock)));
+                        };
+
+                        context.RegisterCodeFix(CodeAction.Create($"Add call to {option}", fix, $"{memberLevelBlock.GetLocation()}-{option}"), context.Diagnostics);
+                    }
+                }
+            }
+        }
+
+        private static (string, string) SplitTypeAndMethodNames(string typeAndMethodName)
+        {
+            int lastPeriod = typeAndMethodName.LastIndexOf('.');
+            if (lastPeriod < 0)
+            {
+                throw new ArgumentException("No type name found.", nameof(typeAndMethodName));
+            }
+
+            return (typeAndMethodName.Substring(0, lastPeriod), typeAndMethodName.Substring(lastPeriod + 1));
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD010MainThreadUsageCodeFix.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD010MainThreadUsageCodeFix.cs
@@ -56,9 +56,11 @@
                 {
                     // We can only offer fixes when they involve adding calls to static methods, since otherwise we don't know
                     // where to find the instance on which to invoke the method.
+                    // TODO: find static fields/properties that return the matching type from other (non-generic) types.
+                    // TODO: also, if we're in an instance member, check instance fields/properties on `this`
                     var (typeName, methodName) = SplitTypeAndMethodNames(option);
                     var proposedType = semanticModel.Compilation.GetTypeByMetadataName(typeName);
-                    var proposedMethod = proposedType?.GetMembers(methodName).FirstOrDefault();
+                    var proposedMethod = proposedType?.GetMembers(methodName).OfType<IMethodSymbol>().FirstOrDefault(m => !m.Parameters.Any(p => !p.HasExplicitDefaultValue));
                     if (proposedMethod?.IsStatic ?? false)
                     {
                         Func<CancellationToken, Task<Document>> fix = cancellationToken =>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD108AssertThreadRequirementUnconditionally.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD108AssertThreadRequirementUnconditionally.cs
@@ -55,7 +55,7 @@
 
             context.RegisterCompilationStartAction(ctxt =>
             {
-                var mainThreadAssertingMethods = CommonInterest.ReadMethods(ctxt, CommonInterest.FileNamePatternForMethodsThatAssertMainThread).ToImmutableArray();
+                var mainThreadAssertingMethods = CommonInterest.ReadMethods(ctxt.Options, CommonInterest.FileNamePatternForMethodsThatAssertMainThread, ctxt.CancellationToken).ToImmutableArray();
 
                 ctxt.RegisterCodeBlockStartAction<SyntaxKind>(ctxt2 =>
                 {


### PR DESCRIPTION
This will offer to fix most occurrences of a VSTHRD010 violation. 

Nothing is hard-coded, but based on the content of AdditionalFiles, it knows that `JTF.SwitchToMainThreadAsync` can switch the user, and because that isn't a static method it 'searches around' for a static instance of JTF and finds it, then offers to fix this:

```cs
    static async Task Foo() {
        var shell = await asp.GetServiceAsync(typeof(SVsShell)) as IVsShell;
    }
```

with this:

```cs
    static async Task Foo() {
        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
        var shell = await asp.GetServiceAsync(typeof(SVsShell)) as IVsShell;
    }
```

It also will find an instance on `this`, so if the context is an `AsyncPackage`, for example:

```cs
    protected override async Task InitializeAsync(System.Threading.CancellationToken cancellationToken, IProgress<ServiceProgressData> progress) {
        await base.InitializeAsync(cancellationToken, progress);
        var shell = await asp.GetServiceAsync(typeof(SVsShell)) as IVsShell;
    }
```

gets changed to:

```cs
    protected override async Task InitializeAsync(System.Threading.CancellationToken cancellationToken, IProgress<ServiceProgressData> progress) {
        await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
        await base.InitializeAsync(cancellationToken, progress);
        var shell = await asp.GetServiceAsync(typeof(SVsShell)) as IVsShell;
    }
```

Notice in the above example how *it even passed in `cancellationToken`* by recognizing that the switching method accepts an optional `CancellationToken` and determining that we had one lying nearby that we could use. It prefers the parameter over the `AsyncPackage.DisposalToken` that (in this case) is also available.

Of course it handles the synchronous method case too:

```cs
    void F() {
        this.Method().SetProperty(1000, null);
    }
```

gets fixed to

```cs
    void F() {
        Microsoft.VisualStudio.Shell.ThreadHelper.ThrowIfNotOnUIThread();
        this.Method().SetProperty(1000, null);
    }
```

Again, all these fixes are data-driven. The fixes will be appropriate for the receiving app. The above examples are tested because our unit tests have VS SDK-like AdditionalFiles input into them.

And yes, it works in anonymous functions too.

I add tests for field initializers as well (no code fix for them at this point, but we flag those that have thread affinity).