### PR TITLE
Use 15.6.0.0 as assembly version for ms.vs.threading.dll

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/Microsoft.VisualStudio.Threading.csproj
+++ b/src/Microsoft.VisualStudio.Threading/Microsoft.VisualStudio.Threading.csproj
@@ -19,7 +19,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageProjectUrl>https://github.com/Microsoft/vs-threading</PackageProjectUrl>
     <PackageIconUrl>https://aka.ms/VsExtensibilityIcon</PackageIconUrl>
-    <PackageReleaseNotes>https://go.microsoft.com/fwlink/?LinkID=746387</PackageReleaseNotes>
+    <PackageReleaseNotes>The library now uses a 15.6.0.0 assembly version to be compatible with Visual Studio 15.7 and to reflect that no additional API was added since the 15.6 package version. Note that earlier versions of the 15.7 package used an assembly version of 15.7.0.0.</PackageReleaseNotes>
 
     <DebugType>full</DebugType>
     <RunCodeAnalysis Condition=" '$(TargetFramework)' != 'portable-net45+win8+wpa81' and '$(TargetFramework)' != 'netstandard2.0' and '$(Configuration)' != 'Debug' ">true</RunCodeAnalysis>

--- a/src/Microsoft.VisualStudio.Threading/version.json
+++ b/src/Microsoft.VisualStudio.Threading/version.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
+  "inherit": true,
+  "assemblyVersion": {
+    "version": "15.6"
+  }
+}


### PR DESCRIPTION
VS 15.7.x ships the same ms.vs.threading.dll assembly that shipped in 15.6, so a 15.7.0.0 assembly version means someone using the 15.7.x.y vs-threading package versions won't run properly in VS 15.7 because the assembly versions don't match. We never added public API to the vs-threading library in 15.7 either, which is another reason to hold the assembly version constant across 15.6 and 15.7.

Fixes #311