### PR TITLE
Optimize JTF Collection size in ReentrantSemaphore

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Tests/ReentrantSemaphoreJTFTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/ReentrantSemaphoreJTFTests.cs
@@ -62,6 +62,57 @@ public class ReentrantSemaphoreJTFTests : ReentrantSemaphoreTestBase
         });
     }
 
+    [Theory]
+    [MemberData(nameof(AllModes))]
+    public void SemaphoreDoesNotDeadlockReturningToMainThread(ReentrantSemaphore.ReentrancyMode mode)
+    {
+        var semaphore = this.CreateSemaphore(mode);
+        this.ExecuteOnDispatcher(
+            async () =>
+            {
+                var semaphoreAquired = new AsyncManualResetEvent();
+                var continueFirstOperation = new AsyncManualResetEvent();
+
+                // First operation holds the semaphore while the next operations are enqueued.
+                var firstOperation = Task.Run(
+                    async () =>
+                    {
+                        await semaphore.ExecuteAsync(
+                            async () =>
+                            {
+                                semaphoreAquired.Set();
+                                await continueFirstOperation.WaitAsync();
+                            },
+                            this.TimeoutToken);
+                    });
+
+                await semaphoreAquired.WaitAsync().WithCancellation(this.TimeoutToken);
+
+                // We have 3 semaphore requests on the main thread here.
+                // 1. Async request within a JTF.RunAsync
+                // 2. Async request not in a JTF.RunAsync
+                // 3. Sync request.
+                // The goal is to test that the 3rd, sync request, will release the UI thread
+                // to the two async requests, then it will resume its operations.
+                await this.joinableTaskContext.Factory.SwitchToMainThreadAsync();
+                var secondOperation = this.joinableTaskContext.Factory.RunAsync(() => this.AcquireSemaphoreAsync(semaphore));
+                var thirdOperation = this.AcquireSemaphoreAsync(semaphore);
+                bool finalSemaphoreAcquired = this.joinableTaskContext.Factory.Run(
+                    () =>
+                    {
+                        var semaphoreTask = this.AcquireSemaphoreAsync(semaphore);
+                        continueFirstOperation.Set();
+                        return semaphoreTask;
+                    });
+
+                await Task.WhenAll(firstOperation, secondOperation.JoinAsync(), thirdOperation).WithCancellation(this.TimeoutToken);
+
+                Assert.True(secondOperation.Task.GetAwaiter().GetResult());
+                Assert.True(thirdOperation.GetAwaiter().GetResult());
+                Assert.True(finalSemaphoreAcquired);
+            });
+    }
+
     protected override ReentrantSemaphore CreateSemaphore(ReentrantSemaphore.ReentrancyMode mode, int initialCount = 1)
     {
         if (this.joinableTaskContext == null)
@@ -73,5 +124,19 @@ public class ReentrantSemaphoreJTFTests : ReentrantSemaphoreTestBase
         }
 
         return ReentrantSemaphore.Create(initialCount, this.joinableTaskContext, mode);
+    }
+
+    private async Task<bool> AcquireSemaphoreAsync(ReentrantSemaphore semaphore)
+    {
+        bool acquired = false;
+        await semaphore.ExecuteAsync(
+            () =>
+            {
+                acquired = true;
+                return TplExtensions.CompletedTask;
+            },
+            this.TimeoutToken);
+
+        return acquired;
     }
 }

--- a/src/Microsoft.VisualStudio.Threading.Tests/ReentrantSemaphoreTestBase.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/ReentrantSemaphoreTestBase.cs
@@ -228,15 +228,14 @@ public abstract class ReentrantSemaphoreTestBase : TestBase, IDisposable
         this.semaphore = this.CreateSemaphore(ReentrantSemaphore.ReentrancyMode.Freeform);
         this.ExecuteOnDispatcher(async delegate
         {
-            var outerReleaser = new AsyncManualResetEvent();
-            var innerReleaser = new AsyncManualResetEvent();
+            var releaser1 = new AsyncManualResetEvent();
             Task innerOperation = null;
             await this.semaphore.ExecuteAsync(delegate
             {
-                innerOperation = EnterAndUseSemaphoreAsync(innerReleaser);
+                innerOperation = EnterAndUseSemaphoreAsync(releaser1);
                 return TplExtensions.CompletedTask;
             });
-            innerReleaser.Set();
+            releaser1.Set();
             await innerOperation;
             Assert.Equal(1, this.semaphore.CurrentCount);
         });

