### PR TITLE
Add AsyncLazy<T>.GetValue(CancellationToken) method

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Tests/AsyncLazyTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/AsyncLazyTests.cs
@@ -197,7 +197,7 @@ namespace Microsoft.VisualStudio.Threading.Tests
                 var context = new JoinableTaskContext(); // we need our own collectible context.
                 collectible = new WeakReference(context.Factory);
                 var valueFactory = throwInValueFactory
-                    ? new Func<Task<object>>(delegate { throw new ApplicationException(); })
+                    ? new Func<Task<object>>(() => throw new ApplicationException())
                     : async delegate
                     {
                         await Task.Yield();
@@ -332,6 +332,86 @@ namespace Microsoft.VisualStudio.Threading.Tests
             Assert.Equal(5, result.Data);
             Assert.True(lazy.IsValueCreated);
             Assert.True(lazy.IsValueFactoryCompleted);
+        }
+
+        [Theory, CombinatorialData]
+        public void GetValue(bool specifyJtf)
+        {
+            var jtf = specifyJtf ? new JoinableTaskContext().Factory : null; // use our own so we don't get main thread deadlocks, which isn't the point of this test.
+            var lazy = new AsyncLazy<GenericParameterHelper>(() => Task.FromResult(new GenericParameterHelper(5)), jtf);
+            Assert.Equal(5, lazy.GetValue().Data);
+        }
+
+        [Theory, CombinatorialData]
+        public void GetValue_Precanceled(bool specifyJtf)
+        {
+            var jtf = specifyJtf ? new JoinableTaskContext().Factory : null; // use our own so we don't get main thread deadlocks, which isn't the point of this test.
+            var lazy = new AsyncLazy<GenericParameterHelper>(() => Task.FromResult(new GenericParameterHelper(5)), jtf);
+            Assert.Throws<OperationCanceledException>(() => lazy.GetValue(new CancellationToken(canceled: true)));
+        }
+
+        [Theory, CombinatorialData]
+        public async Task GetValue_CalledAfterGetValueAsyncHasCompleted(bool specifyJtf)
+        {
+            var jtf = specifyJtf ? new JoinableTaskContext().Factory : null; // use our own so we don't get main thread deadlocks, which isn't the point of this test.
+            var lazy = new AsyncLazy<GenericParameterHelper>(() => Task.FromResult(new GenericParameterHelper(5)), jtf);
+            var result = await lazy.GetValueAsync();
+            Assert.Same(result, lazy.GetValue());
+        }
+
+        [Theory, CombinatorialData]
+        public async Task GetValue_CalledAfterGetValueAsync_InProgress(bool specifyJtf)
+        {
+            var completeValueFactory = new AsyncManualResetEvent();
+            var jtf = specifyJtf ? new JoinableTaskContext().Factory : null; // use our own so we don't get main thread deadlocks, which isn't the point of this test.
+            var lazy = new AsyncLazy<GenericParameterHelper>(
+                async delegate
+                {
+                    await completeValueFactory;
+                    return new GenericParameterHelper(5);
+                },
+                jtf);
+            Task<GenericParameterHelper> getValueAsyncTask = lazy.GetValueAsync();
+            Task<GenericParameterHelper> getValueTask = Task.Run(() => lazy.GetValue());
+            Assert.False(getValueAsyncTask.IsCompleted);
+            Assert.False(getValueTask.IsCompleted);
+            completeValueFactory.Set();
+            GenericParameterHelper[] results = await Task.WhenAll(getValueAsyncTask, getValueTask);
+            Assert.Same(results[0], results[1]);
+        }
+
+        [Theory, CombinatorialData]
+        public async Task GetValue_ThenCanceled(bool specifyJtf)
+        {
+            var completeValueFactory = new AsyncManualResetEvent();
+            var jtf = specifyJtf ? new JoinableTaskContext().Factory : null; // use our own so we don't get main thread deadlocks, which isn't the point of this test.
+            var lazy = new AsyncLazy<GenericParameterHelper>(
+                async delegate
+                {
+                    await completeValueFactory;
+                    return new GenericParameterHelper(5);
+                },
+                jtf);
+            var cts = new CancellationTokenSource();
+            Task<GenericParameterHelper> getValueTask = Task.Run(() => lazy.GetValue(cts.Token));
+            Assert.False(getValueTask.IsCompleted);
+            cts.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => getValueTask);
+        }
+
+        [Theory, CombinatorialData]
+        public void GetValue_ValueFactoryThrows(bool specifyJtf)
+        {
+            var exception = new InvalidOperationException();
+            var completeValueFactory = new AsyncManualResetEvent();
+            var jtf = specifyJtf ? new JoinableTaskContext().Factory : null; // use our own so we don't get main thread deadlocks, which isn't the point of this test.
+            var lazy = new AsyncLazy<GenericParameterHelper>(() => throw exception, jtf);
+
+            // Verify that we throw the right exception the first time.
+            Assert.Same(exception, Assert.Throws(exception.GetType(), () => lazy.GetValue()));
+
+            // Assert that we rethrow the exception the second time.
+            Assert.Same(exception, Assert.Throws(exception.GetType(), () => lazy.GetValue()));
         }
 
         [Fact]
