### PR TITLE
Fix NullReferenceException thrown from VSTHRD109

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/MultiAnalyzerTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/MultiAnalyzerTests.cs
@@ -265,6 +265,16 @@ public class Test {
             Assert.False(refAssemblies.Any(a => a.Name.Equals("System.ValueTuple", StringComparison.OrdinalIgnoreCase)));
         }
 
+        [Fact]
+        public void NameOfUsedInAttributeArgument()
+        {
+            var test = @"
+[System.Diagnostics.DebuggerDisplay(""hi"", Name = nameof(System.Console))]
+class Foo { }
+";
+            this.VerifyCSharpDiagnostic(test);
+        }
+
         private void VerifyNoMoreThanOneDiagnosticPerLine(string test, bool hasEntrypoint = false)
         {
             this.LogFileContent(test);

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD109AvoidAssertInAsyncMethodsAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD109AvoidAssertInAsyncMethodsAnalyzer.cs
@@ -56,6 +56,14 @@
         private void AnalyzeInvocation(SyntaxNodeAnalysisContext context, ImmutableArray<CommonInterest.QualifiedMember> mainThreadAssertingMethods)
         {
             var functionInfo = Utils.GetContainingFunction((CSharpSyntaxNode)context.Node);
+            if (functionInfo.Function == null)
+            {
+                // One case where this happens is the use of nameof(X) in the argument of a custom attribute on a type, such as:
+                // [System.Diagnostics.DebuggerDisplay(""hi"", Name = nameof(System.Console))]
+                // class Foo { }
+                return;
+            }
+
             var methodSymbol = context.SemanticModel.GetDeclaredSymbol(functionInfo.Function);
             ITypeSymbol implicitReturnType = null;
             if (methodSymbol == null)


### PR DESCRIPTION
...when nameof() is used outside any function.