--- a/src/Microsoft.VisualStudio.Threading.Tests/ReentrantSemaphoreTestBase.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/ReentrantSemaphoreTestBase.cs
@@ -180,7 +180,8 @@ public abstract class ReentrantSemaphoreTestBase : TestBase, IDisposable
                 // Fill the semaphore to its capacity
                 for (int j = 0; j < initialCount; j++)
                 {
-                    operations[j] = this.semaphore.ExecuteAsync(() => releasers[j].WaitAsync(), this.TimeoutToken);
+                    int k = j; // Capture j, as it will increment
+                    operations[j] = this.semaphore.ExecuteAsync(() => releasers[k].WaitAsync(), this.TimeoutToken);
                 }
 
                 var releaseSequence = Enumerable.Range(0, initialCount);

--- a/src/Microsoft.VisualStudio.Threading/AwaitExtensions.cs
+++ b/src/Microsoft.VisualStudio.Threading/AwaitExtensions.cs
@@ -897,8 +897,9 @@ namespace Microsoft.VisualStudio.Threading
             }
 
             /// <summary>
-            /// No result to return.
+            /// Does nothing.
             /// </summary>
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic")]
             public void GetResult()
             {
             }

--- a/src/Microsoft.VisualStudio.Threading/AwaitExtensions.cs
+++ b/src/Microsoft.VisualStudio.Threading/AwaitExtensions.cs
@@ -49,17 +49,6 @@ namespace Microsoft.VisualStudio.Threading
             return new TaskSchedulerAwaitable(scheduler, alwaysYield);
         }
 
-        /// <summary>
-        /// Gets an awaitable that schedules continuations on the specified synchronization context.
-        /// </summary>
-        /// <param name="context">The synchronization context used to execute continuations.</param>
-        /// <returns>An awaitable.</returns>
-        public static SynchronizationContextAwaiter GetAwaiter(this SynchronizationContext context)
-        {
-            Requires.NotNull(context, nameof(context));
-            return new SynchronizationContextAwaiter(context);
-        }
-
 #if DESKTOP || NETSTANDARD2_0
 
         /// <summary>
@@ -861,48 +850,6 @@ namespace Microsoft.VisualStudio.Threading
                     CancellationToken.None,
                     TaskContinuationOptions.ExecuteSynchronously,
                     TaskScheduler.Default);
-            }
-        }
-
-        /// <summary>
-        /// A task awaiter that executes callbacks on the supplied synchronization context.
-        /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes")]
-        public struct SynchronizationContextAwaiter : INotifyCompletion
-        {
-            private static readonly SendOrPostCallback PostCallback = state => ((Action)state)();
-            private readonly SynchronizationContext context;
-
-            /// <summary>
-            /// Initializes a new instance of the <see cref="SynchronizationContextAwaiter"/> struct.
-            /// </summary>
-            /// <param name="context">The synchonization context which the continuation will be posted to.</param>
-            public SynchronizationContextAwaiter(SynchronizationContext context)
-            {
-                Requires.NotNull(context, nameof(context));
-                this.context = context;
-            }
-
-            /// <summary>
-            /// Gets a value indicating whether the current task is completed.
-            /// </summary>
-            public bool IsCompleted => this.context == SynchronizationContext.Current;
-
-            /// <summary>
-            /// Posts the callback to the supplied synchronization context.
-            /// </summary>
-            /// <param name="continuation">The action to continue</param>
-            public void OnCompleted(Action continuation)
-            {
-                this.context.Post(PostCallback, continuation);
-            }
-
-            /// <summary>
-            /// Does nothing.
-            /// </summary>
-            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic")]
-            public void GetResult()
-            {
             }
         }
     }