@@ -541,6 +621,46 @@ namespace Microsoft.VisualStudio.Threading.Tests
                 var backgroundValue = await backgroundRequest;
                 Assert.Same(foregroundValue, backgroundValue);
             });
+        }
+
+        /// <summary>
+        /// Verifies that no deadlock occurs if the value factory synchronously blocks while switching to the UI thread
+        /// and the UI thread then uses <see cref="AsyncLazy{T}.GetValue()"/>.
+        /// </summary>
+        [Fact]
+        public void ValueFactoryRequiresMainThreadHeldByOtherInGetValue()
+        {
+            var ctxt = SingleThreadedSynchronizationContext.New();
+            SynchronizationContext.SetSynchronizationContext(ctxt);
+            var context = new JoinableTaskContext();
+            var asyncPump = context.Factory;
+            var originalThread = Thread.CurrentThread;
+
+            var evt = new AsyncManualResetEvent();
+            var lazy = new AsyncLazy<object>(
+                async delegate
+                {
+                    // It is important that no await appear before this JTF.Run call, since
+                    // we're testing that the value factory is not invoked while the AsyncLazy
+                    // holds a private lock that would deadlock when called from another thread.
+                    asyncPump.Run(async delegate
+                    {
+                        await asyncPump.SwitchToMainThreadAsync(this.TimeoutToken);
+                    });
+                    await Task.Yield();
+                    return new object();
+                },
+                asyncPump);
+
+            var backgroundRequest = Task.Run(async delegate
+            {
+                return await lazy.GetValueAsync();
+            });
+
+            Thread.Sleep(AsyncDelay); // Give the background thread time to call GetValueAsync(), but it doesn't yield (when the test was written).
+            var foregroundValue = lazy.GetValue(this.TimeoutToken);
+            var backgroundValue = asyncPump.Run(() => backgroundRequest);
+            Assert.Same(foregroundValue, backgroundValue);
         }
 
         [Fact]

--- a/src/Microsoft.VisualStudio.Threading/AsyncLazy.cs
+++ b/src/Microsoft.VisualStudio.Threading/AsyncLazy.cs
@@ -96,10 +96,7 @@ namespace Microsoft.VisualStudio.Threading
         /// Thrown when the value factory calls <see cref="GetValueAsync()"/> on this instance.
         /// </exception>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
-        public Task<T> GetValueAsync()
-        {
-            return this.GetValueAsync(CancellationToken.None);
-        }
+        public Task<T> GetValueAsync() => this.GetValueAsync(CancellationToken.None);
 
         /// <summary>
         /// Gets the task that produces or has produced the value.
@@ -194,6 +191,47 @@ namespace Microsoft.VisualStudio.Threading
             }
 
             return this.value.WithCancellation(cancellationToken);
+        }
+
+        /// <summary>
+        /// Gets the lazily computed value.
+        /// </summary>
+        /// <returns>The lazily constructed value.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when the value factory calls <see cref="GetValueAsync()"/> on this instance.
+        /// </exception>
+        public T GetValue() => this.GetValue(CancellationToken.None);
+
+        /// <summary>
+        /// Gets the lazily computed value.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// A token whose cancellation indicates that the caller no longer is interested in the result.
+        /// Note that this will not cancel the value factory (since other callers may exist).
+        /// But when this token is canceled, the caller will experience an <see cref="OperationCanceledException"/>
+        /// immediately and a dis-joining of any <see cref="JoinableTask"/> that may have occurred as a result of this call.
+        /// </param>
+        /// <returns>The lazily constructed value.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when the value factory calls <see cref="GetValueAsync()"/> on this instance.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">Thrown when <paramref name="cancellationToken"/> is canceled before the value is computed.</exception>
+        public T GetValue(CancellationToken cancellationToken)
+        {
+            // As a perf optimization, avoid calling JTF or GetValueAsync if the value factory has already completed.
+            if (this.IsValueFactoryCompleted)
+            {
+                return this.value.GetAwaiter().GetResult();
+            }
+            else
+            {
+                // Capture the factory as a local before comparing and dereferencing it since
+                // the field can transition to null and we want to gracefully handle that race condition.
+                JoinableTaskFactory factory = this.jobFactory;
+                return factory != null
+                    ? factory.Run(() => this.GetValueAsync(cancellationToken))
+                    : this.GetValueAsync(cancellationToken).GetAwaiter().GetResult();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This method embodies the optimization that many existing callers use, where they avoid the JTF.Run call if the value factory has already completed. It also avoids the GetValueAsync call entirely in that case (which goes beyond what externals can do).