### PR TITLE
Flag use of JTF.Run in Lazy<T> value factories

### DIFF
--- a/doc/analyzers/VSTHRD011.md
+++ b/doc/analyzers/VSTHRD011.md
@@ -1,14 +1,18 @@
-# VSTHRD011 Avoid using `Lazy<T>` where `T` is `Task<T2>`
+# VSTHRD011 Use `AsyncLazy<T>`
 
 The `Lazy<T>` type executes the value factory just once and
 the value factory inherits the context of the first one to request the
-`Lazy<T>.Value` property's value.
+`Lazy<T>.Value` property's value. This can lead to deadlocks when
+the value factory attempts to switch to the main thread.
+
+## Examples of patterns that are flagged by this analyzer
+
+### Using `Lazy<T>` where `T` is `Task<T2>`
+
 When `T` is `Task<T2>` (because the value factory is an async method),
 if the first caller had no access to the main thread, and the value factory
 requires it, it will block. If later a second caller calls the `Value` property
-and that second caller is blocking the UI thread for its result, it will deadlock. 
-
-## Examples of patterns that are flagged by this analyzer
+and that second caller is blocking the UI thread for its result, it will deadlock.
 
 ```csharp
 var lazy = new Lazy<Task<int>>(async delegate // analyzer flags this line
@@ -20,9 +24,27 @@ var lazy = new Lazy<Task<int>>(async delegate // analyzer flags this line
 int value = await lazy.Value;
 ```
 
+### Using synchronously blocking methods in `Lazy<T>` value factories
+
+When the value factory passed to the `Lazy<T>` constructor calls synchronously
+blocking methods such as `JoinableTaskFactory.Run`, only the first caller
+can help any required transition to the main thread.
+
+```csharp
+var lazy = new Lazy<int>(delegate
+{
+    return joinableTaskFactory.Run(async delegate { // analyzer flags this line
+        int result = await SomeAsyncMethod();
+        return result + 3;
+    });
+});
+
+int value = lazy.Value;
+```
+
 ## Solution
 