--- a/src/Microsoft.VisualStudio.Threading/AwaitExtensions.cs
+++ b/src/Microsoft.VisualStudio.Threading/AwaitExtensions.cs
@@ -867,6 +867,7 @@ namespace Microsoft.VisualStudio.Threading
         /// <summary>
         /// A task awaiter that executes callbacks on the supplied synchronization context.
         /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes")]
         public struct SynchronizationContextAwaiter : INotifyCompletion
         {
             private static readonly SendOrPostCallback PostCallback = state => ((Action)state)();

--- a/src/Microsoft.VisualStudio.Threading/ReentrantSemaphore.cs
+++ b/src/Microsoft.VisualStudio.Threading/ReentrantSemaphore.cs
@@ -117,6 +117,11 @@ namespace Microsoft.VisualStudio.Threading
         }
 
         /// <summary>
+        /// Gets a value indicating whether this instance is using Joinable Task aware or not.
+        /// </summary>
+        private bool IsJoinableTaskAware => this.joinableTaskCollection != null;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ReentrantSemaphore"/> class.
         /// </summary>
         /// <param name="initialCount">The initial number of concurrent operations to allow.</param>
@@ -143,10 +148,10 @@ namespace Microsoft.VisualStudio.Threading
         /// Executes a given operation within the semaphore.
         /// </summary>
         /// <param name="operation">
-        /// The delegate to invoke once the semaphore is entered. Not guaranteed to be executed on the context this was originally called on.
-        /// If a <see cref="JoinableTaskContext"/> was supplied to the constructor, this delegate will execute on the main thread if  is
-        /// invoked on the main thread, otherwise it will be invoked on the threadpool. When no <see cref="JoinableTaskContext"/> is supplied
-        /// to the constructor, this delegate will execute on the caller's context or the task scheduler.
+        /// The delegate to invoke once the semaphore is entered. If a <see cref="JoinableTaskContext"/> was supplied to the constructor,
+        /// this delegate will execute on the main thread if this is invoked on the main thread, otherwise it will be invoked on the
+        /// threadpool. When no <see cref="JoinableTaskContext"/> is supplied to the constructor, this delegate will execute on the
+        /// caller's context.
         /// </param>
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>A task that completes with the result of <paramref name="operation"/>, after the semaphore has been exited.</returns>
@@ -285,12 +290,11 @@ namespace Microsoft.VisualStudio.Threading
                 // resuming on the correct sync context. To partially fix this, we will at least resume you on the main thread or
                 // thread pool.
                 AsyncSemaphore.Releaser releaser;
