### PR TITLE
VSTHRD010 code fix should find the inner-most node for a given span

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD010MainThreadUsageAnalyzerTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD010MainThreadUsageAnalyzerTests.cs
@@ -1542,6 +1542,41 @@ class A
             this.VerifyCSharpFix(test, fix);
         }
 
+        [Fact]
+        public void ArgumentExpressionEntirelyMadeOfViolatingCast()
+        {
+            var test = @"
+using Microsoft.VisualStudio.Shell.Interop;
+
+class A
+{
+    void Foo() {
+        object o = null;
+        Bar((IVsSolution)o);
+    }
+
+    void Bar(IVsSolution solution) { }
+}
+";
+            var fix = @"
+using Microsoft.VisualStudio.Shell.Interop;
+
+class A
+{
+    void Foo() {
+        Microsoft.VisualStudio.Shell.ThreadHelper.ThrowIfNotOnUIThread();
+        object o = null;
+        Bar((IVsSolution)o);
+    }
+
+    void Bar(IVsSolution solution) { }
+}
+";
+            this.expect = this.CreateDiagnostic(8, 13, 8, 27);
+            this.VerifyCSharpDiagnostic(test, this.expect);
+            this.VerifyCSharpFix(test, fix);
+        }
+
         private DiagnosticResult CreateDiagnostic(int line, int column, int endLine, int endColumn) =>
             new DiagnosticResult
             {

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD010MainThreadUsageCodeFix.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD010MainThreadUsageCodeFix.cs
@@ -33,7 +33,7 @@
             var diagnostic = context.Diagnostics.First();
 
             var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-            var syntaxNode = (ExpressionSyntax)root.FindNode(diagnostic.Location.SourceSpan);
+            var syntaxNode = (ExpressionSyntax)root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
 
             var container = Utils.GetContainingFunction(syntaxNode);
             if (container.BlockOrExpression == null)


### PR DESCRIPTION
When an ArgumentSyntax is made up entirely of an ExpressionSyntax that violates VSTHRD010, an InvalidCastException would be thrown by the code fix provider. This fixes that by always preferring the most derived node that matches the span.

If that someday fails as well, we can choose the outer-most or inner-most and then walk the tree till we find what we expect.

Fixes #270