### PR TITLE
VSTHRD010 to allow type checks and casts on managed objects

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD010MainThreadUsageAnalyzerTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD010MainThreadUsageAnalyzerTests.cs
@@ -863,6 +863,31 @@ class Test {
             this.VerifyCSharpDiagnostic(test, this.expect);
         }
 
+        /// <summary>
+        /// Verifies that the () cast operator does not produce a diagnostic when the type is to a managed type.
+        /// </summary>
+        [Fact]
+        public void CastToManagedType_ProducesNoDiagnostic()
+        {
+            var test = @"
+using System;
+
+namespace TestNS {
+    class SomeClass { }
+    class SomeInterface { }
+}
+
+class Test {
+    void F() {
+        object obj1 = null;
+        var o1 = (TestNS.SomeClass)obj1;
+        var o2 = (TestNS.SomeInterface)obj1;
+    }
+}
+";
+            this.VerifyCSharpDiagnostic(test);
+        }
+
         [Fact]
         public void CastToVsSolutionAfterVerifyOnUIThread()
         {
@@ -902,6 +927,31 @@ class Test {
             this.VerifyCSharpDiagnostic(test, this.expect);
         }
 
+        /// <summary>
+        /// Verifies that the as cast operator does not produce a diagnostic when the type is to a managed type.
+        /// </summary>
+        [Fact]
+        public void CastToManagedTypeViaAs_ProducesNoDiagnostic()
+        {
+            var test = @"
+using System;
+
+namespace TestNS {
+    class SomeClass { }
+    class SomeInterface { }
+}
+
+class Test {
+    void F() {
+        object obj1 = null;
+        var o1 = obj1 as TestNS.SomeClass;
+        var o2 = obj1 as TestNS.SomeInterface;
+    }
+}
+";
+            this.VerifyCSharpDiagnostic(test);
+        }
+
         [Fact]
         public void TestVsSolutionViaIs()
         {
@@ -918,6 +968,31 @@ class Test {
 ";
             this.expect.Locations = new[] { new DiagnosticResultLocation("Test0.cs", 8, 27, 8, 41) };
             this.VerifyCSharpDiagnostic(test, this.expect);
+        }
+
+        /// <summary>
+        /// Verifies that the is type check operator does not produce a diagnostic when the type is to a managed type.
+        /// </summary>
+        [Fact]
+        public void CastToManagedTypeViaIs_ProducesNoDiagnostic()
+        {
+            var test = @"
+using System;
+
+namespace TestNS {
+    class SomeClass { }
+    class SomeInterface { }
+}
+
+class Test {
+    void F() {
+        object obj1 = null;
+        var o1 = obj1 is TestNS.SomeClass;
+        var o2 = obj1 is TestNS.SomeInterface;
+    }
+}
+";
+            this.VerifyCSharpDiagnostic(test);
         }
 
         [Fact]
@@ -1371,26 +1446,25 @@ using System;
 using Microsoft.VisualStudio.Shell;
 
 class Test {
-    object o;
     void Foo() {
-        object v;
-        v = o as TestNS.FreeThreadedType;
-        v = o as TestNS.SingleThreadedType;
-        v = o as TestNS2.FreeThreadedType;
-        v = o as TestNS2.SingleThreadedType;
+        object o = null;
+        ((TestNS.FreeThreadedType) o).Foo();
+        ((TestNS.SingleThreadedType) o).Foo();
+        ((TestNS2.FreeThreadedType) o).Foo();
+        ((TestNS2.SingleThreadedType) o).Foo();
     }
 }
 
 namespace TestNS {
-    interface SingleThreadedType { }
+    interface SingleThreadedType { void Foo(); }
 
-    interface FreeThreadedType { }
+    interface FreeThreadedType { void Foo(); }
 }
 
 namespace TestNS2 {
-    interface SingleThreadedType { }
+    interface SingleThreadedType { void Foo(); }
 
-    interface FreeThreadedType { }
+    interface FreeThreadedType { void Foo(); }
 }
 ";
             var expect = new[]
@@ -1400,14 +1474,14 @@ namespace TestNS2 {
                     Id = VSTHRD010MainThreadUsageAnalyzer.Id,
                     SkipVerifyMessage = true,
                     Severity = DiagnosticSeverity.Warning,
-                    Locations = new DiagnosticResultLocation[] { new DiagnosticResultLocation("Test0.cs", 10, 15, 10, 43), },
+                    Locations = new DiagnosticResultLocation[] { new DiagnosticResultLocation("Test0.cs", 9, 41, 9, 44), },
                 },
                 new DiagnosticResult
                 {
                     Id = VSTHRD010MainThreadUsageAnalyzer.Id,
                     SkipVerifyMessage = true,
                     Severity = DiagnosticSeverity.Warning,
-                    Locations = new DiagnosticResultLocation[] { new DiagnosticResultLocation("Test0.cs", 12, 15, 12, 44), },
+                    Locations = new DiagnosticResultLocation[] { new DiagnosticResultLocation("Test0.cs", 11, 42, 11, 45), },
                 },
             };
             this.VerifyCSharpDiagnostic(test, expect);

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Namespaces.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Namespaces.cs
@@ -35,6 +35,13 @@
             nameof(global::System.Runtime.CompilerServices),
         };
 
+        internal static readonly IReadOnlyList<string> SystemRuntimeInteropServices = new[]
+        {
+            nameof(System),
+            nameof(global::System.Runtime),
+            nameof(global::System.Runtime.InteropServices),
+        };
+
         internal static readonly IReadOnlyList<string> SystemWindowsThreading = new[]
         {
             nameof(System),

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Types.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Types.cs
@@ -130,5 +130,26 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
 
             internal const string FullName = Namespace + TypeName;
         }
+
+        internal static class ComImportAttribute
+        {
+            internal const string TypeName = nameof(System.Runtime.InteropServices.ComImportAttribute);
+
+            internal static readonly IReadOnlyList<string> Namespace = Namespaces.SystemRuntimeInteropServices;
+        }
+
+        internal static class InterfaceTypeAttribute
+        {
+            internal const string TypeName = nameof(System.Runtime.InteropServices.InterfaceTypeAttribute);
+
+            internal static readonly IReadOnlyList<string> Namespace = Namespaces.SystemRuntimeInteropServices;
+        }
+
+        internal static class TypeLibTypeAttribute
+        {
+            internal const string TypeName = "TypeLibTypeAttribute";
+
+            internal static readonly IReadOnlyList<string> Namespace = Namespaces.SystemRuntimeInteropServices;
+        }
     }
 }


### PR DESCRIPTION
Type checks and casts are only thread affinitized for COM objects. So do what we can to detect whether the type represents a COM type that we're testing for. If it's pure managed, don't flag that it must be done on the main thread.

Fixes #263 
