### PR TITLE
VSTHRD103 calls out using IVsTask.Wait() in async methods

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/Helpers/CodeFixVerifier.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/Helpers/CodeFixVerifier.cs
@@ -165,14 +165,21 @@ namespace Microsoft.VisualStudio.Threading.Analyzers.Tests
                 }
             }
 
-            Assert.True(fixApplied, "No code fix offered.");
-
-            // After applying all of the code fixes, compare the resulting string to the inputted one
-            int j = 0;
-            foreach (var document in project.Documents)
+            if (newSources != null && newSources[0] != null)
             {
-                var actual = GetStringFromDocument(document);
-                Assert.Equal(newSources[j++], actual, ignoreLineEndingDifferences: true);
+                Assert.True(fixApplied, "No code fix offered.");
+
+                // After applying all of the code fixes, compare the resulting string to the inputted one
+                int j = 0;
+                foreach (var document in project.Documents)
+                {
+                    var actual = GetStringFromDocument(document);
+                    Assert.Equal(newSources[j++], actual, ignoreLineEndingDifferences: true);
+                }
+            }
+            else
+            {
+                Assert.False(fixApplied, "No code fix expected, but was offered.");
             }
         }
     }

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/CommonInterest.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/CommonInterest.cs
@@ -34,7 +34,11 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
             new SyncBlockingMethod(new QualifiedMember(new QualifiedType(Namespaces.SystemRuntimeCompilerServices, nameof(TaskAwaiter)), nameof(TaskAwaiter.GetResult)), null),
         };
 
-        internal static readonly IEnumerable<SyncBlockingMethod> SyncBlockingMethods = JTFSyncBlockers.Concat(ProblematicSyncBlockingMethods);
+        internal static readonly IEnumerable<SyncBlockingMethod> SyncBlockingMethods = JTFSyncBlockers.Concat(ProblematicSyncBlockingMethods).Concat(new[]
+        {
+            new SyncBlockingMethod(new QualifiedMember(new QualifiedType(Namespaces.MicrosoftVisualStudioShellInterop, "IVsTask"), "Wait"), extensionMethodNamespace: Namespaces.MicrosoftVisualStudioShell),
+            new SyncBlockingMethod(new QualifiedMember(new QualifiedType(Namespaces.MicrosoftVisualStudioShellInterop, "IVsTask"), "GetResult"), extensionMethodNamespace: Namespaces.MicrosoftVisualStudioShell),
+        });
 
         internal static readonly IEnumerable<QualifiedMember> LegacyThreadSwitchingMethods = new[]
         {
@@ -381,15 +385,18 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
         [DebuggerDisplay("{" + nameof(Method) + "} -> {" + nameof(AsyncAlternativeMethodName) + "}")]
         internal struct SyncBlockingMethod
         {
-            public SyncBlockingMethod(QualifiedMember method, string asyncAlternativeMethodName)
+            public SyncBlockingMethod(QualifiedMember method, string asyncAlternativeMethodName = null, IReadOnlyList<string> extensionMethodNamespace = null)
             {
                 this.Method = method;
                 this.AsyncAlternativeMethodName = asyncAlternativeMethodName;
+                this.ExtensionMethodNamespace = extensionMethodNamespace;
             }
 
             public QualifiedMember Method { get; }
 
             public string AsyncAlternativeMethodName { get; }
+
+            public IReadOnlyList<string> ExtensionMethodNamespace { get; }
         }
     }
 }

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Namespaces.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Namespaces.cs
@@ -62,5 +62,13 @@
             "VisualStudio",
             "Shell",
         };