-Instead of using `Lazy<Task<T>>` when the value factory is async, use `AsyncLazy<T>`:
+Use `AsyncLazy<T>` with an async value factory:
 
 ```csharp
 var lazy = new AsyncLazy<int>(async delegate

--- a/doc/analyzers/index.md
+++ b/doc/analyzers/index.md
@@ -10,7 +10,7 @@ ID | Title | Severity | Supports
 [VSTHRD003](VSTHRD003.md) | Use JTF.RunAsync to block later | Critical | [3rd rule](../threading_rules.md#Rule3)
 [VSTHRD004](VSTHRD004.md) | Await SwitchToMainThreadAsync | Critical | [1st rule](../threading_rules.md#Rule1)
 [VSTHRD010](VSTHRD010.md) | Invoke single-threaded types on Main thread | Critical | [1st rule](../threading_rules.md#Rule1)
-[VSTHRD011](VSTHRD011.md) | Avoid using `Lazy<T>` where `T` is `Task<T2>` | Critical | [3rd rule](../threading_rules.md#Rule3)
+[VSTHRD011](VSTHRD011.md) | Use `AsyncLazy<T>` | Critical | [3rd rule](../threading_rules.md#Rule3)
 [VSTHRD012](VSTHRD012.md) | Provide JoinableTaskFactory where allowed | Critical | [All rules](../threading_rules.md)
 [VSTHRD100](VSTHRD100.md) | Avoid `async void` methods | Advisory
 [VSTHRD101](VSTHRD101.md) | Avoid unsupported async delegates | Advisory | [VSTHRD100](VSTHRD100.md)

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD011UseAsyncLazyAnalyzerTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD011UseAsyncLazyAnalyzerTests.cs
@@ -6,22 +6,22 @@
     using Xunit;
     using Xunit.Abstractions;
 
-    public class VSTHRD011LazyOfTaskAnalyzerTests : DiagnosticVerifier
+    public class VSTHRD011UseAsyncLazyAnalyzerTests : DiagnosticVerifier
     {
         private DiagnosticResult expect = new DiagnosticResult
         {
-            Id = VSTHRD011LazyOfTaskAnalyzer.Id,
+            Id = VSTHRD011UseAsyncLazyAnalyzer.Id,
             Severity = DiagnosticSeverity.Error,
         };
 
-        public VSTHRD011LazyOfTaskAnalyzerTests(ITestOutputHelper logger)
+        public VSTHRD011UseAsyncLazyAnalyzerTests(ITestOutputHelper logger)
             : base(logger)
         {
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
         {
-            return new VSTHRD011LazyOfTaskAnalyzer();
+            return new VSTHRD011UseAsyncLazyAnalyzer();
         }
 
         [Fact]

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD011UseAsyncLazyAnalyzerTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD011UseAsyncLazyAnalyzerTests.cs
@@ -37,10 +37,8 @@ class Test {
     Lazy<int> tInt = new Lazy<int>();
 }
 ";
-            this.expect.Locations = new[] {
-                new DiagnosticResultLocation("Test0.cs", 6, 25),
-            };
-            this.VerifyCSharpDiagnostic(test, this.expect);
+            var expect = this.CreateDiagnostic(6, 29, 15);
+            this.VerifyCSharpDiagnostic(test, expect);
         }
 
         [Fact]
@@ -54,10 +52,23 @@ class Test {
     Lazy<Task<object>> t3 = new Lazy<Task<object>>();
 }
 ";
-            this.expect.Locations = new[] {
-                new DiagnosticResultLocation("Test0.cs", 6, 29),
-            };
-            this.VerifyCSharpDiagnostic(test, this.expect);
+            var expect = this.CreateDiagnostic(6, 33, 18);
+            this.VerifyCSharpDiagnostic(test, expect);
+        }
+
+        [Fact]
+        public void ReportErrorOnLazyOfTConstructionInFieldNoTypeArg()
+        {
+            var test = @"
+using System;
+using System.Threading.Tasks;
+
+class Test {
+    Lazy<Task> t3 = new Lazy<Task>();
+}
+";
+            var expect = this.CreateDiagnostic(6, 25, 10);
+            this.VerifyCSharpDiagnostic(test, expect);
         }
 
         [Fact]
@@ -113,6 +124,32 @@ class Test {
         }
 
         [Fact]
+        public void JTFRunAsyncInLazyValueFactory_Lambda()
+        {
+            var test = @"
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
+
+class Test {
+    JoinableTaskFactory jtf;
+
+    void Foo() {
+        var t4 = new Lazy<Task<int>>(async () => {
+            await jtf.RunAsync(async delegate {
+                await Task.Yield();
+            });
+
+            return 3;
+        });
+    }
+}
+";
+            var expect = this.CreateDiagnostic(10, 22, 15);
+            this.VerifyCSharpDiagnostic(test, expect);
+        }
+
+        [Fact]
         public void JTFRunInLazyValueFactory_MethodGroup()
         {
             var test = @"
@@ -154,10 +191,8 @@ class Test {
     }
 }
 ";
-            this.expect.Locations = new[] {
-                new DiagnosticResultLocation("Test0.cs", 7, 18),
-            };
-            this.VerifyCSharpDiagnostic(test, this.expect);
+            var expect = this.CreateDiagnostic(7, 22, 18);
+            this.VerifyCSharpDiagnostic(test, expect);
         }
 
         private DiagnosticResult CreateDiagnostic(int line, int column, int length, string messagePattern = null) =>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.cs.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.cs.xlf
@@ -74,8 +74,9 @@ Use AsyncLazy&lt;T&gt; instead.</source>
 Použijte raději AsyncLazy&lt;T&gt;.</target>
         </trans-unit>
         <trans-unit id="VSTHRD011_Title" translate="yes" xml:space="preserve">
-          <source>Avoid using Lazy<it id="1" pos="open">&lt;T&gt;</it> where T is a Task<it id="2" pos="open">&lt;T2&gt;</it></source>
-          <target state="translated">Vyhněte se použití Lazy<it id="1" pos="open">&lt;T&gt;</it>, kde T označuje Task<it id="2" pos="open">&lt;T2&gt;</it></target>
+          <source>Use AsyncLazy<it id="1" pos="open">&lt;T&gt;</it></source>
+          <target state="needs-review-translation">Vyhněte se použití Lazy<it id="1" pos="open">&lt;T&gt;</it>, kde T označuje Task<it id="2" pos="open">&lt;T2&gt;</it></target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="VSTHRD103_MessageFormat" translate="yes" xml:space="preserve">
           <source>{0} synchronously blocks. Await {1} instead.</source>
@@ -210,6 +211,12 @@ Použijte raději AsyncLazy&lt;T&gt;.</target>
         <trans-unit id="VSTHRD110_Title" translate="yes" xml:space="preserve">
           <source>Observe result of async calls</source>
           <target state="new">Observe result of async calls</target>
+        </trans-unit>
+        <trans-unit id="VSTHRD011b_MessageFormat" translate="yes" xml:space="preserve">
+          <source>Invoking or blocking on async code in a Lazy<it id="1" pos="open">&lt;T&gt;</it> value factory can deadlock.
+Use AsyncLazy<it id="2" pos="open">&lt;T&gt;</it> instead.</source>
+          <target state="new">Invoking or blocking on async code in a Lazy<it id="1" pos="open">&lt;T&gt;</it> value factory can deadlock.
+Use AsyncLazy<it id="2" pos="open">&lt;T&gt;</it> instead.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.de.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.de.xlf
@@ -74,8 +74,9 @@ Use AsyncLazy&lt;T&gt; instead.</source>
 Verwenden Sie stattdessen AsyncLazy&lt;T&gt;.</target>
         </trans-unit>
         <trans-unit id="VSTHRD011_Title" translate="yes" xml:space="preserve">
-          <source>Avoid using Lazy<it id="1" pos="open">&lt;T&gt;</it> where T is a Task<it id="2" pos="open">&lt;T2&gt;</it></source>
-          <target state="translated">Die Verwendung von Lazy<it id="1" pos="open">&lt;T&gt;</it> vermeiden, wenn T ein Task<it id="2" pos="open">&lt;T2&gt;</it> ist</target>
+          <source>Use AsyncLazy<it id="1" pos="open">&lt;T&gt;</it></source>
+          <target state="needs-review-translation">Die Verwendung von Lazy<it id="1" pos="open">&lt;T&gt;</it> vermeiden, wenn T ein Task<it id="2" pos="open">&lt;T2&gt;</it> ist</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="VSTHRD103_MessageFormat" translate="yes" xml:space="preserve">
           <source>{0} synchronously blocks. Await {1} instead.</source>
@@ -210,6 +211,12 @@ Verwenden Sie stattdessen AsyncLazy&lt;T&gt;.</target>
         <trans-unit id="VSTHRD110_Title" translate="yes" xml:space="preserve">
           <source>Observe result of async calls</source>
           <target state="new">Observe result of async calls</target>
+        </trans-unit>
+        <trans-unit id="VSTHRD011b_MessageFormat" translate="yes" xml:space="preserve">
+          <source>Invoking or blocking on async code in a Lazy<it id="1" pos="open">&lt;T&gt;</it> value factory can deadlock.
+Use AsyncLazy<it id="2" pos="open">&lt;T&gt;</it> instead.</source>
+          <target state="new">Invoking or blocking on async code in a Lazy<it id="1" pos="open">&lt;T&gt;</it> value factory can deadlock.
+Use AsyncLazy<it id="2" pos="open">&lt;T&gt;</it> instead.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.es.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.es.xlf
@@ -74,8 +74,9 @@ Use AsyncLazy&lt;T&gt; instead.</source>
 Use AsyncLazy&lt;T&gt; en su lugar.</target>
         </trans-unit>
         <trans-unit id="VSTHRD011_Title" translate="yes" xml:space="preserve">
-          <source>Avoid using Lazy<it id="1" pos="open">&lt;T&gt;</it> where T is a Task<it id="2" pos="open">&lt;T2&gt;</it></source>
-          <target state="translated">Evite el uso de Lazy<it id="1" pos="open">&lt;T&gt;</it> donde T es Task<it id="2" pos="open">&lt;T2&gt;</it></target>
+          <source>Use AsyncLazy<it id="1" pos="open">&lt;T&gt;</it></source>
+          <target state="needs-review-translation">Evite el uso de Lazy<it id="1" pos="open">&lt;T&gt;</it> donde T es Task<it id="2" pos="open">&lt;T2&gt;</it></target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="VSTHRD103_MessageFormat" translate="yes" xml:space="preserve">
           <source>{0} synchronously blocks. Await {1} instead.</source>
@@ -210,6 +211,12 @@ Use AsyncLazy&lt;T&gt; en su lugar.</target>
         <trans-unit id="VSTHRD110_Title" translate="yes" xml:space="preserve">
           <source>Observe result of async calls</source>
           <target state="new">Observe result of async calls</target>
+        </trans-unit>
+        <trans-unit id="VSTHRD011b_MessageFormat" translate="yes" xml:space="preserve">
+          <source>Invoking or blocking on async code in a Lazy<it id="1" pos="open">&lt;T&gt;</it> value factory can deadlock.
+Use AsyncLazy<it id="2" pos="open">&lt;T&gt;</it> instead.</source>
+          <target state="new">Invoking or blocking on async code in a Lazy<it id="1" pos="open">&lt;T&gt;</it> value factory can deadlock.
+Use AsyncLazy<it id="2" pos="open">&lt;T&gt;</it> instead.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.fr.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.fr.xlf
@@ -74,8 +74,9 @@ Use AsyncLazy&lt;T&gt; instead.</source>
 Utilisez AsyncLazy&lt;T&gt; à la place</target>
         </trans-unit>
         <trans-unit id="VSTHRD011_Title" translate="yes" xml:space="preserve">
-          <source>Avoid using Lazy<it id="1" pos="open">&lt;T&gt;</it> where T is a Task<it id="2" pos="open">&lt;T2&gt;</it></source>
-          <target state="translated">Éviter d’utiliser Lazy<it id="1" pos="open">&lt;T&gt;</it> si T est une tâche<it id="2" pos="open">&lt;T2&gt;</it></target>
+          <source>Use AsyncLazy<it id="1" pos="open">&lt;T&gt;</it></source>
+          <target state="needs-review-translation">Éviter d’utiliser Lazy<it id="1" pos="open">&lt;T&gt;</it> si T est une tâche<it id="2" pos="open">&lt;T2&gt;</it></target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="VSTHRD103_MessageFormat" translate="yes" xml:space="preserve">
           <source>{0} synchronously blocks. Await {1} instead.</source>
@@ -210,6 +211,12 @@ Utilisez AsyncLazy&lt;T&gt; à la place</target>
         <trans-unit id="VSTHRD110_Title" translate="yes" xml:space="preserve">
           <source>Observe result of async calls</source>
           <target state="new">Observe result of async calls</target>
+        </trans-unit>
+        <trans-unit id="VSTHRD011b_MessageFormat" translate="yes" xml:space="preserve">
+          <source>Invoking or blocking on async code in a Lazy<it id="1" pos="open">&lt;T&gt;</it> value factory can deadlock.
+Use AsyncLazy<it id="2" pos="open">&lt;T&gt;</it> instead.</source>
+          <target state="new">Invoking or blocking on async code in a Lazy<it id="1" pos="open">&lt;T&gt;</it> value factory can deadlock.
+Use AsyncLazy<it id="2" pos="open">&lt;T&gt;</it> instead.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.it.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.it.xlf
@@ -74,8 +74,9 @@ Use AsyncLazy&lt;T&gt; instead.</source>
 In alternativa, usare AsyncLazy&lt;T&gt;.</target>
         </trans-unit>
         <trans-unit id="VSTHRD011_Title" translate="yes" xml:space="preserve">
-          <source>Avoid using Lazy<it id="1" pos="open">&lt;T&gt;</it> where T is a Task<it id="2" pos="open">&lt;T2&gt;</it></source>
-          <target state="translated">Evitare di usare Lazy<it id="1" pos="open">&lt;T&gt;</it> in cui T è un elemento Task<it id="2" pos="open">&lt;T2&gt;</it></target>
+          <source>Use AsyncLazy<it id="1" pos="open">&lt;T&gt;</it></source>
+          <target state="needs-review-translation">Evitare di usare Lazy<it id="1" pos="open">&lt;T&gt;</it> in cui T è un elemento Task<it id="2" pos="open">&lt;T2&gt;</it></target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="VSTHRD103_MessageFormat" translate="yes" xml:space="preserve">
           <source>{0} synchronously blocks. Await {1} instead.</source>
@@ -210,6 +211,12 @@ In alternativa, usare AsyncLazy&lt;T&gt;.</target>
         <trans-unit id="VSTHRD110_Title" translate="yes" xml:space="preserve">
           <source>Observe result of async calls</source>
           <target state="new">Observe result of async calls</target>
+        </trans-unit>
+        <trans-unit id="VSTHRD011b_MessageFormat" translate="yes" xml:space="preserve">
+          <source>Invoking or blocking on async code in a Lazy<it id="1" pos="open">&lt;T&gt;</it> value factory can deadlock.
+Use AsyncLazy<it id="2" pos="open">&lt;T&gt;</it> instead.</source>
+          <target state="new">Invoking or blocking on async code in a Lazy<it id="1" pos="open">&lt;T&gt;</it> value factory can deadlock.
+Use AsyncLazy<it id="2" pos="open">&lt;T&gt;</it> instead.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.ja.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.ja.xlf
@@ -74,8 +74,9 @@ Use AsyncLazy&lt;T&gt; instead.</source>
 代わりに AsyncLazy&lt;T&gt; を使用します。</target>
         </trans-unit>
         <trans-unit id="VSTHRD011_Title" translate="yes" xml:space="preserve">
-          <source>Avoid using Lazy<it id="1" pos="open">&lt;T&gt;</it> where T is a Task<it id="2" pos="open">&lt;T2&gt;</it></source>
-          <target state="translated">T が Task<it id="2" pos="open">&lt;T2&gt;</it> を表す Lazy<it id="1" pos="open">&lt;T&gt;</it> を使用しない</target>
+          <source>Use AsyncLazy<it id="1" pos="open">&lt;T&gt;</it></source>
+          <target state="needs-review-translation">T が Task<it id="2" pos="open">&lt;T2&gt;</it> を表す Lazy<it id="1" pos="open">&lt;T&gt;</it> を使用しない</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="VSTHRD103_MessageFormat" translate="yes" xml:space="preserve">
           <source>{0} synchronously blocks. Await {1} instead.</source>
@@ -210,6 +211,12 @@ Use AsyncLazy&lt;T&gt; instead.</source>
         <trans-unit id="VSTHRD110_Title" translate="yes" xml:space="preserve">
           <source>Observe result of async calls</source>
           <target state="new">Observe result of async calls</target>
+        </trans-unit>
+        <trans-unit id="VSTHRD011b_MessageFormat" translate="yes" xml:space="preserve">
+          <source>Invoking or blocking on async code in a Lazy<it id="1" pos="open">&lt;T&gt;</it> value factory can deadlock.
+Use AsyncLazy<it id="2" pos="open">&lt;T&gt;</it> instead.</source>
+          <target state="new">Invoking or blocking on async code in a Lazy<it id="1" pos="open">&lt;T&gt;</it> value factory can deadlock.
+Use AsyncLazy<it id="2" pos="open">&lt;T&gt;</it> instead.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.ko.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.ko.xlf
@@ -79,8 +79,9 @@ Use AsyncLazy&lt;T&gt; instead.</source>
 대신 AsyncLazy&lt;T&gt;를 사용하세요.</target>
         </trans-unit>
         <trans-unit id="VSTHRD011_Title" translate="yes" xml:space="preserve">
-          <source>Avoid using Lazy<it id="1" pos="open">&lt;T&gt;</it> where T is a Task<it id="2" pos="open">&lt;T2&gt;</it></source>
-          <target state="translated"><it id="1" pos="open">&lt;T&gt;</it>T가 Task인 경우 Lazy를 사용하지 않습니다.<it id="2" pos="open">&lt;T2&gt;</it></target>
+          <source>Use AsyncLazy<it id="1" pos="open">&lt;T&gt;</it></source>
+          <target state="needs-review-translation"><it id="1" pos="open">&lt;T&gt;</it>T가 Task인 경우 Lazy를 사용하지 않습니다.<it id="2" pos="open">&lt;T2&gt;</it></target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="VSTHRD103_MessageFormat" translate="yes" xml:space="preserve">
           <source>{0} synchronously blocks. Await {1} instead.</source>
@@ -210,6 +211,12 @@ Use AsyncLazy&lt;T&gt; instead.</source>
         <trans-unit id="VSTHRD110_Title" translate="yes" xml:space="preserve">
           <source>Observe result of async calls</source>
           <target state="new">Observe result of async calls</target>
+        </trans-unit>
+        <trans-unit id="VSTHRD011b_MessageFormat" translate="yes" xml:space="preserve">
+          <source>Invoking or blocking on async code in a Lazy<it id="1" pos="open">&lt;T&gt;</it> value factory can deadlock.
+Use AsyncLazy<it id="2" pos="open">&lt;T&gt;</it> instead.</source>
+          <target state="new">Invoking or blocking on async code in a Lazy<it id="1" pos="open">&lt;T&gt;</it> value factory can deadlock.
+Use AsyncLazy<it id="2" pos="open">&lt;T&gt;</it> instead.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.pl.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.pl.xlf
@@ -74,8 +74,9 @@ Use AsyncLazy&lt;T&gt; instead.</source>
 Zamiast tego używaj klasy AsyncLazy&lt;T&gt;.</target>
         </trans-unit>
         <trans-unit id="VSTHRD011_Title" translate="yes" xml:space="preserve">
-          <source>Avoid using Lazy<it id="1" pos="open">&lt;T&gt;</it> where T is a Task<it id="2" pos="open">&lt;T2&gt;</it></source>
-          <target state="translated">Unikaj używania klasy Lazy<it id="1" pos="open">&lt;T&gt;</it>, jeśli T jest obiektem Task<it id="2" pos="open">&lt;T2&gt;</it></target>
+          <source>Use AsyncLazy<it id="1" pos="open">&lt;T&gt;</it></source>
+          <target state="needs-review-translation">Unikaj używania klasy Lazy<it id="1" pos="open">&lt;T&gt;</it>, jeśli T jest obiektem Task<it id="2" pos="open">&lt;T2&gt;</it></target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="VSTHRD103_MessageFormat" translate="yes" xml:space="preserve">
           <source>{0} synchronously blocks. Await {1} instead.</source>
@@ -210,6 +211,12 @@ Zamiast tego używaj klasy AsyncLazy&lt;T&gt;.</target>
         <trans-unit id="VSTHRD110_Title" translate="yes" xml:space="preserve">
           <source>Observe result of async calls</source>
           <target state="new">Observe result of async calls</target>
+        </trans-unit>
+        <trans-unit id="VSTHRD011b_MessageFormat" translate="yes" xml:space="preserve">
+          <source>Invoking or blocking on async code in a Lazy<it id="1" pos="open">&lt;T&gt;</it> value factory can deadlock.
+Use AsyncLazy<it id="2" pos="open">&lt;T&gt;</it> instead.</source>
+          <target state="new">Invoking or blocking on async code in a Lazy<it id="1" pos="open">&lt;T&gt;</it> value factory can deadlock.
+Use AsyncLazy<it id="2" pos="open">&lt;T&gt;</it> instead.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.pt-BR.xlf
@@ -74,8 +74,9 @@ Use AsyncLazy&lt;T&gt; instead.</source>
 Em vez disso, use AsyncLazy&lt;T&gt;.</target>
         </trans-unit>
         <trans-unit id="VSTHRD011_Title" translate="yes" xml:space="preserve">
-          <source>Avoid using Lazy<it id="1" pos="open">&lt;T&gt;</it> where T is a Task<it id="2" pos="open">&lt;T2&gt;</it></source>
-          <target state="translated">Evite usar Lazy<it id="1" pos="open">&lt;T&gt;</it>, no qual T é uma Task<it id="2" pos="open">&lt;T2&gt;</it></target>
+          <source>Use AsyncLazy<it id="1" pos="open">&lt;T&gt;</it></source>
+          <target state="needs-review-translation">Evite usar Lazy<it id="1" pos="open">&lt;T&gt;</it>, no qual T é uma Task<it id="2" pos="open">&lt;T2&gt;</it></target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="VSTHRD103_MessageFormat" translate="yes" xml:space="preserve">
           <source>{0} synchronously blocks. Await {1} instead.</source>
@@ -210,6 +211,12 @@ Em vez disso, use AsyncLazy&lt;T&gt;.</target>
         <trans-unit id="VSTHRD110_Title" translate="yes" xml:space="preserve">
           <source>Observe result of async calls</source>
           <target state="new">Observe result of async calls</target>
+        </trans-unit>
+        <trans-unit id="VSTHRD011b_MessageFormat" translate="yes" xml:space="preserve">
+          <source>Invoking or blocking on async code in a Lazy<it id="1" pos="open">&lt;T&gt;</it> value factory can deadlock.
+Use AsyncLazy<it id="2" pos="open">&lt;T&gt;</it> instead.</source>
+          <target state="new">Invoking or blocking on async code in a Lazy<it id="1" pos="open">&lt;T&gt;</it> value factory can deadlock.
+Use AsyncLazy<it id="2" pos="open">&lt;T&gt;</it> instead.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.ru.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.ru.xlf
@@ -74,8 +74,9 @@ Use AsyncLazy&lt;T&gt; instead.</source>
 Вместо этого используйте AsyncLazy&lt;T&gt;.</target>
         </trans-unit>
         <trans-unit id="VSTHRD011_Title" translate="yes" xml:space="preserve">
-          <source>Avoid using Lazy<it id="1" pos="open">&lt;T&gt;</it> where T is a Task<it id="2" pos="open">&lt;T2&gt;</it></source>
-          <target state="translated">Не используйте Lazy<it id="1" pos="open">&lt;T&gt;</it>, где T — объект Task<it id="2" pos="open">&lt;T2&gt;</it></target>
+          <source>Use AsyncLazy<it id="1" pos="open">&lt;T&gt;</it></source>
+          <target state="needs-review-translation">Не используйте Lazy<it id="1" pos="open">&lt;T&gt;</it>, где T — объект Task<it id="2" pos="open">&lt;T2&gt;</it></target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="VSTHRD103_MessageFormat" translate="yes" xml:space="preserve">
           <source>{0} synchronously blocks. Await {1} instead.</source>
@@ -210,6 +211,12 @@ Use AsyncLazy&lt;T&gt; instead.</source>
         <trans-unit id="VSTHRD110_Title" translate="yes" xml:space="preserve">
           <source>Observe result of async calls</source>
           <target state="new">Observe result of async calls</target>
+        </trans-unit>
+        <trans-unit id="VSTHRD011b_MessageFormat" translate="yes" xml:space="preserve">
+          <source>Invoking or blocking on async code in a Lazy<it id="1" pos="open">&lt;T&gt;</it> value factory can deadlock.
+Use AsyncLazy<it id="2" pos="open">&lt;T&gt;</it> instead.</source>
+          <target state="new">Invoking or blocking on async code in a Lazy<it id="1" pos="open">&lt;T&gt;</it> value factory can deadlock.
+Use AsyncLazy<it id="2" pos="open">&lt;T&gt;</it> instead.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.tr.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.tr.xlf
@@ -74,8 +74,9 @@ Use AsyncLazy&lt;T&gt; instead.</source>
 Bunun yerine AsyncLazy&lt;T&gt; kullanın.</target>
         </trans-unit>
         <trans-unit id="VSTHRD011_Title" translate="yes" xml:space="preserve">
-          <source>Avoid using Lazy<it id="1" pos="open">&lt;T&gt;</it> where T is a Task<it id="2" pos="open">&lt;T2&gt;</it></source>
-          <target state="translated">T’nin Task<it id="1" pos="open">&lt;T&gt;</it> olduğu durumlarda Lazy<it id="2" pos="open">&lt;T2&gt;</it> kullanmayın.</target>
+          <source>Use AsyncLazy<it id="1" pos="open">&lt;T&gt;</it></source>
+          <target state="needs-review-translation">T’nin Task<it id="1" pos="open">&lt;T&gt;</it> olduğu durumlarda Lazy<it id="2" pos="open">&lt;T2&gt;</it> kullanmayın.</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="VSTHRD103_MessageFormat" translate="yes" xml:space="preserve">
           <source>{0} synchronously blocks. Await {1} instead.</source>
@@ -210,6 +211,12 @@ Bunun yerine AsyncLazy&lt;T&gt; kullanın.</target>
         <trans-unit id="VSTHRD110_Title" translate="yes" xml:space="preserve">
           <source>Observe result of async calls</source>
           <target state="new">Observe result of async calls</target>
+        </trans-unit>
+        <trans-unit id="VSTHRD011b_MessageFormat" translate="yes" xml:space="preserve">
+          <source>Invoking or blocking on async code in a Lazy<it id="1" pos="open">&lt;T&gt;</it> value factory can deadlock.
+Use AsyncLazy<it id="2" pos="open">&lt;T&gt;</it> instead.</source>
+          <target state="new">Invoking or blocking on async code in a Lazy<it id="1" pos="open">&lt;T&gt;</it> value factory can deadlock.
+Use AsyncLazy<it id="2" pos="open">&lt;T&gt;</it> instead.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.zh-Hans.xlf
@@ -74,8 +74,9 @@ Use AsyncLazy&lt;T&gt; instead.</source>
 改用 AsyncLazy&lt;T&gt;。</target>
         </trans-unit>
         <trans-unit id="VSTHRD011_Title" translate="yes" xml:space="preserve">
-          <source>Avoid using Lazy<it id="1" pos="open">&lt;T&gt;</it> where T is a Task<it id="2" pos="open">&lt;T2&gt;</it></source>
-          <target state="translated">当 T 为 Task<it id="2" pos="open">&lt;T2&gt;</it> 时，避免使用 Lazy<it id="1" pos="open">&lt;T&gt;</it></target>
+          <source>Use AsyncLazy<it id="1" pos="open">&lt;T&gt;</it></source>
+          <target state="needs-review-translation">当 T 为 Task<it id="2" pos="open">&lt;T2&gt;</it> 时，避免使用 Lazy<it id="1" pos="open">&lt;T&gt;</it></target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="VSTHRD103_MessageFormat" translate="yes" xml:space="preserve">
           <source>{0} synchronously blocks. Await {1} instead.</source>
@@ -210,6 +211,12 @@ Use AsyncLazy&lt;T&gt; instead.</source>
         <trans-unit id="VSTHRD110_Title" translate="yes" xml:space="preserve">
           <source>Observe result of async calls</source>
           <target state="new">Observe result of async calls</target>
+        </trans-unit>
+        <trans-unit id="VSTHRD011b_MessageFormat" translate="yes" xml:space="preserve">
+          <source>Invoking or blocking on async code in a Lazy<it id="1" pos="open">&lt;T&gt;</it> value factory can deadlock.
+Use AsyncLazy<it id="2" pos="open">&lt;T&gt;</it> instead.</source>
+          <target state="new">Invoking or blocking on async code in a Lazy<it id="1" pos="open">&lt;T&gt;</it> value factory can deadlock.
+Use AsyncLazy<it id="2" pos="open">&lt;T&gt;</it> instead.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/MultilingualResources/Microsoft.VisualStudio.Threading.Analyzers.zh-Hant.xlf
@@ -74,8 +74,9 @@ Use AsyncLazy&lt;T&gt; instead.</source>
 請改用 AsyncLazy&lt;T&gt;。</target>
         </trans-unit>
         <trans-unit id="VSTHRD011_Title" translate="yes" xml:space="preserve">
-          <source>Avoid using Lazy<it id="1" pos="open">&lt;T&gt;</it> where T is a Task<it id="2" pos="open">&lt;T2&gt;</it></source>
-          <target state="translated">避免在 T 為 Task<it id="2" pos="open">&lt;T2&gt;</it> 時使用 Lazy<it id="1" pos="open">&lt;T&gt;</it></target>
+          <source>Use AsyncLazy<it id="1" pos="open">&lt;T&gt;</it></source>
+          <target state="needs-review-translation">避免在 T 為 Task<it id="2" pos="open">&lt;T2&gt;</it> 時使用 Lazy<it id="1" pos="open">&lt;T&gt;</it></target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="VSTHRD103_MessageFormat" translate="yes" xml:space="preserve">
           <source>{0} synchronously blocks. Await {1} instead.</source>
@@ -210,6 +211,12 @@ Use AsyncLazy&lt;T&gt; instead.</source>
         <trans-unit id="VSTHRD110_Title" translate="yes" xml:space="preserve">
           <source>Observe result of async calls</source>
           <target state="new">Observe result of async calls</target>
+        </trans-unit>
+        <trans-unit id="VSTHRD011b_MessageFormat" translate="yes" xml:space="preserve">
+          <source>Invoking or blocking on async code in a Lazy<it id="1" pos="open">&lt;T&gt;</it> value factory can deadlock.
+Use AsyncLazy<it id="2" pos="open">&lt;T&gt;</it> instead.</source>
+          <target state="new">Invoking or blocking on async code in a Lazy<it id="1" pos="open">&lt;T&gt;</it> value factory can deadlock.
+Use AsyncLazy<it id="2" pos="open">&lt;T&gt;</it> instead.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.Designer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.Designer.cs
@@ -199,11 +199,21 @@ namespace Microsoft.VisualStudio.Threading.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Avoid using Lazy&lt;T&gt; where T is a Task&lt;T2&gt;.
+        ///   Looks up a localized string similar to Use AsyncLazy&lt;T&gt;.
         /// </summary>
         internal static string VSTHRD011_Title {
             get {
                 return ResourceManager.GetString("VSTHRD011_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invoking or blocking on async code in a Lazy&lt;T&gt; value factory can deadlock.
+        ///Use AsyncLazy&lt;T&gt; instead..
+        /// </summary>
+        internal static string VSTHRD011b_MessageFormat {
+            get {
+                return ResourceManager.GetString("VSTHRD011b_MessageFormat", resourceCulture);
             }
         }
         

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.resx
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.resx
@@ -172,12 +172,16 @@ You can avoid this problem by ensuring the task is initialized within the delega
   <data name="VSTHRD003_Title" xml:space="preserve">
     <value>Avoid awaiting non-joinable tasks in join contexts</value>
   </data>
+  <data name="VSTHRD011b_MessageFormat" xml:space="preserve">
+    <value>Invoking or blocking on async code in a Lazy&lt;T&gt; value factory can deadlock.
+Use AsyncLazy&lt;T&gt; instead.</value>
+  </data>
   <data name="VSTHRD011_MessageFormat" xml:space="preserve">
     <value>Lazy&lt;Task&lt;T&gt;&gt;.Value can deadlock.
 Use AsyncLazy&lt;T&gt; instead.</value>
   </data>
   <data name="VSTHRD011_Title" xml:space="preserve">
-    <value>Avoid using Lazy&lt;T&gt; where T is a Task&lt;T2&gt;</value>
+    <value>Use AsyncLazy&lt;T&gt;</value>
   </data>
   <data name="VSTHRD103_MessageFormat" xml:space="preserve">
     <value>{0} synchronously blocks. Await {1} instead.</value>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD011UseAsyncLazyAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD011UseAsyncLazyAnalyzer.cs
@@ -16,7 +16,7 @@
     {
         public const string Id = "VSTHRD011";
 
-        internal static readonly DiagnosticDescriptor Descriptor = new DiagnosticDescriptor(
+        internal static readonly DiagnosticDescriptor LazyOfTaskDescriptor = new DiagnosticDescriptor(
             id: Id,
             title: Strings.VSTHRD011_Title,
             messageFormat: Strings.VSTHRD011_MessageFormat,
@@ -25,10 +25,19 @@
             defaultSeverity: DiagnosticSeverity.Error,
             isEnabledByDefault: true);
 
+        internal static readonly DiagnosticDescriptor SyncBlockInValueFactoryDescriptor = new DiagnosticDescriptor(
+            id: Id,
+            title: Strings.VSTHRD011_Title,
+            messageFormat: Strings.VSTHRD011b_MessageFormat,
+            helpLinkUri: Utils.GetHelpLink(Id),
+            category: "Usage",
+            defaultSeverity: DiagnosticSeverity.Error,
+            isEnabledByDefault: true);
+
         /// <inheritdoc />
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
         {
-            get { return ImmutableArray.Create(Descriptor); }
+            get { return ImmutableArray.Create(LazyOfTaskDescriptor, SyncBlockInValueFactoryDescriptor); }
         }
 
         /// <inheritdoc />
@@ -44,7 +53,8 @@
 
         private void AnalyzeNode(SyntaxNodeAnalysisContext context)
         {
-            var methodSymbol = context.SemanticModel.GetSymbolInfo(context.Node).Symbol as IMethodSymbol;
+            var objectCreationSyntax = (ObjectCreationExpressionSyntax)context.Node;
+            var methodSymbol = context.SemanticModel.GetSymbolInfo(objectCreationSyntax).Symbol as IMethodSymbol;
             var constructedType = methodSymbol?.ReceiverType as INamedTypeSymbol;
             var isLazyOfT = constructedType?.ContainingNamespace?.Name == nameof(System)
                 && (constructedType?.ContainingNamespace?.ContainingNamespace?.IsGlobalNamespace ?? false)
@@ -57,7 +67,23 @@
                     && typeArg.BelongsToNamespace(Namespaces.SystemThreadingTasks);
                 if (typeArgIsTask)
                 {
-                    context.ReportDiagnostic(Diagnostic.Create(Descriptor, context.Node.GetLocation()));
+                    context.ReportDiagnostic(Diagnostic.Create(LazyOfTaskDescriptor, objectCreationSyntax.GetLocation()));
+                }
+                else
+                {
+                    var firstArgExpression = objectCreationSyntax.ArgumentList.Arguments.FirstOrDefault()?.Expression;
+                    if (firstArgExpression is AnonymousFunctionExpressionSyntax anonFunc)
+                    {
+                        var problems = from invocation in anonFunc.DescendantNodes().OfType<InvocationExpressionSyntax>()
+                                       let invokedSymbol = context.SemanticModel.GetSymbolInfo(invocation.Expression).Symbol
+                                       where invokedSymbol != null && CommonInterest.SyncBlockingMethods.Any(m => m.Method.IsMatch(invokedSymbol))
+                                       select invocation.Expression;
+                        var firstProblem = problems.FirstOrDefault();
+                        if (firstProblem != null)
+                        {
+                            context.ReportDiagnostic(Diagnostic.Create(SyncBlockInValueFactoryDescriptor, firstProblem.GetLocation()));
+                        }
+                    }
                 }
             }
         }

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD011UseAsyncLazyAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD011UseAsyncLazyAnalyzer.cs
@@ -67,7 +67,7 @@
                     && typeArg.BelongsToNamespace(Namespaces.SystemThreadingTasks);
                 if (typeArgIsTask)
                 {
-                    context.ReportDiagnostic(Diagnostic.Create(LazyOfTaskDescriptor, objectCreationSyntax.GetLocation()));
+                    context.ReportDiagnostic(Diagnostic.Create(LazyOfTaskDescriptor, objectCreationSyntax.Type.GetLocation()));
                 }
                 else
                 {

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD011UseAsyncLazyAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD011UseAsyncLazyAnalyzer.cs
@@ -12,7 +12,7 @@
     using Microsoft.CodeAnalysis.Diagnostics;
 
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class VSTHRD011LazyOfTaskAnalyzer : DiagnosticAnalyzer
+    public class VSTHRD011UseAsyncLazyAnalyzer : DiagnosticAnalyzer
     {
         public const string Id = "VSTHRD011";
 

--- a/src/Microsoft.VisualStudio.Threading/Microsoft.VisualStudio.Threading.csproj
+++ b/src/Microsoft.VisualStudio.Threading/Microsoft.VisualStudio.Threading.csproj
@@ -55,6 +55,8 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <!-- Reference directly to use 4.3.1 and suppress package restore warnings. https://github.com/dotnet/corefx/issues/29907 -->
+    <PackageReference Include="runtime.native.System.IO.Compression" Version="4.3.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Validation" Version="15.3.15" />
     <PackageReference Include="MicroBuild.VisualStudio" Version="$(MicroBuildVersion)" PrivateAssets="all" />
     <PackageReference Include="MSBuild.SDK.Extras" Version="1.0.6" PrivateAssets="all" />


### PR DESCRIPTION
VSTHRD011 previously would flag `Lazy<Task<T>>` as a deadlock prone pattern, prescribing `AsyncLazy<T>` instead. But some equivalent problems were instead expressed as `Lazy<T>` with a value factory that synchronously blocked using JTF.Run.

This PR expands `VSTHRD011` to report diagnostics on the case of using JTF.Run in the value factory as well so we can avoid deadlocks in more cases.

```csharp
var lazy = new Lazy<int>(delegate
{
    return joinableTaskFactory.Run(async delegate { // analyzer flags this line
        int result = await SomeAsyncMethod();
        return result + 3;
    });
});

int value = lazy.Value;
```

Closes #253