### PR TITLE
Add JTF-aware ReentrantSemaphore class

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,6 +3,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)..\obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
     <BaseOutputPath Condition=" '$(BaseOutputPath)' == '' ">$(MSBuildThisFileDirectory)..\bin\$(MSBuildProjectName)\</BaseOutputPath>
+    <LangVersion>7.3</LangVersion>
 
     <MicroBuildVersion>2.0.54</MicroBuildVersion>
   </PropertyGroup>

--- a/src/Microsoft.VisualStudio.Threading.Tests/ReentrantSemaphoreJTFTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/ReentrantSemaphoreJTFTests.cs
@@ -70,7 +70,7 @@
                 }
             }
 
-            return new ReentrantSemaphore(initialCount, this.joinableTaskContext, mode);
+            return ReentrantSemaphore.Create(initialCount, this.joinableTaskContext, mode);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.Threading.Tests/ReentrantSemaphoreJTFTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/ReentrantSemaphoreJTFTests.cs
@@ -23,23 +23,23 @@ public class ReentrantSemaphoreJTFTests : ReentrantSemaphoreTestBase
     public void SemaphoreWaiterJoinsSemaphoreHolders(ReentrantSemaphore.ReentrancyMode mode)
     {
         this.semaphore = this.CreateSemaphore(mode);
-        var firstEntered = new AsyncManualResetEvent();
-        bool firstOperationReachedMainThread = false;
-        var firstOperation = Task.Run(async delegate
-        {
-            await this.semaphore.ExecuteAsync(
-                async delegate
-                {
-                    firstEntered.Set();
-                    await this.joinableTaskContext.Factory.SwitchToMainThreadAsync(this.TimeoutToken);
-                    firstOperationReachedMainThread = true;
-                },
-                this.TimeoutToken);
-        });
-
-        bool secondEntryComplete = false;
         this.ExecuteOnDispatcher(async delegate
         {
+            var firstEntered = new AsyncManualResetEvent();
+            bool firstOperationReachedMainThread = false;
+            var firstOperation = Task.Run(async delegate
+            {
+                await this.semaphore.ExecuteAsync(
+                    async delegate
+                    {
+                        firstEntered.Set();
+                        await this.joinableTaskContext.Factory.SwitchToMainThreadAsync(this.TimeoutToken);
+                        firstOperationReachedMainThread = true;
+                    },
+                    this.TimeoutToken);
+            });
+
+            bool secondEntryComplete = false;
             this.joinableTaskContext.Factory.Run(async delegate
             {
                 await firstEntered.WaitAsync().WithCancellation(this.TimeoutToken);

--- a/src/Microsoft.VisualStudio.Threading.Tests/ReentrantSemaphoreJTFTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/ReentrantSemaphoreJTFTests.cs
@@ -1,0 +1,69 @@
+﻿namespace Microsoft.VisualStudio.Threading.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Xunit;
+    using Xunit.Abstractions;
+
+    public class ReentrantSemaphoreJTFTests : ReentrantSemaphoreTestBase
+    {
+        private readonly JoinableTaskContext joinableTaskContext;
+
+        public ReentrantSemaphoreJTFTests(ITestOutputHelper logger)
+            : base(logger)
+        {
+            using (this.Dispatcher.Apply())
+            {
+                this.joinableTaskContext = new JoinableTaskContext();
+            }
+
+            this.semaphore = new ReentrantSemaphore(joinableTaskContext: this.joinableTaskContext);
+        }
+
+        [Fact]
+        public void SemaphoreWaiterJoinsSemaphoreHolders()
+        {
+            var firstEntered = new AsyncManualResetEvent();
+            bool firstOperationReachedMainThread = false;
+            var firstOperation = Task.Run(async delegate
+            {
+                await this.semaphore.ExecuteAsync(
+                    async delegate
+                    {
+                        firstEntered.Set();
+                        await this.joinableTaskContext.Factory.SwitchToMainThreadAsync(this.TimeoutToken);
+                        firstOperationReachedMainThread = true;
+                    },
+                    this.TimeoutToken);
+            });
+
+            bool secondEntryComplete = false;
+            this.ExecuteOnDispatcher(async delegate
+            {
+                this.joinableTaskContext.Factory.Run(async delegate
+                {
+                    await firstEntered.WaitAsync().WithCancellation(this.TimeoutToken);
+                    Assumes.False(firstOperationReachedMainThread);
+
+                    // While blocking the main thread, request the semaphore.
+                    // This should NOT deadlock if the semaphore properly Joins the existing semaphore holder(s),
+                    // allowing them to get to the UI thread and then finally to exit the semaphore so we can enter it.
+                    await this.semaphore.ExecuteAsync(
+                        delegate
+                        {
+                            secondEntryComplete = true;
+                            Assert.True(firstOperationReachedMainThread);
+                            return TplExtensions.CompletedTask;
+                        },
+                        this.TimeoutToken);
+                });
+                await Task.WhenAll(firstOperation).WithCancellation(this.TimeoutToken);
+                Assert.True(secondEntryComplete);
+            });
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Threading.Tests/ReentrantSemaphoreJTFTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/ReentrantSemaphoreJTFTests.cs
@@ -1,76 +1,77 @@
-﻿namespace Microsoft.VisualStudio.Threading.Tests
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft;
+using Microsoft.VisualStudio.Threading;
+using Xunit;
+using Xunit.Abstractions;
+
+public class ReentrantSemaphoreJTFTests : ReentrantSemaphoreTestBase
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Xunit;
-    using Xunit.Abstractions;
+    private JoinableTaskContext joinableTaskContext;
 
-    public class ReentrantSemaphoreJTFTests : ReentrantSemaphoreTestBase
+    public ReentrantSemaphoreJTFTests(ITestOutputHelper logger)
+        : base(logger)
     {
-        private JoinableTaskContext joinableTaskContext;
+    }
 
-        public ReentrantSemaphoreJTFTests(ITestOutputHelper logger)
-            : base(logger)
+    [Theory]
+    [MemberData(nameof(AllModes))]
+    public void SemaphoreWaiterJoinsSemaphoreHolders(ReentrantSemaphore.ReentrancyMode mode)
+    {
+        this.semaphore = this.CreateSemaphore(mode);
+        var firstEntered = new AsyncManualResetEvent();
+        bool firstOperationReachedMainThread = false;
+        var firstOperation = Task.Run(async delegate
         {
-        }
+            await this.semaphore.ExecuteAsync(
+                async delegate
+                {
+                    firstEntered.Set();
+                    await this.joinableTaskContext.Factory.SwitchToMainThreadAsync(this.TimeoutToken);
+                    firstOperationReachedMainThread = true;
+                },
+                this.TimeoutToken);
+        });
 
-        [Fact]
-        public void SemaphoreWaiterJoinsSemaphoreHolders()
+        bool secondEntryComplete = false;
+        this.ExecuteOnDispatcher(async delegate
         {
-            var firstEntered = new AsyncManualResetEvent();
-            bool firstOperationReachedMainThread = false;
-            var firstOperation = Task.Run(async delegate
+            this.joinableTaskContext.Factory.Run(async delegate
             {
+                await firstEntered.WaitAsync().WithCancellation(this.TimeoutToken);
+                Assumes.False(firstOperationReachedMainThread);
+
+                // While blocking the main thread, request the semaphore.
+                // This should NOT deadlock if the semaphore properly Joins the existing semaphore holder(s),
+                // allowing them to get to the UI thread and then finally to exit the semaphore so we can enter it.
                 await this.semaphore.ExecuteAsync(
-                    async delegate
+                    delegate
                     {
-                        firstEntered.Set();
-                        await this.joinableTaskContext.Factory.SwitchToMainThreadAsync(this.TimeoutToken);
-                        firstOperationReachedMainThread = true;
+                        secondEntryComplete = true;
+                        Assert.True(firstOperationReachedMainThread);
+                        return TplExtensions.CompletedTask;
                     },
                     this.TimeoutToken);
             });
+            await Task.WhenAll(firstOperation).WithCancellation(this.TimeoutToken);
+            Assert.True(secondEntryComplete);
+        });
+    }
 
-            bool secondEntryComplete = false;
-            this.ExecuteOnDispatcher(async delegate
-            {
-                this.joinableTaskContext.Factory.Run(async delegate
-                {
-                    await firstEntered.WaitAsync().WithCancellation(this.TimeoutToken);
-                    Assumes.False(firstOperationReachedMainThread);
-
-                    // While blocking the main thread, request the semaphore.
-                    // This should NOT deadlock if the semaphore properly Joins the existing semaphore holder(s),
-                    // allowing them to get to the UI thread and then finally to exit the semaphore so we can enter it.
-                    await this.semaphore.ExecuteAsync(
-                        delegate
-                        {
-                            secondEntryComplete = true;
-                            Assert.True(firstOperationReachedMainThread);
-                            return TplExtensions.CompletedTask;
-                        },
-                        this.TimeoutToken);
-                });
-                await Task.WhenAll(firstOperation).WithCancellation(this.TimeoutToken);
-                Assert.True(secondEntryComplete);
-            });
-        }
-
-        protected override ReentrantSemaphore CreateSemaphore(ReentrantSemaphore.ReentrancyMode mode, int initialCount)
+    protected override ReentrantSemaphore CreateSemaphore(ReentrantSemaphore.ReentrancyMode mode, int initialCount = 1)
+    {
+        if (this.joinableTaskContext == null)
         {
-            if (this.joinableTaskContext == null)
+            using (this.Dispatcher.Apply())
             {
-                using (this.Dispatcher.Apply())
-                {
-                    this.joinableTaskContext = new JoinableTaskContext();
-                }
+                this.joinableTaskContext = new JoinableTaskContext();
             }
-
-            return ReentrantSemaphore.Create(initialCount, this.joinableTaskContext, mode);
         }
+
+        return ReentrantSemaphore.Create(initialCount, this.joinableTaskContext, mode);
     }
 }

--- a/src/Microsoft.VisualStudio.Threading.Tests/ReentrantSemaphoreNonJTFTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/ReentrantSemaphoreNonJTFTests.cs
@@ -1,29 +1,29 @@
-﻿namespace Microsoft.VisualStudio.Threading.Tests
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
+using Xunit;
+using Xunit.Abstractions;
+
+public class ReentrantSemaphoreNonJTFTests : ReentrantSemaphoreTestBase
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Xunit;
-    using Xunit.Abstractions;
-
-    public class ReentrantSemaphoreNonJTFTests : ReentrantSemaphoreTestBase
+    public ReentrantSemaphoreNonJTFTests(ITestOutputHelper logger)
+        : base(logger)
     {
-        public ReentrantSemaphoreNonJTFTests(ITestOutputHelper logger)
-            : base(logger)
-        {
-        }
+    }
 
-        [Fact]
-        public void NoDeadlockOnSyncBlockingOnSemaphore_NoContention()
+    [Theory]
+    [MemberData(nameof(AllModes))]
+    public void NoDeadlockOnSyncBlockingOnSemaphore_NoContention(ReentrantSemaphore.ReentrancyMode mode)
+    {
+        this.semaphore = this.CreateSemaphore(mode);
+        this.ExecuteOnDispatcher(delegate
         {
-            this.ExecuteOnDispatcher(delegate
-            {
-                this.semaphore.ExecuteAsync(() => TplExtensions.CompletedTask).Wait(this.TimeoutToken);
-                return TplExtensions.CompletedTask;
-            });
-        }
+            this.semaphore.ExecuteAsync(() => TplExtensions.CompletedTask).Wait(this.TimeoutToken);
+            return TplExtensions.CompletedTask;
+        });
     }
 }

--- a/src/Microsoft.VisualStudio.Threading.Tests/ReentrantSemaphoreNonJTFTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/ReentrantSemaphoreNonJTFTests.cs
@@ -1,0 +1,29 @@
+﻿namespace Microsoft.VisualStudio.Threading.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Xunit;
+    using Xunit.Abstractions;
+
+    public class ReentrantSemaphoreNonJTFTests : ReentrantSemaphoreTestBase
+    {
+        public ReentrantSemaphoreNonJTFTests(ITestOutputHelper logger)
+            : base(logger)
+        {
+        }
+
+        [Fact]
+        public void NoDeadlockOnSyncBlockingOnSemaphore_NoContention()
+        {
+            this.ExecuteOnDispatcher(delegate
+            {
+                this.semaphore.ExecuteAsync(() => TplExtensions.CompletedTask).Wait(this.TimeoutToken);
+                return TplExtensions.CompletedTask;
+            });
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Threading.Tests/ReentrantSemaphoreTestBase.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/ReentrantSemaphoreTestBase.cs
@@ -221,6 +221,19 @@
             });
         }
 
+        [Fact]
+        public void DisposeWhileHoldingSemaphore()
+        {
+            this.ExecuteOnDispatcher(async delegate
+            {
+                await this.semaphore.ExecuteAsync(delegate
+                {
+                    this.semaphore.Dispose();
+                    return TplExtensions.CompletedTask;
+                });
+            });
+        }
+
         protected void ExecuteOnDispatcher(Func<Task> test)
         {
             using (this.Dispatcher.Apply())

--- a/src/Microsoft.VisualStudio.Threading.Tests/ReentrantSemaphoreTestBase.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/ReentrantSemaphoreTestBase.cs
@@ -1,0 +1,232 @@
+﻿namespace Microsoft.VisualStudio.Threading.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Xunit;
+    using Xunit.Abstractions;
+
+    public abstract class ReentrantSemaphoreTestBase : TestBase, IDisposable
+    {
+        protected ReentrantSemaphore semaphore;
+
+        public ReentrantSemaphoreTestBase(ITestOutputHelper logger)
+            : base(logger)
+        {
+            this.Dispatcher = SingleThreadedSynchronizationContext.New();
+            this.semaphore = new ReentrantSemaphore();
+        }
+
+        public static object[][] SemaphoreCapacitySizes
+        {
+            get
+            {
+                return new object[][]
+                {
+                    new object[] { 1 },
+                    new object[] { 2 },
+                    new object[] { 5 },
+                };
+            }
+        }
+
+        protected SynchronizationContext Dispatcher { get; }
+
+        public void Dispose() => this.semaphore.Dispose();
+
+        [Fact]
+        public void ExecuteAsync_InvokesDelegateInOriginalContext_NoContention()
+        {
+            int originalThreadId = Environment.CurrentManagedThreadId;
+            this.ExecuteOnDispatcher(async delegate
+            {
+                bool executed = false;
+                await this.semaphore.ExecuteAsync(
+                    delegate
+                    {
+                        Assert.Equal(originalThreadId, Environment.CurrentManagedThreadId);
+                        executed = true;
+                        return TplExtensions.CompletedTask;
+                    }, this.TimeoutToken);
+                Assert.True(executed);
+            });
+        }
+
+        [Fact]
+        public void ExecuteAsync_InvokesDelegateInOriginalContext_WithContention()
+        {
+            int originalThreadId = Environment.CurrentManagedThreadId;
+            this.ExecuteOnDispatcher(async delegate
+            {
+                var releaseHolder = new AsyncManualResetEvent();
+                var holder = this.semaphore.ExecuteAsync(() => releaseHolder.WaitAsync());
+
+                bool executed = false;
+                var waiter = this.semaphore.ExecuteAsync(
+                    delegate
+                    {
+                        Assert.Equal(originalThreadId, Environment.CurrentManagedThreadId);
+                        executed = true;
+                        return TplExtensions.CompletedTask;
+                    }, this.TimeoutToken);
+
+                releaseHolder.Set();
+                await waiter.WithCancellation(this.TimeoutToken);
+                Assert.True(executed);
+            });
+        }
+
+        [Fact]
+        public void ExecuteAsync_NullDelegate()
+        {
+            this.ExecuteOnDispatcher(async delegate
+            {
+                await Assert.ThrowsAsync<ArgumentNullException>(() => this.semaphore.ExecuteAsync(null, this.TimeoutToken));
+            });
+        }
+
+        [Fact]
+        public void ExecuteAsync_Contested()
+        {
+            this.ExecuteOnDispatcher(async delegate
+            {
+                var firstEntered = new AsyncManualResetEvent();
+                var firstRelease = new AsyncManualResetEvent();
+                var secondEntered = new AsyncManualResetEvent();
+
+                var firstOperation = this.semaphore.ExecuteAsync(
+                    async delegate
+                    {
+                        firstEntered.Set();
+                        await firstRelease;
+                    },
+                    this.TimeoutToken);
+
+                var secondOperation = this.semaphore.ExecuteAsync(
+                    delegate
+                    {
+                        secondEntered.Set();
+                        return TplExtensions.CompletedTask;
+                    },
+                    this.TimeoutToken);
+
+                await firstEntered.WaitAsync().WithCancellation(this.TimeoutToken);
+                await Assert.ThrowsAsync<TimeoutException>(() => secondEntered.WaitAsync().WithTimeout(ExpectedTimeout));
+
+                firstRelease.Set();
+                await secondEntered.WaitAsync().WithCancellation(this.TimeoutToken);
+                await Task.WhenAll(firstOperation, secondOperation);
+            });
+        }
+
+        [Theory, MemberData(nameof(SemaphoreCapacitySizes))]
+        public void Uncontested(int initialCount)
+        {
+            this.ExecuteOnDispatcher(async delegate
+            {
+                this.semaphore = new ReentrantSemaphore(initialCount);
+
+                var releasers = Enumerable.Range(0, initialCount).Select(i => new AsyncManualResetEvent()).ToArray();
+                var operations = new Task[initialCount];
+                for (int i = 0; i < 5; i++)
+                {
+                    // Fill the semaphore to its capacity
+                    for (int j = 0; j < initialCount; j++)
+                    {
+                        operations[j] = this.semaphore.ExecuteAsync(() => releasers[j].WaitAsync(), this.TimeoutToken);
+                    }
+
+                    var releaseSequence = Enumerable.Range(0, initialCount);
+
+                    // We'll test both releasing in FIFO and LIFO order.
+                    if (i % 2 == 0)
+                    {
+                        releaseSequence = releaseSequence.Reverse();
+                    }
+
+                    foreach (int j in releaseSequence)
+                    {
+                        releasers[j].Set();
+                    }
+
+                    await Task.WhenAll(operations).WithCancellation(this.TimeoutToken);
+                }
+            });
+        }
+
+        [Fact]
+        public void Reentrant()
+        {
+            this.ExecuteOnDispatcher(async delegate
+            {
+                await this.semaphore.ExecuteAsync(async delegate
+                {
+                    await this.semaphore.ExecuteAsync(async delegate
+                    {
+                        await this.semaphore.ExecuteAsync(delegate
+                        {
+                            return TplExtensions.CompletedTask;
+                        }, this.TimeoutToken);
+                    }, this.TimeoutToken);
+                }, this.TimeoutToken);
+            });
+        }
+
+        [Fact]
+        public void SemaphoreWorkThrows_DoesNotAbandonSemaphore()
+        {
+            this.ExecuteOnDispatcher(async delegate
+            {
+                await Assert.ThrowsAsync<InvalidOperationException>(async delegate
+                {
+                    await this.semaphore.ExecuteAsync(
+                        delegate
+                        {
+                            throw new InvalidOperationException();
+                        },
+                        this.TimeoutToken);
+                });
+
+                await this.semaphore.ExecuteAsync(() => TplExtensions.CompletedTask, this.TimeoutToken);
+            });
+        }
+
+        [Fact]
+        public void Semaphore_PreCanceledRequest_DoesNotEnterSemaphore()
+        {
+            this.ExecuteOnDispatcher(async delegate
+            {
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => this.semaphore.ExecuteAsync(() => TplExtensions.CompletedTask, new CancellationToken(true)));
+            });
+        }
+
+        [Fact]
+        public void CancellationAbortsContendedRequest()
+        {
+            this.ExecuteOnDispatcher(async delegate
+            {
+                var release = new AsyncManualResetEvent();
+                var holder = this.semaphore.ExecuteAsync(() => release.WaitAsync(), this.TimeoutToken);
+
+                var cts = CancellationTokenSource.CreateLinkedTokenSource(this.TimeoutToken);
+                var waiter = this.semaphore.ExecuteAsync(() => TplExtensions.CompletedTask, cts.Token);
+                Assert.False(waiter.IsCompleted);
+                cts.Cancel();
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => waiter).WithCancellation(this.TimeoutToken);
+                release.Set();
+                await holder;
+            });
+        }
+
+        protected void ExecuteOnDispatcher(Func<Task> test)
+        {
+            using (this.Dispatcher.Apply())
+            {
+                this.ExecuteOnDispatcher(test, staRequired: false);
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Threading.Tests/ReentrantSemaphoreTestBase.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/ReentrantSemaphoreTestBase.cs
@@ -457,7 +457,7 @@
         }
 
 #pragma warning disable VSTHRD012 // Provide JoinableTaskFactory where allowed (we do this in the JTF-aware variant of these tests in a derived class.)
-        protected virtual ReentrantSemaphore CreateSemaphore(ReentrantSemaphore.ReentrancyMode mode = ReentrantSemaphore.ReentrancyMode.NotAllowed, int initialCount = 1) => new ReentrantSemaphore(initialCount, mode: mode);
+        protected virtual ReentrantSemaphore CreateSemaphore(ReentrantSemaphore.ReentrancyMode mode = ReentrantSemaphore.ReentrancyMode.NotAllowed, int initialCount = 1) => ReentrantSemaphore.Create(initialCount, mode: mode);
 #pragma warning restore VSTHRD012 // Provide JoinableTaskFactory where allowed
 
         protected void ExecuteOnDispatcher(Func<Task> test)

--- a/src/Microsoft.VisualStudio.Threading.Tests/ReentrantSemaphoreTestBase.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/ReentrantSemaphoreTestBase.cs
@@ -158,8 +158,8 @@
         }
 
         [Theory]
-        [InlineData(ReentrantSemaphore.ReentrancyMode.ExitAnyOrder)]
-        [InlineData(ReentrantSemaphore.ReentrancyMode.ExitInReverseOrder)]
+        [InlineData(ReentrantSemaphore.ReentrancyMode.FreeForm)]
+        [InlineData(ReentrantSemaphore.ReentrancyMode.Stack)]
         public void Reentrant(ReentrantSemaphore.ReentrancyMode mode)
         {
             this.semaphore = this.CreateSemaphore(mode);
@@ -181,7 +181,7 @@
         [Fact]
         public void ExitInAnyOrder_ExitInAcquisitionOrder()
         {
-            this.semaphore = this.CreateSemaphore(ReentrantSemaphore.ReentrancyMode.ExitAnyOrder);
+            this.semaphore = this.CreateSemaphore(ReentrantSemaphore.ReentrancyMode.FreeForm);
             this.ExecuteOnDispatcher(async delegate
             {
                 var releaser1 = new AsyncManualResetEvent();
@@ -384,7 +384,7 @@
         [Fact]
         public void ExitInReverseOrder_Allowed()
         {
-            this.semaphore = this.CreateSemaphore(ReentrantSemaphore.ReentrancyMode.ExitInReverseOrder);
+            this.semaphore = this.CreateSemaphore(ReentrantSemaphore.ReentrancyMode.Stack);
             this.ExecuteOnDispatcher(async delegate
             {
                 await this.semaphore.ExecuteAsync(async delegate
@@ -400,7 +400,7 @@
         [Fact]
         public void ExitInReverseOrder_ViolationCaughtAtBothSites()
         {
-            this.semaphore = this.CreateSemaphore(ReentrantSemaphore.ReentrancyMode.ExitInReverseOrder);
+            this.semaphore = this.CreateSemaphore(ReentrantSemaphore.ReentrancyMode.Stack);
             this.ExecuteOnDispatcher(async delegate
             {
                 var release1 = new AsyncManualResetEvent();
@@ -438,7 +438,7 @@
         [Fact]
         public void ExitInAnyOrder_Allowed()
         {
-            this.semaphore = this.CreateSemaphore(ReentrantSemaphore.ReentrancyMode.ExitAnyOrder);
+            this.semaphore = this.CreateSemaphore(ReentrantSemaphore.ReentrancyMode.FreeForm);
             this.ExecuteOnDispatcher(async delegate
             {
                 await this.semaphore.ExecuteAsync(async delegate

--- a/src/Microsoft.VisualStudio.Threading.Tests/ReentrantSemaphoreTestBase.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/ReentrantSemaphoreTestBase.cs
@@ -45,7 +45,7 @@ public abstract class ReentrantSemaphoreTestBase : TestBase, IDisposable
                     new object[] { ReentrantSemaphore.ReentrancyMode.NotAllowed },
                     new object[] { ReentrantSemaphore.ReentrancyMode.NotRecognized },
                     new object[] { ReentrantSemaphore.ReentrancyMode.Stack },
-                    new object[] { ReentrantSemaphore.ReentrancyMode.FreeForm },
+                    new object[] { ReentrantSemaphore.ReentrancyMode.Freeform },
             };
         }
     }
@@ -57,14 +57,20 @@ public abstract class ReentrantSemaphoreTestBase : TestBase, IDisposable
             return new object[][]
             {
                     new object[] { ReentrantSemaphore.ReentrancyMode.Stack },
-                    new object[] { ReentrantSemaphore.ReentrancyMode.FreeForm },
+                    new object[] { ReentrantSemaphore.ReentrancyMode.Freeform },
             };
         }
     }
 
     protected SynchronizationContext Dispatcher { get; }
 
-    public void Dispose() => this.semaphore.Dispose();
+    public void Dispose() => this.semaphore?.Dispose();
+
+    [Fact]
+    public void InvalidMode()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => this.CreateSemaphore((ReentrantSemaphore.ReentrancyMode)100));
+    }
 
     [Theory]
     [MemberData(nameof(AllModes))]
@@ -217,7 +223,7 @@ public abstract class ReentrantSemaphoreTestBase : TestBase, IDisposable
     [Fact]
     public void ExitInAnyOrder_ExitInAcquisitionOrder()
     {
-        this.semaphore = this.CreateSemaphore(ReentrantSemaphore.ReentrancyMode.FreeForm);
+        this.semaphore = this.CreateSemaphore(ReentrantSemaphore.ReentrancyMode.Freeform);
         this.ExecuteOnDispatcher(async delegate
         {
             var releaser1 = new AsyncManualResetEvent();

--- a/src/Microsoft.VisualStudio.Threading.Tests/TestBase.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/TestBase.cs
@@ -38,7 +38,7 @@
         /// Gets or sets the source of <see cref="TimeoutToken"/> that influences
         /// when tests consider themselves to be timed out.
         /// </summary>
-        protected CancellationTokenSource TimeoutTokenSource { get; set; } = new CancellationTokenSource(TestTimeout);
+        protected CancellationTokenSource TimeoutTokenSource { get; set; } = new CancellationTokenSource(UnexpectedTimeout);
 
         /// <summary>
         /// Gets a token that is canceled when the test times out,
@@ -272,7 +272,7 @@
             });
         }
 
-        protected void ExecuteOnDispatcher(Func<Task> action)
+        protected void ExecuteOnDispatcher(Func<Task> action, bool staRequired = true)
         {
             Action worker = delegate
             {
@@ -304,7 +304,7 @@
             };
 
 #if DESKTOP || NETCOREAPP2_0
-            if (Thread.CurrentThread.GetApartmentState() == ApartmentState.STA &&
+            if ((!staRequired || Thread.CurrentThread.GetApartmentState() == ApartmentState.STA) &&
                 SingleThreadedSynchronizationContext.IsSingleThreadedSyncContext(SynchronizationContext.Current))
             {
                 worker();

--- a/src/Microsoft.VisualStudio.Threading/MultilingualResources/Microsoft.VisualStudio.Threading.cs.xlf
+++ b/src/Microsoft.VisualStudio.Threading/MultilingualResources/Microsoft.VisualStudio.Threading.cs.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="cs" original="MICROSOFT.VISUALSTUDIO.THREADING/STRINGS.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -70,6 +70,14 @@
         <trans-unit id="ValueFactoryReentrancy" translate="yes" xml:space="preserve">
           <source>The value factory has called for the value on the same instance.</source>
           <target state="translated">Objekt pro vytváření hodnot zavolal hodnotu pro stejnou instanci.</target>
+        </trans-unit>
+        <trans-unit id="SemaphoreMisused" translate="yes" xml:space="preserve">
+          <source>This semaphore has been misused and can no longer be used.</source>
+          <target state="new">This semaphore has been misused and can no longer be used.</target>
+        </trans-unit>
+        <trans-unit id="SemaphoreStackNestingViolated" translate="yes" xml:space="preserve">
+          <source>Nested semaphore requests must be released in LIFO order when the reentrancy setting is: '{0}'</source>
+          <target state="new">Nested semaphore requests must be released in LIFO order when the reentrancy setting is: '{0}'</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Threading/MultilingualResources/Microsoft.VisualStudio.Threading.de.xlf
+++ b/src/Microsoft.VisualStudio.Threading/MultilingualResources/Microsoft.VisualStudio.Threading.de.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="de" original="MICROSOFT.VISUALSTUDIO.THREADING/STRINGS.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -70,6 +70,14 @@
         <trans-unit id="ValueFactoryReentrancy" translate="yes" xml:space="preserve">
           <source>The value factory has called for the value on the same instance.</source>
           <target state="translated">Die Wertfactory hat den Wert für die gleiche Instanz aufgerufen.</target>
+        </trans-unit>
+        <trans-unit id="SemaphoreMisused" translate="yes" xml:space="preserve">
+          <source>This semaphore has been misused and can no longer be used.</source>
+          <target state="new">This semaphore has been misused and can no longer be used.</target>
+        </trans-unit>
+        <trans-unit id="SemaphoreStackNestingViolated" translate="yes" xml:space="preserve">
+          <source>Nested semaphore requests must be released in LIFO order when the reentrancy setting is: '{0}'</source>
+          <target state="new">Nested semaphore requests must be released in LIFO order when the reentrancy setting is: '{0}'</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Threading/MultilingualResources/Microsoft.VisualStudio.Threading.es.xlf
+++ b/src/Microsoft.VisualStudio.Threading/MultilingualResources/Microsoft.VisualStudio.Threading.es.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="es" original="MICROSOFT.VISUALSTUDIO.THREADING/STRINGS.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -70,6 +70,14 @@
         <trans-unit id="ValueFactoryReentrancy" translate="yes" xml:space="preserve">
           <source>The value factory has called for the value on the same instance.</source>
           <target state="translated">Este generador de valores ha llamado al valor en la misma instancia.</target>
+        </trans-unit>
+        <trans-unit id="SemaphoreMisused" translate="yes" xml:space="preserve">
+          <source>This semaphore has been misused and can no longer be used.</source>
+          <target state="new">This semaphore has been misused and can no longer be used.</target>
+        </trans-unit>
+        <trans-unit id="SemaphoreStackNestingViolated" translate="yes" xml:space="preserve">
+          <source>Nested semaphore requests must be released in LIFO order when the reentrancy setting is: '{0}'</source>
+          <target state="new">Nested semaphore requests must be released in LIFO order when the reentrancy setting is: '{0}'</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Threading/MultilingualResources/Microsoft.VisualStudio.Threading.fr.xlf
+++ b/src/Microsoft.VisualStudio.Threading/MultilingualResources/Microsoft.VisualStudio.Threading.fr.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="fr" original="MICROSOFT.VISUALSTUDIO.THREADING/STRINGS.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -70,6 +70,14 @@
         <trans-unit id="ValueFactoryReentrancy" translate="yes" xml:space="preserve">
           <source>The value factory has called for the value on the same instance.</source>
           <target state="translated">La fabrique de valeurs a fait appel à la valeur sur la même instance.</target>
+        </trans-unit>
+        <trans-unit id="SemaphoreMisused" translate="yes" xml:space="preserve">
+          <source>This semaphore has been misused and can no longer be used.</source>
+          <target state="new">This semaphore has been misused and can no longer be used.</target>
+        </trans-unit>
+        <trans-unit id="SemaphoreStackNestingViolated" translate="yes" xml:space="preserve">
+          <source>Nested semaphore requests must be released in LIFO order when the reentrancy setting is: '{0}'</source>
+          <target state="new">Nested semaphore requests must be released in LIFO order when the reentrancy setting is: '{0}'</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Threading/MultilingualResources/Microsoft.VisualStudio.Threading.it.xlf
+++ b/src/Microsoft.VisualStudio.Threading/MultilingualResources/Microsoft.VisualStudio.Threading.it.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="it" original="MICROSOFT.VISUALSTUDIO.THREADING/STRINGS.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -70,6 +70,14 @@
         <trans-unit id="ValueFactoryReentrancy" translate="yes" xml:space="preserve">
           <source>The value factory has called for the value on the same instance.</source>
           <target state="translated">La factory del valore ha richiesto il valore nella stessa istanza.</target>
+        </trans-unit>
+        <trans-unit id="SemaphoreMisused" translate="yes" xml:space="preserve">
+          <source>This semaphore has been misused and can no longer be used.</source>
+          <target state="new">This semaphore has been misused and can no longer be used.</target>
+        </trans-unit>
+        <trans-unit id="SemaphoreStackNestingViolated" translate="yes" xml:space="preserve">
+          <source>Nested semaphore requests must be released in LIFO order when the reentrancy setting is: '{0}'</source>
+          <target state="new">Nested semaphore requests must be released in LIFO order when the reentrancy setting is: '{0}'</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Threading/MultilingualResources/Microsoft.VisualStudio.Threading.ja.xlf
+++ b/src/Microsoft.VisualStudio.Threading/MultilingualResources/Microsoft.VisualStudio.Threading.ja.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="ja" original="MICROSOFT.VISUALSTUDIO.THREADING/STRINGS.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -70,6 +70,14 @@
         <trans-unit id="ValueFactoryReentrancy" translate="yes" xml:space="preserve">
           <source>The value factory has called for the value on the same instance.</source>
           <target state="translated">値ファクトリが同じインスタンスの値を呼び出しました。</target>
+        </trans-unit>
+        <trans-unit id="SemaphoreMisused" translate="yes" xml:space="preserve">
+          <source>This semaphore has been misused and can no longer be used.</source>
+          <target state="new">This semaphore has been misused and can no longer be used.</target>
+        </trans-unit>
+        <trans-unit id="SemaphoreStackNestingViolated" translate="yes" xml:space="preserve">
+          <source>Nested semaphore requests must be released in LIFO order when the reentrancy setting is: '{0}'</source>
+          <target state="new">Nested semaphore requests must be released in LIFO order when the reentrancy setting is: '{0}'</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Threading/MultilingualResources/Microsoft.VisualStudio.Threading.ko.xlf
+++ b/src/Microsoft.VisualStudio.Threading/MultilingualResources/Microsoft.VisualStudio.Threading.ko.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="ko" original="MICROSOFT.VISUALSTUDIO.THREADING/STRINGS.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -70,6 +70,14 @@
         <trans-unit id="ValueFactoryReentrancy" translate="yes" xml:space="preserve">
           <source>The value factory has called for the value on the same instance.</source>
           <target state="translated">값 팩토리가 같은 인스턴스의 값을 호출했습니다.</target>
+        </trans-unit>
+        <trans-unit id="SemaphoreMisused" translate="yes" xml:space="preserve">
+          <source>This semaphore has been misused and can no longer be used.</source>
+          <target state="new">This semaphore has been misused and can no longer be used.</target>
+        </trans-unit>
+        <trans-unit id="SemaphoreStackNestingViolated" translate="yes" xml:space="preserve">
+          <source>Nested semaphore requests must be released in LIFO order when the reentrancy setting is: '{0}'</source>
+          <target state="new">Nested semaphore requests must be released in LIFO order when the reentrancy setting is: '{0}'</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Threading/MultilingualResources/Microsoft.VisualStudio.Threading.pl.xlf
+++ b/src/Microsoft.VisualStudio.Threading/MultilingualResources/Microsoft.VisualStudio.Threading.pl.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="pl" original="MICROSOFT.VISUALSTUDIO.THREADING/STRINGS.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -70,6 +70,14 @@
         <trans-unit id="ValueFactoryReentrancy" translate="yes" xml:space="preserve">
           <source>The value factory has called for the value on the same instance.</source>
           <target state="translated">Fabryka wartości zażądała wartości w tym samym wystąpieniu.</target>
+        </trans-unit>
+        <trans-unit id="SemaphoreMisused" translate="yes" xml:space="preserve">
+          <source>This semaphore has been misused and can no longer be used.</source>
+          <target state="new">This semaphore has been misused and can no longer be used.</target>
+        </trans-unit>
+        <trans-unit id="SemaphoreStackNestingViolated" translate="yes" xml:space="preserve">
+          <source>Nested semaphore requests must be released in LIFO order when the reentrancy setting is: '{0}'</source>
+          <target state="new">Nested semaphore requests must be released in LIFO order when the reentrancy setting is: '{0}'</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Threading/MultilingualResources/Microsoft.VisualStudio.Threading.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.Threading/MultilingualResources/Microsoft.VisualStudio.Threading.pt-BR.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="pt-BR" original="MICROSOFT.VISUALSTUDIO.THREADING/STRINGS.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -70,6 +70,14 @@
         <trans-unit id="ValueFactoryReentrancy" translate="yes" xml:space="preserve">
           <source>The value factory has called for the value on the same instance.</source>
           <target state="translated">O alocador de valor chamou o valor na mesma instância.</target>
+        </trans-unit>
+        <trans-unit id="SemaphoreMisused" translate="yes" xml:space="preserve">
+          <source>This semaphore has been misused and can no longer be used.</source>
+          <target state="new">This semaphore has been misused and can no longer be used.</target>
+        </trans-unit>
+        <trans-unit id="SemaphoreStackNestingViolated" translate="yes" xml:space="preserve">
+          <source>Nested semaphore requests must be released in LIFO order when the reentrancy setting is: '{0}'</source>
+          <target state="new">Nested semaphore requests must be released in LIFO order when the reentrancy setting is: '{0}'</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Threading/MultilingualResources/Microsoft.VisualStudio.Threading.ru.xlf
+++ b/src/Microsoft.VisualStudio.Threading/MultilingualResources/Microsoft.VisualStudio.Threading.ru.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="ru" original="MICROSOFT.VISUALSTUDIO.THREADING/STRINGS.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -70,6 +70,14 @@
         <trans-unit id="ValueFactoryReentrancy" translate="yes" xml:space="preserve">
           <source>The value factory has called for the value on the same instance.</source>
           <target state="translated">Фабрика значений вызвала значение в том же экземпляре.</target>
+        </trans-unit>
+        <trans-unit id="SemaphoreMisused" translate="yes" xml:space="preserve">
+          <source>This semaphore has been misused and can no longer be used.</source>
+          <target state="new">This semaphore has been misused and can no longer be used.</target>
+        </trans-unit>
+        <trans-unit id="SemaphoreStackNestingViolated" translate="yes" xml:space="preserve">
+          <source>Nested semaphore requests must be released in LIFO order when the reentrancy setting is: '{0}'</source>
+          <target state="new">Nested semaphore requests must be released in LIFO order when the reentrancy setting is: '{0}'</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Threading/MultilingualResources/Microsoft.VisualStudio.Threading.tr.xlf
+++ b/src/Microsoft.VisualStudio.Threading/MultilingualResources/Microsoft.VisualStudio.Threading.tr.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="tr" original="MICROSOFT.VISUALSTUDIO.THREADING/STRINGS.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -70,6 +70,14 @@
         <trans-unit id="ValueFactoryReentrancy" translate="yes" xml:space="preserve">
           <source>The value factory has called for the value on the same instance.</source>
           <target state="translated">Değer fabrikası aynı örnekteki değeri çağırdı.</target>
+        </trans-unit>
+        <trans-unit id="SemaphoreMisused" translate="yes" xml:space="preserve">
+          <source>This semaphore has been misused and can no longer be used.</source>
+          <target state="new">This semaphore has been misused and can no longer be used.</target>
+        </trans-unit>
+        <trans-unit id="SemaphoreStackNestingViolated" translate="yes" xml:space="preserve">
+          <source>Nested semaphore requests must be released in LIFO order when the reentrancy setting is: '{0}'</source>
+          <target state="new">Nested semaphore requests must be released in LIFO order when the reentrancy setting is: '{0}'</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Threading/MultilingualResources/Microsoft.VisualStudio.Threading.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.Threading/MultilingualResources/Microsoft.VisualStudio.Threading.zh-Hans.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="zh-Hans" original="MICROSOFT.VISUALSTUDIO.THREADING/STRINGS.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -70,6 +70,14 @@
         <trans-unit id="ValueFactoryReentrancy" translate="yes" xml:space="preserve">
           <source>The value factory has called for the value on the same instance.</source>
           <target state="translated">值工厂已对相同实例调用了值。</target>
+        </trans-unit>
+        <trans-unit id="SemaphoreMisused" translate="yes" xml:space="preserve">
+          <source>This semaphore has been misused and can no longer be used.</source>
+          <target state="new">This semaphore has been misused and can no longer be used.</target>
+        </trans-unit>
+        <trans-unit id="SemaphoreStackNestingViolated" translate="yes" xml:space="preserve">
+          <source>Nested semaphore requests must be released in LIFO order when the reentrancy setting is: '{0}'</source>
+          <target state="new">Nested semaphore requests must be released in LIFO order when the reentrancy setting is: '{0}'</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Threading/MultilingualResources/Microsoft.VisualStudio.Threading.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.Threading/MultilingualResources/Microsoft.VisualStudio.Threading.zh-Hant.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="zh-Hant" original="MICROSOFT.VISUALSTUDIO.THREADING/STRINGS.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -70,6 +70,14 @@
         <trans-unit id="ValueFactoryReentrancy" translate="yes" xml:space="preserve">
           <source>The value factory has called for the value on the same instance.</source>
           <target state="translated">值 Factory 需要相同執行個體上的值。</target>
+        </trans-unit>
+        <trans-unit id="SemaphoreMisused" translate="yes" xml:space="preserve">
+          <source>This semaphore has been misused and can no longer be used.</source>
+          <target state="new">This semaphore has been misused and can no longer be used.</target>
+        </trans-unit>
+        <trans-unit id="SemaphoreStackNestingViolated" translate="yes" xml:space="preserve">
+          <source>Nested semaphore requests must be released in LIFO order when the reentrancy setting is: '{0}'</source>
+          <target state="new">Nested semaphore requests must be released in LIFO order when the reentrancy setting is: '{0}'</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Threading/ReentrantSemaphore.cs
+++ b/src/Microsoft.VisualStudio.Threading/ReentrantSemaphore.cs
@@ -156,7 +156,7 @@ namespace Microsoft.VisualStudio.Threading
         /// <param name="operation">The delegate to invoke once the semaphore is entered.</param>
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>A task that completes with the result of <paramref name="operation"/>, after the semaphore has been exited.</returns>
-        public async Task ExecuteAsync(Func<Task> operation, CancellationToken cancellationToken = default)
+        public virtual async Task ExecuteAsync(Func<Task> operation, CancellationToken cancellationToken = default)
         {
             Requires.NotNull(operation, nameof(operation));
             this.ThrowIfFaulted();

--- a/src/Microsoft.VisualStudio.Threading/ReentrantSemaphore.cs
+++ b/src/Microsoft.VisualStudio.Threading/ReentrantSemaphore.cs
@@ -72,7 +72,14 @@ namespace Microsoft.VisualStudio.Threading
                     finally
                     {
                         reentrantCountBox.Value--;
-                        releaser.Dispose();
+                        try
+                        {
+                            releaser.Dispose();
+                        }
+                        catch (ObjectDisposedException)
+                        {
+                            // Swallow this, since in releasing the semaphore if it's already disposed the caller probably doesn't care.
+                        }
                     }
                 }
             };

--- a/src/Microsoft.VisualStudio.Threading/ReentrantSemaphore.cs
+++ b/src/Microsoft.VisualStudio.Threading/ReentrantSemaphore.cs
@@ -54,7 +54,7 @@ namespace Microsoft.VisualStudio.Threading
             Requires.NotNull(operation, nameof(operation));
 
             StrongBox<int> reentrantCountBox = this.reentrantCount.Value;
-            if (reentrantCountBox == null)
+            if (reentrantCountBox == null || reentrantCountBox.Value == 0)
             {
                 this.reentrantCount.Value = reentrantCountBox = new StrongBox<int>();
             }

--- a/src/Microsoft.VisualStudio.Threading/ReentrantSemaphore.cs
+++ b/src/Microsoft.VisualStudio.Threading/ReentrantSemaphore.cs
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio.Threading
         /// <param name="initialCount">The initial number of concurrent operations to allow.</param>
         /// <param name="joinableTaskContext">The <see cref="JoinableTaskContext"/> to use to mitigate deadlocks.</param>
         /// <param name="mode">How to respond to a semaphore request by a caller that has already entered the semaphore.</param>
-        public ReentrantSemaphore(int initialCount = 1, JoinableTaskContext joinableTaskContext = default, ReentrancyMode mode = ReentrancyMode.NotAllowed)
+        internal ReentrantSemaphore(int initialCount, JoinableTaskContext joinableTaskContext, ReentrancyMode mode)
         {
             this.joinableTaskCollection = joinableTaskContext?.CreateCollection();
             this.joinableTaskFactory = joinableTaskContext?.CreateFactory(this.joinableTaskCollection);
@@ -134,6 +134,17 @@ namespace Microsoft.VisualStudio.Threading
                 this.ThrowIfFaulted();
                 return this.semaphore.CurrentCount;
             }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReentrantSemaphore"/> class.
+        /// </summary>
+        /// <param name="initialCount">The initial number of concurrent operations to allow.</param>
+        /// <param name="joinableTaskContext">The <see cref="JoinableTaskContext"/> to use to mitigate deadlocks.</param>
+        /// <param name="mode">How to respond to a semaphore request by a caller that has already entered the semaphore.</param>
+        public static ReentrantSemaphore Create(int initialCount = 1, JoinableTaskContext joinableTaskContext = default, ReentrancyMode mode = ReentrancyMode.NotAllowed)
+        {
+            return new ReentrantSemaphore(initialCount, joinableTaskContext, mode);
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.Threading/ReentrantSemaphore.cs
+++ b/src/Microsoft.VisualStudio.Threading/ReentrantSemaphore.cs
@@ -109,7 +109,7 @@ namespace Microsoft.VisualStudio.Threading
             /// When a violation occurs, this semaphore transitions into a faulted state, after which any call
             /// will throw an <see cref="InvalidOperationException"/>.
             /// </remarks>
-            ExitInReverseOrder,
+            Stack,
 
             /// <summary>
             /// A request made by a caller that is already in the semaphore is immediately executed,
@@ -121,7 +121,7 @@ namespace Microsoft.VisualStudio.Threading
             /// Leaked semaphore access is a condition where code is inappropriately considered parented to another semaphore holder,
             /// leading to it being allowed to run code within the semaphore, potentially in parallel with the actual semaphore holder.
             /// </remarks>
-            ExitAnyOrder,
+            FreeForm,
         }
 
         /// <summary>
@@ -188,7 +188,7 @@ namespace Microsoft.VisualStudio.Threading
                             {
                                 var poppedReleaser = reentrantStack.Pop();
                                 releaser = poppedReleaser.Value;
-                                if (this.mode == ReentrancyMode.ExitInReverseOrder && !object.ReferenceEquals(poppedReleaser, pushedReleaser))
+                                if (this.mode == ReentrancyMode.Stack && !object.ReferenceEquals(poppedReleaser, pushedReleaser))
                                 {
                                     this.faulted = true;
                                     Verify.FailOperation("Nested semaphore requests must be released in LIFO order when the reentrancy setting is: '{0}'", this.mode);

--- a/src/Microsoft.VisualStudio.Threading/ReentrantSemaphore.cs
+++ b/src/Microsoft.VisualStudio.Threading/ReentrantSemaphore.cs
@@ -1,0 +1,109 @@
+﻿/********************************************************
+*                                                        *
+*   © Copyright (C) Microsoft. All rights reserved.      *
+*                                                        *
+*********************************************************/
+
+namespace Microsoft.VisualStudio.Threading
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Runtime.CompilerServices;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// A <see cref="JoinableTaskFactory" />-aware semaphore that allows reentrancy without consuming another slot in the semaphore.
+    /// </summary>
+    public class ReentrantSemaphore : IDisposable
+    {
+        private readonly JoinableTaskFactory joinableTaskFactory;
+
+        private readonly JoinableTaskCollection joinableTaskCollection;
+
+        private readonly AsyncSemaphore semaphore;
+
+        private readonly AsyncLocal<StrongBox<int>> reentrantCount = new AsyncLocal<StrongBox<int>>();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReentrantSemaphore"/> class.
+        /// </summary>
+        /// <param name="initialCount">The initial number of concurrent operations to allow.</param>
+        /// <param name="joinableTaskContext">The <see cref="JoinableTaskContext"/> to use to mitigate deadlocks.</param>
+        public ReentrantSemaphore(int initialCount = 1, JoinableTaskContext joinableTaskContext = default)
+        {
+            this.joinableTaskCollection = joinableTaskContext?.CreateCollection();
+            this.joinableTaskFactory = joinableTaskContext?.CreateFactory(this.joinableTaskCollection);
+            this.semaphore = new AsyncSemaphore(initialCount);
+        }
+
+        /// <summary>
+        /// Gets the number of openings that remain in the semaphore.
+        /// </summary>
+        public int CurrentCount => this.semaphore.CurrentCount;
+
+        /// <summary>
+        /// Executes a given operation within the semaphore.
+        /// </summary>
+        /// <param name="operation">The delegate to invoke once the semaphore is entered.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>A task that completes with the result of <paramref name="operation"/>, after the semaphore has been exited.</returns>
+        public async Task ExecuteAsync(Func<Task> operation, CancellationToken cancellationToken = default)
+        {
+            Requires.NotNull(operation, nameof(operation));
+
+            StrongBox<int> reentrantCountBox = this.reentrantCount.Value;
+            if (reentrantCountBox == null)
+            {
+                this.reentrantCount.Value = reentrantCountBox = new StrongBox<int>();
+            }
+
+            Func<Task> semaphoreUser = async delegate
+            {
+                using (this.joinableTaskCollection?.Join())
+                {
+                    AsyncSemaphore.Releaser releaser = reentrantCountBox.Value == 0 ? await this.semaphore.EnterAsync(cancellationToken).ConfigureAwait(true) : default;
+                    try
+                    {
+                        reentrantCountBox.Value++;
+                        await operation().ConfigureAwaitRunInline();
+                    }
+                    finally
+                    {
+                        reentrantCountBox.Value--;
+                        releaser.Dispose();
+                    }
+                }
+            };
+
+            if (this.joinableTaskFactory != null)
+            {
+                await this.joinableTaskFactory.RunAsync(semaphoreUser).Task.ConfigureAwaitRunInline();
+            }
+            else
+            {
+                await semaphoreUser().ConfigureAwaitRunInline();
+            }
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Disposes managed and unmanaged resources held by this instance.
+        /// </summary>
+        /// <param name="disposing"><c>true</c> if <see cref="Dispose()"/> was called; <c>false</c> if the object is being finalized.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                this.semaphore.Dispose();
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Threading/ReentrantSemaphore.cs
+++ b/src/Microsoft.VisualStudio.Threading/ReentrantSemaphore.cs
@@ -56,7 +56,10 @@ namespace Microsoft.VisualStudio.Threading
         /// <param name="initialCount">The initial number of concurrent operations to allow.</param>
         /// <param name="joinableTaskContext">The <see cref="JoinableTaskContext"/> to use to mitigate deadlocks.</param>
         /// <param name="mode">How to respond to a semaphore request by a caller that has already entered the semaphore.</param>
-        internal ReentrantSemaphore(int initialCount, JoinableTaskContext joinableTaskContext, ReentrancyMode mode)
+        /// <devremarks>
+        /// This is private protected so that others cannot derive from this type but we can within the assembly.
+        /// </devremarks>
+        private protected ReentrantSemaphore(int initialCount, JoinableTaskContext joinableTaskContext, ReentrancyMode mode)
         {
             this.joinableTaskCollection = joinableTaskContext?.CreateCollection();
             this.joinableTaskFactory = joinableTaskContext?.CreateFactory(this.joinableTaskCollection);

--- a/src/Microsoft.VisualStudio.Threading/ReentrantSemaphore.cs
+++ b/src/Microsoft.VisualStudio.Threading/ReentrantSemaphore.cs
@@ -66,12 +66,12 @@ namespace Microsoft.VisualStudio.Threading
                     AsyncSemaphore.Releaser releaser = reentrantCountBox.Value == 0 ? await this.semaphore.EnterAsync(cancellationToken).ConfigureAwait(true) : default;
                     try
                     {
-                        reentrantCountBox.Value++;
+                        Interlocked.Increment(ref reentrantCountBox.Value);
                         await operation().ConfigureAwaitRunInline();
                     }
                     finally
                     {
-                        reentrantCountBox.Value--;
+                        Interlocked.Decrement(ref reentrantCountBox.Value);
                         try
                         {
                             releaser.Dispose();

--- a/src/Microsoft.VisualStudio.Threading/ReentrantSemaphore.cs
+++ b/src/Microsoft.VisualStudio.Threading/ReentrantSemaphore.cs
@@ -8,6 +8,7 @@ namespace Microsoft.VisualStudio.Threading
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Runtime.CompilerServices;
     using System.Text;
     using System.Threading;
@@ -16,32 +17,124 @@ namespace Microsoft.VisualStudio.Threading
     /// <summary>
     /// A <see cref="JoinableTaskFactory" />-aware semaphore that allows reentrancy without consuming another slot in the semaphore.
     /// </summary>
+    [DebuggerDisplay(nameof(CurrentCount) + " = {" + nameof(CurrentCount) + "}")]
     public class ReentrantSemaphore : IDisposable
     {
+        /// <summary>
+        /// The factory to wrap all pending and active semaphore requests with to mitigate deadlocks.
+        /// </summary>
         private readonly JoinableTaskFactory joinableTaskFactory;
 
+        /// <summary>
+        /// The collection of all semaphore holders (and possibly waiters), which waiters should join to mitigate deadlocks.
+        /// </summary>
         private readonly JoinableTaskCollection joinableTaskCollection;
 
+        /// <summary>
+        /// The underlying semaphore primitive.
+        /// </summary>
         private readonly AsyncSemaphore semaphore;
 
-        private readonly AsyncLocal<StrongBox<int>> reentrantCount = new AsyncLocal<StrongBox<int>>();
+        /// <summary>
+        /// The means to recognize that a caller has already entered the semaphore.
+        /// </summary>
+        private readonly AsyncLocal<Stack<StrongBox<AsyncSemaphore.Releaser>>> reentrantCount;
+
+        /// <summary>
+        /// The behavior to exhibit when reentrancy is encountered.
+        /// </summary>
+        private readonly ReentrancyMode mode;
+
+        /// <summary>
+        /// A flag to indicate this instance was misused and the data it protects should not be touched as it may be corrupted.
+        /// </summary>
+        private bool faulted;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ReentrantSemaphore"/> class.
         /// </summary>
         /// <param name="initialCount">The initial number of concurrent operations to allow.</param>
         /// <param name="joinableTaskContext">The <see cref="JoinableTaskContext"/> to use to mitigate deadlocks.</param>
-        public ReentrantSemaphore(int initialCount = 1, JoinableTaskContext joinableTaskContext = default)
+        /// <param name="mode">How to respond to a semaphore request by a caller that has already entered the semaphore.</param>
+        public ReentrantSemaphore(int initialCount = 1, JoinableTaskContext joinableTaskContext = default, ReentrancyMode mode = ReentrancyMode.NotAllowed)
         {
             this.joinableTaskCollection = joinableTaskContext?.CreateCollection();
             this.joinableTaskFactory = joinableTaskContext?.CreateFactory(this.joinableTaskCollection);
             this.semaphore = new AsyncSemaphore(initialCount);
+            this.mode = mode;
+
+            if (mode != ReentrancyMode.NotRecognized)
+            {
+                this.reentrantCount = new AsyncLocal<Stack<StrongBox<AsyncSemaphore.Releaser>>>();
+            }
+        }
+
+        /// <summary>
+        /// Describes ways the <see cref="ReentrantSemaphore"/> may behave when a semaphore request is made in a context that is already in the semaphore.
+        /// </summary>
+        public enum ReentrancyMode
+        {
+            /// <summary>
+            /// Reject all requests when the caller has already entered the semaphore
+            /// (and not yet exited) by throwing an <see cref="InvalidOperationException"/>.
+            /// </summary>
+            /// <remarks>
+            /// When reentrancy is not expected this is the recommended mode as it will prevent deadlocks
+            /// when unexpected reentrancy is detected.
+            /// </remarks>
+            NotAllowed,
+
+            /// <summary>
+            /// Each request occupies a unique slot in the semaphore.
+            /// Reentrancy is not recognized and may lead to deadlocks if the reentrancy level exceeds the count on the semaphore.
+            /// This resembles the behavior of the <see cref="AsyncSemaphore"/> class.
+            /// </summary>
+            /// <remarks>
+            /// If reentrancy is not in the design, but <see cref="NotAllowed"/> leads to exceptions due to
+            /// ExecutionContext flowing unexpectedly, this mode may be the best option.
+            /// </remarks>
+            NotRecognized,
+
+            /// <summary>
+            /// A request made by a caller that is already in the semaphore is immediately executed,
+            /// and shares the same semaphore slot with its parent.
+            /// This nested request must exit before its parent (Strict LIFO/stack behavior).
+            /// Exiting the semaphore before a child has or after the parent has will cause an
+            /// <see cref="InvalidOperationException"/> to fault the <see cref="Task"/> returned
+            /// from <see cref="ExecuteAsync(Func{Task}, CancellationToken)"/>.
+            /// </summary>
+            /// <remarks>
+            /// When reentrancy is a requirement, this mode helps ensure that reentrancy only happens
+            /// where code enters a semaphore, then awaits on other code that itself may enter the semaphore.
+            /// When a violation occurs, this semaphore transitions into a faulted state, after which any call
+            /// will throw an <see cref="InvalidOperationException"/>.
+            /// </remarks>
+            ExitInReverseOrder,
+
+            /// <summary>
+            /// A request made by a caller that is already in the semaphore is immediately executed,
+            /// and shares the same semaphore slot with its parent.
+            /// The slot is only released when all requests have exited, which may be in any order.
+            /// </summary>
+            /// <remarks>
+            /// This is the most permissive, but has the highest risk that leaked semaphore access will remain undetected.
+            /// Leaked semaphore access is a condition where code is inappropriately considered parented to another semaphore holder,
+            /// leading to it being allowed to run code within the semaphore, potentially in parallel with the actual semaphore holder.
+            /// </remarks>
+            ExitAnyOrder,
         }
 
         /// <summary>
         /// Gets the number of openings that remain in the semaphore.
         /// </summary>
-        public int CurrentCount => this.semaphore.CurrentCount;
+        public int CurrentCount
+        {
+            get
+            {
+                this.ThrowIfFaulted();
+                return this.semaphore.CurrentCount;
+            }
+        }
 
         /// <summary>
         /// Executes a given operation within the semaphore.
@@ -52,26 +145,61 @@ namespace Microsoft.VisualStudio.Threading
         public async Task ExecuteAsync(Func<Task> operation, CancellationToken cancellationToken = default)
         {
             Requires.NotNull(operation, nameof(operation));
+            this.ThrowIfFaulted();
 
-            StrongBox<int> reentrantCountBox = this.reentrantCount.Value;
-            if (reentrantCountBox == null || reentrantCountBox.Value == 0)
+            Stack<StrongBox<AsyncSemaphore.Releaser>> reentrantStack = null;
+            if (this.mode != ReentrancyMode.NotRecognized)
             {
-                this.reentrantCount.Value = reentrantCountBox = new StrongBox<int>();
+                reentrantStack = this.reentrantCount.Value;
+                if (reentrantStack == null || reentrantStack.Count == 0)
+                {
+                    this.reentrantCount.Value = reentrantStack = new Stack<StrongBox<AsyncSemaphore.Releaser>>(capacity: this.mode == ReentrancyMode.NotAllowed ? 1 : 2);
+                }
+                else
+                {
+                    Verify.Operation(this.mode != ReentrancyMode.NotAllowed || reentrantStack.Count == 0, "Semaphore is already held and reentrancy setting is '{0}'.", this.mode);
+                }
             }
 
             Func<Task> semaphoreUser = async delegate
             {
                 using (this.joinableTaskCollection?.Join())
                 {
-                    AsyncSemaphore.Releaser releaser = reentrantCountBox.Value == 0 ? await this.semaphore.EnterAsync(cancellationToken).ConfigureAwait(true) : default;
+                    AsyncSemaphore.Releaser releaser = reentrantStack == null || reentrantStack.Count == 0 ? await this.semaphore.EnterAsync(cancellationToken).ConfigureAwait(true) : default;
+                    var pushedReleaser = new StrongBox<AsyncSemaphore.Releaser>(releaser);
+                    releaser = default; // we should release whatever we Pop off the stack later on.
                     try
                     {
-                        Interlocked.Increment(ref reentrantCountBox.Value);
+                        if (reentrantStack != null)
+                        {
+                            lock (reentrantStack)
+                            {
+                                reentrantStack.Push(pushedReleaser);
+                            }
+                        }
+
                         await operation().ConfigureAwaitRunInline();
                     }
                     finally
                     {
-                        Interlocked.Decrement(ref reentrantCountBox.Value);
+                        if (reentrantStack != null)
+                        {
+                            lock (reentrantStack)
+                            {
+                                var poppedReleaser = reentrantStack.Pop();
+                                releaser = poppedReleaser.Value;
+                                if (this.mode == ReentrancyMode.ExitInReverseOrder && !object.ReferenceEquals(poppedReleaser, pushedReleaser))
+                                {
+                                    this.faulted = true;
+                                    Verify.FailOperation("Nested semaphore requests must be released in LIFO order when the reentrancy setting is: '{0}'", this.mode);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            releaser = pushedReleaser.Value;
+                        }
+
                         try
                         {
                             releaser.Dispose();
@@ -111,6 +239,14 @@ namespace Microsoft.VisualStudio.Threading
             {
                 this.semaphore.Dispose();
             }
+        }
+
+        /// <summary>
+        /// Throws an exception if this instance has been faulted.
+        /// </summary>
+        private void ThrowIfFaulted()
+        {
+            Verify.Operation(!this.faulted, "This semaphore has been misused and cannot be used any more.");
         }
     }
 }

--- a/src/Microsoft.VisualStudio.Threading/Strings.Designer.cs
+++ b/src/Microsoft.VisualStudio.Threading/Strings.Designer.cs
@@ -11,8 +11,8 @@
 namespace Microsoft.VisualStudio.Threading {
     using System;
     using System.Reflection;
-
-
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -20,19 +20,19 @@ namespace Microsoft.VisualStudio.Threading {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {
-
+        
         private static global::System.Resources.ResourceManager resourceMan;
-
+        
         private static global::System.Globalization.CultureInfo resourceCulture;
-
+        
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         internal Strings() {
         }
-
+        
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
@@ -46,7 +46,7 @@ namespace Microsoft.VisualStudio.Threading {
                 return resourceMan;
             }
         }
-
+        
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
@@ -60,7 +60,7 @@ namespace Microsoft.VisualStudio.Threading {
                 resourceCulture = value;
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Acquiring locks on threads with a SynchronizationContext applied is not allowed..
         /// </summary>
@@ -69,7 +69,7 @@ namespace Microsoft.VisualStudio.Threading {
                 return ResourceManager.GetString("AppliedSynchronizationContextNotAllowed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to A non-upgradeable read lock is held by the caller and cannot be upgraded..
         /// </summary>
@@ -78,7 +78,7 @@ namespace Microsoft.VisualStudio.Threading {
                 return ResourceManager.GetString("CannotUpgradeNonUpgradeableLock", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Dangerous request for read lock from fork of write lock..
         /// </summary>
@@ -87,7 +87,7 @@ namespace Microsoft.VisualStudio.Threading {
                 return ResourceManager.GetString("DangerousReadLockRequestFromWriteLockFork", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Already transitioned to the Completed state..
         /// </summary>
@@ -96,7 +96,7 @@ namespace Microsoft.VisualStudio.Threading {
                 return ResourceManager.GetString("InvalidAfterCompleted", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to This operation can only be executed against a valid lock..
         /// </summary>
@@ -105,7 +105,7 @@ namespace Microsoft.VisualStudio.Threading {
                 return ResourceManager.GetString("InvalidLock", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to A lock is required..
         /// </summary>
@@ -114,7 +114,7 @@ namespace Microsoft.VisualStudio.Threading {
                 return ResourceManager.GetString("InvalidWithoutLock", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to JoinableTask does not belong to the context this collection was instantiated with..
         /// </summary>
@@ -123,7 +123,7 @@ namespace Microsoft.VisualStudio.Threading {
                 return ResourceManager.GetString("JoinableTaskContextAndCollectionMismatch", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to This node already registered..
         /// </summary>
@@ -132,7 +132,7 @@ namespace Microsoft.VisualStudio.Threading {
                 return ResourceManager.GetString("JoinableTaskContextNodeAlreadyRegistered", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Lazily created value faulted during construction..
         /// </summary>
@@ -141,7 +141,7 @@ namespace Microsoft.VisualStudio.Threading {
                 return ResourceManager.GetString("LazyValueFaulted", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Lazily created value not yet constructed..
         /// </summary>
@@ -150,7 +150,7 @@ namespace Microsoft.VisualStudio.Threading {
                 return ResourceManager.GetString("LazyValueNotCreated", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to This lock has already been marked for completion.  No new top-level locks can be serviced..
         /// </summary>
@@ -159,7 +159,7 @@ namespace Microsoft.VisualStudio.Threading {
                 return ResourceManager.GetString("LockCompletionAlreadyRequested", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to This operation is not allowed while holding an active upgradeable read or write lock from an AsyncReaderWriterLock..
         /// </summary>
@@ -168,7 +168,7 @@ namespace Microsoft.VisualStudio.Threading {
                 return ResourceManager.GetString("NotAllowedUnderURorWLock", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The queue is empty..
         /// </summary>
@@ -177,7 +177,25 @@ namespace Microsoft.VisualStudio.Threading {
                 return ResourceManager.GetString("QueueEmpty", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This semaphore has been misused and can no longer be used..
+        /// </summary>
+        internal static string SemaphoreMisused {
+            get {
+                return ResourceManager.GetString("SemaphoreMisused", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Nested semaphore requests must be released in LIFO order when the reentrancy setting is: &apos;{0}&apos;.
+        /// </summary>
+        internal static string SemaphoreStackNestingViolated {
+            get {
+                return ResourceManager.GetString("SemaphoreStackNestingViolated", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to This operation cannot be completed on an STA thread..
         /// </summary>
@@ -186,7 +204,7 @@ namespace Microsoft.VisualStudio.Threading {
                 return ResourceManager.GetString("STAThreadCallerNotAllowed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to An attempt to switch to the main thread failed to reach the expected thread. Was the JoinableTaskContext initialized on the wrong thread or with a SynchronizationContext whose Post method does not execute its delegate on the main thread?.
         /// </summary>
@@ -195,7 +213,7 @@ namespace Microsoft.VisualStudio.Threading {
                 return ResourceManager.GetString("SwitchToMainThreadFailedToReachExpectedThread", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The value factory has called for the value on the same instance..
         /// </summary>

--- a/src/Microsoft.VisualStudio.Threading/Strings.resx
+++ b/src/Microsoft.VisualStudio.Threading/Strings.resx
@@ -156,6 +156,12 @@
   <data name="QueueEmpty" xml:space="preserve">
     <value>The queue is empty.</value>
   </data>
+  <data name="SemaphoreMisused" xml:space="preserve">
+    <value>This semaphore has been misused and can no longer be used.</value>
+  </data>
+  <data name="SemaphoreStackNestingViolated" xml:space="preserve">
+    <value>Nested semaphore requests must be released in LIFO order when the reentrancy setting is: '{0}'</value>
+  </data>
   <data name="STAThreadCallerNotAllowed" xml:space="preserve">
     <value>This operation cannot be completed on an STA thread.</value>
   </data>


### PR DESCRIPTION
Several teams have asked for such functionality and I've helped them implement it themselves each time. This simply packages it up as a ready to use class.

This is a 15.8 port of the 16.0 change in #296, which addressed #295

* [x] Ask mode approval obtained