+
+        internal static readonly IReadOnlyList<string> MicrosoftVisualStudioShellInterop = new[]
+        {
+            "Microsoft",
+            "VisualStudio",
+            "Shell",
+            "Interop",
+        };
     }
 }

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD103UseAsyncOptionAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD103UseAsyncOptionAnalyzer.cs
@@ -182,7 +182,8 @@
                         if (item.Method.IsMatch(memberSymbol))
                         {
                             var location = memberAccessSyntax.Name.GetLocation();
-                            var properties = ImmutableDictionary<string, string>.Empty;
+                            var properties = ImmutableDictionary<string, string>.Empty
+                                .Add(VSTHRD103UseAsyncOptionCodeFix.ExtensionMethodNamespaceKeyName, item.ExtensionMethodNamespace != null ? string.Join(".", item.ExtensionMethodNamespace) : string.Empty);
                             DiagnosticDescriptor descriptor;
                             var messageArgs = new List<object>(2);
                             messageArgs.Add(item.Method.Name);

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD103UseAsyncOptionCodeFix.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD103UseAsyncOptionCodeFix.cs
@@ -33,6 +33,8 @@
     {
         internal const string AsyncMethodKeyName = "AsyncMethodName";
 
+        internal const string ExtensionMethodNamespaceKeyName = "ExtensionMethodNamespace";
+
         private static readonly ImmutableArray<string> ReusableFixableDiagnosticIds = ImmutableArray.Create(
             VSTHRD103UseAsyncOptionAnalyzer.Id);
 
@@ -40,15 +42,41 @@
         public override ImmutableArray<string> FixableDiagnosticIds => ReusableFixableDiagnosticIds;
 
         /// <inheritdoc />
-        public override Task RegisterCodeFixesAsync(CodeFixContext context)
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             var diagnostic = context.Diagnostics.FirstOrDefault(d => d.Properties.ContainsKey(AsyncMethodKeyName));
             if (diagnostic != null)
             {
-                context.RegisterCodeFix(new ReplaceSyncMethodCallWithAwaitAsync(context.Document, diagnostic), diagnostic);
-            }
+                // Check that the method we're replacing the sync blocking call with actually exists.
+                // This is particularly useful when the method is an extension method, since the using directive
+                // would need to be present (or the namespace imply it) and we don't yet add missing using directives.
+                bool asyncAlternativeExists = false;
+                string asyncMethodName = diagnostic.Properties[AsyncMethodKeyName];
+                if (string.IsNullOrEmpty(asyncMethodName))
+                {
+                    asyncMethodName = "GetAwaiter";
+                }
 
-            return Task.FromResult<object>(null);
+                var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+                var syntaxRoot = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+                var blockingIdentifier = syntaxRoot.FindNode(diagnostic.Location.SourceSpan) as IdentifierNameSyntax;
+                var memberAccessExpression = blockingIdentifier?.Parent as MemberAccessExpressionSyntax;
+
+                // Check whether this code was already calling the awaiter (in a synchronous fashion).
+                asyncAlternativeExists |= memberAccessExpression?.Expression is InvocationExpressionSyntax invoke && invoke.Expression is MemberAccessExpressionSyntax parentMemberAccess && parentMemberAccess.Name.Identifier.Text == nameof(Task.GetAwaiter);
+
+                if (!asyncAlternativeExists)
+                {
+                    // If we fail to recognize the container, assume it exists since the analyzer thought it would.
+                    var container = memberAccessExpression != null ? semanticModel.GetTypeInfo(memberAccessExpression.Expression, context.CancellationToken).ConvertedType : null;
+                    asyncAlternativeExists = container == null || semanticModel.LookupSymbols(diagnostic.Location.SourceSpan.Start, name: asyncMethodName, container: container, includeReducedExtensionMethods: true).Any();
+                }
+
+                if (asyncAlternativeExists)
+                {
+                    context.RegisterCodeFix(new ReplaceSyncMethodCallWithAwaitAsync(context.Document, diagnostic), diagnostic);
+                }
+            }
         }
 
         /// <inheritdoc />
@@ -79,6 +107,8 @@
             public override string EquivalenceKey => VSTHRD103UseAsyncOptionAnalyzer.Id;
 
             private string AlternativeAsyncMethod => this.diagnostic.Properties[AsyncMethodKeyName];
+
+            private string ExtensionMethodNamespace => this.diagnostic.Properties[ExtensionMethodNamespaceKeyName];
 
             protected override async Task<Solution> GetChangedSolutionAsync(CancellationToken cancellationToken)
             {


### PR DESCRIPTION
This also ensures that code fixes are only offered when the (extension) method that is prescribed as an async substitute is actually available so that the code fix does not lead to a compiler error.

Fixes #287