-                bool usingJtf = this.joinableTaskFactory != null;
-                bool resumeOnMainThread = usingJtf ? this.joinableTaskCollection.Context.IsOnMainThread : false;
+                bool resumeOnMainThread = this.IsJoinableTaskAware ? this.joinableTaskCollection.Context.IsOnMainThread : false;
                 bool mustYield = false;
                 using (this.joinableTaskCollection?.Join())
                 {
-                    if (usingJtf)
+                    if (this.IsJoinableTaskAware)
                     {
                         // Use ConfiguredAwaitRunInline() as ConfigureAwait(true) will
                         // deadlock due to not being inside a JTF.RunAsync().
@@ -308,7 +312,7 @@ namespace Microsoft.VisualStudio.Threading
                 {
                     try
                     {
-                        if (usingJtf)
+                        if (this.IsJoinableTaskAware)
                         {
                             if (resumeOnMainThread)
                             {
@@ -383,12 +387,11 @@ namespace Microsoft.VisualStudio.Threading
                 // resuming on the correct sync context. To partially fix this, we will at least resume you on the main thread or
                 // thread pool.
                 AsyncSemaphore.Releaser releaser;
-                bool usingJtf = this.joinableTaskFactory != null;
-                bool resumeOnMainThread = usingJtf ? this.joinableTaskCollection.Context.IsOnMainThread : false;
+                bool resumeOnMainThread = this.IsJoinableTaskAware ? this.joinableTaskCollection.Context.IsOnMainThread : false;
                 bool mustYield = false;
                 using (this.joinableTaskCollection?.Join())
                 {
-                    if (usingJtf)
+                    if (this.IsJoinableTaskAware)
                     {
                         // Use ConfiguredAwaitRunInline() as ConfigureAwait(true) will
                         // deadlock due to not being inside a JTF.RunAsync().
@@ -406,7 +409,7 @@ namespace Microsoft.VisualStudio.Threading
                 {
                     try
                     {
-                        if (usingJtf)
+                        if (this.IsJoinableTaskAware)
                         {
                             if (resumeOnMainThread)
                             {
@@ -506,14 +509,13 @@ namespace Microsoft.VisualStudio.Threading
                 // resuming on the correct sync context. To partially fix this, we will at least resume you on the main thread or
                 // thread pool.
                 AsyncSemaphore.Releaser releaser;
-                bool usingJtf = this.joinableTaskFactory != null;
-                bool resumeOnMainThread = usingJtf ? this.joinableTaskCollection.Context.IsOnMainThread : false;
+                bool resumeOnMainThread = this.IsJoinableTaskAware ? this.joinableTaskCollection.Context.IsOnMainThread : false;
                 bool mustYield = false;
                 if (reentrantStack.Count == 0)
                 {
                     using (this.joinableTaskCollection?.Join())
                     {
-                        if (usingJtf)
+                        if (this.IsJoinableTaskAware)
                         {
                             // Use ConfiguredAwaitRunInline() as ConfigureAwait(true) will
                             // deadlock due to not being inside a JTF.RunAsync().
@@ -538,7 +540,7 @@ namespace Microsoft.VisualStudio.Threading
                     var pushedReleaser = new StrongBox<AsyncSemaphore.Releaser>(releaser);
                     try
                     {
-                        if (usingJtf)
+                        if (this.IsJoinableTaskAware)
                         {
                             if (resumeOnMainThread)
                             {
@@ -643,14 +645,13 @@ namespace Microsoft.VisualStudio.Threading
                 // resuming on the correct sync context. To partially fix this, we will at least resume you on the main thread or
                 // thread pool.
                 AsyncSemaphore.Releaser releaser;
-                bool usingJtf = this.joinableTaskFactory != null;
-                bool resumeOnMainThread = usingJtf ? this.joinableTaskCollection.Context.IsOnMainThread : false;
+                bool resumeOnMainThread = this.IsJoinableTaskAware ? this.joinableTaskCollection.Context.IsOnMainThread : false;
                 bool mustYield = false;
                 if (reentrantStack.Count == 0)
                 {
                     using (this.joinableTaskCollection?.Join())
                     {
-                        if (usingJtf)
+                        if (this.IsJoinableTaskAware)
                         {
                             // Use ConfiguredAwaitRunInline() as ConfigureAwait(true) will
                             // deadlock due to not being inside a JTF.RunAsync().
@@ -674,7 +675,7 @@ namespace Microsoft.VisualStudio.Threading
                     bool pushed = false;
                     try
                     {
-                        if (usingJtf)
+                        if (this.IsJoinableTaskAware)
                         {
                             if (resumeOnMainThread)
                             {

--- a/src/Microsoft.VisualStudio.Threading/ReentrantSemaphore.cs
+++ b/src/Microsoft.VisualStudio.Threading/ReentrantSemaphore.cs
@@ -431,7 +431,7 @@ namespace Microsoft.VisualStudio.Threading
                         // Restore the synchronization context that was lost acquiring the semaphore.
                         await synchronizationContext;
                     }
-                    
+
                     var pushedReleaser = new StrongBox<AsyncSemaphore.Releaser>(releaser);
                     lock (reentrantStack)
                     {


### PR DESCRIPTION
The pattern of:
``` CSharp
this.joinableTaskFactory.RunAsync(async () =>
{
    using (this.joinableTaskCollection.Join())
    using (await this.semaphore.EnterAsync())
    {
        await externalOperation();
    }
});
```

is problematic in that it explodes the size of the joinable task collection, leading to a large dependency graph and serious performance issues. This PR proposes a fix by:

1. Capture synchronization context
2. Await semaphore _without_ using `JTF.RunAsync`. This requires `ConfigureAwaitRunInline()` (hence step 1).
3. `RunAsync` and restore synchronization context.

Let me know what you think of this change, and if the general concept looks good I will apply it to all of `ReentrantSemaphore` and add unit tests as appropriate.

Another thing to consider, is to change `AsyncSemaphore` to use the `SynchronizationContextAwaiter` directly, but I think that would be a breaking change.

/cc: @lifengl