### PR TITLE
Add AsyncLazyInitializer class

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,11 @@ Analyzers: [![NuGet package](https://img.shields.io/nuget/v/Microsoft.VisualStud
   * `AsyncSemaphore`
   * `AsyncReaderWriterLock`
 * Async versions of very common types
+  * `AsyncEventHandler`
   * `AsyncLazy<T>`
+  * `AsyncLazyInitializer`
   * `AsyncLocal<T>`
   * `AsyncQueue<T>`
-  * `AsyncEventHandler`
 * Await extension methods
   * Await on a `TaskScheduler` to switch to it.
     Switch to a background thread with `await TaskScheduler.Default;`

--- a/src/Microsoft.VisualStudio.Threading.Tests/AsyncLazyInitializerTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/AsyncLazyInitializerTests.cs
@@ -1,0 +1,271 @@
+﻿/********************************************************
+*                                                        *
+*   © Copyright (C) Microsoft. All rights reserved.      *
+*                                                        *
+*********************************************************/
+
+namespace Microsoft.VisualStudio.Threading.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Xunit;
+    using Xunit.Abstractions;
+
+    public class AsyncLazyInitializerTests : TestBase
+    {
+        public AsyncLazyInitializerTests(ITestOutputHelper logger)
+            : base(logger)
+        {
+        }
+
+        [Theory, CombinatorialData]
+        public void Ctor_NullAction(bool specifyJtf)
+        {
+            var jtf = specifyJtf ? new JoinableTaskContext().Factory : null; // use our own so we don't get main thread deadlocks, which isn't the point of this test.
+            Assert.Throws<ArgumentNullException>(() => new AsyncLazyInitializer(null, jtf));
+        }
+
+        [Fact]
+        public void Initialize_OnlyExecutesActionOnce_Success()
+        {
+            int invocationCount = 0;
+            var lazy = new AsyncLazyInitializer(async delegate
+            {
+                invocationCount++;
+                await Task.Yield();
+            });
+
+            Assert.Equal(0, invocationCount);
+            Assert.False(lazy.IsCompleted);
+            Assert.False(lazy.IsCompletedSuccessfully);
+
+            lazy.Initialize();
+            Assert.Equal(1, invocationCount);
+            Assert.True(lazy.IsCompleted);
+            Assert.True(lazy.IsCompletedSuccessfully);
+
+            lazy.Initialize();
+            Assert.Equal(1, invocationCount);
+            Assert.True(lazy.IsCompleted);
+            Assert.True(lazy.IsCompletedSuccessfully);
+        }
+
+        [Fact]
+        public async Task InitializeAsync_OnlyExecutesActionOnce_Success()
+        {
+            int invocationCount = 0;
+            var lazy = new AsyncLazyInitializer(async delegate
+            {
+                invocationCount++;
+                await Task.Yield();
+            });
+
+            Assert.Equal(0, invocationCount);
+            Assert.False(lazy.IsCompleted);
+            Assert.False(lazy.IsCompletedSuccessfully);
+
+            await lazy.InitializeAsync();
+            Assert.Equal(1, invocationCount);
+            Assert.True(lazy.IsCompleted);
+            Assert.True(lazy.IsCompletedSuccessfully);
+
+            await lazy.InitializeAsync();
+            Assert.Equal(1, invocationCount);
+            Assert.True(lazy.IsCompleted);
+            Assert.True(lazy.IsCompletedSuccessfully);
+        }
+
+        [Fact]
+        public void Initialize_OnlyExecutesActionOnce_Failure()
+        {
+            int invocationCount = 0;
+            var lazy = new AsyncLazyInitializer(async delegate
+            {
+                invocationCount++;
+                await Task.Yield();
+                throw new InvalidOperationException();
+            });
+
+            Assert.Equal(0, invocationCount);
+            Assert.False(lazy.IsCompleted);
+            Assert.False(lazy.IsCompletedSuccessfully);
+
+            Assert.Throws<InvalidOperationException>(() => lazy.Initialize());
+            Assert.Equal(1, invocationCount);
+            Assert.True(lazy.IsCompleted);
+            Assert.False(lazy.IsCompletedSuccessfully);
+
+            Assert.Throws<InvalidOperationException>(() => lazy.Initialize());
+            Assert.Equal(1, invocationCount);
+            Assert.True(lazy.IsCompleted);
+            Assert.False(lazy.IsCompletedSuccessfully);
+        }
+
+        [Fact]
+        public async Task InitializeAsync_OnlyExecutesActionOnce_Failure()
+        {
+            int invocationCount = 0;
+            var lazy = new AsyncLazyInitializer(async delegate
+            {
+                invocationCount++;
+                await Task.Yield();
+                throw new InvalidOperationException();
+            });
+
+            Assert.Equal(0, invocationCount);
+            Assert.False(lazy.IsCompleted);
+            Assert.False(lazy.IsCompletedSuccessfully);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => lazy.InitializeAsync());
+            Assert.Equal(1, invocationCount);
+            Assert.True(lazy.IsCompleted);
+            Assert.False(lazy.IsCompletedSuccessfully);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => lazy.InitializeAsync());
+            Assert.Equal(1, invocationCount);
+            Assert.True(lazy.IsCompleted);
+            Assert.False(lazy.IsCompletedSuccessfully);
+        }
+
+        /// <summary>
+        /// Verifies that even after the action has been invoked
+        /// its dependency on the Main thread can be satisfied by
+        /// someone synchronously blocking on the Main thread that is
+        /// also interested in its completion.
+        /// </summary>
+        [Fact]
+        public void InitializeAsync_RequiresMainThreadHeldByOther()
+        {
+            var context = this.InitializeJTCAndSC();
+            var jtf = context.Factory;
+
+            var evt = new AsyncManualResetEvent();
+            var lazy = new AsyncLazyInitializer(
+                async delegate
+                {
+                    await evt; // use an event here to ensure it won't resume till the Main thread is blocked.
+                },
+                jtf);
+
+            var resultTask = lazy.InitializeAsync();
+            Assert.False(resultTask.IsCompleted);
+
+            var collection = context.CreateCollection();
+            var someRandomPump = context.CreateFactory(collection);
+            someRandomPump.Run(async delegate
+            {
+                evt.Set(); // setting this event allows the value factory to resume, once it can get the Main thread.
+
+                // The interesting bit we're testing here is that
+                // the value factory has already been invoked.  It cannot
+                // complete until the Main thread is available and we're blocking
+                // the Main thread waiting for it to complete.
+                // This will deadlock unless the AsyncLazy joins
+                // the value factory's async pump with the currently blocking one.
+                await lazy.InitializeAsync();
+            });
+
+            // Now that the value factory has completed, the earlier acquired
+            // task should have no problem completing.
+            Assert.True(resultTask.Wait(AsyncDelay));
+        }
+
+        /// <summary>
+        /// Verifies that even after the action has been invoked
+        /// its dependency on the Main thread can be satisfied by
+        /// someone synchronously blocking on the Main thread that is
+        /// also interested in its completion.
+        /// </summary>
+        [Fact]
+        public void Initialize_RequiresMainThreadHeldByOther()
+        {
+            var context = this.InitializeJTCAndSC();
+            var jtf = context.Factory;
+
+            var evt = new AsyncManualResetEvent();
+            var lazy = new AsyncLazyInitializer(
+                async delegate
+                {
+                    await evt; // use an event here to ensure it won't resume till the Main thread is blocked.
+                },
+                jtf);
+
+            var resultTask = lazy.InitializeAsync();
+            Assert.False(resultTask.IsCompleted);
+
+            evt.Set(); // setting this event allows the value factory to resume, once it can get the Main thread.
+
+            // The interesting bit we're testing here is that
+            // the value factory has already been invoked.  It cannot
+            // complete until the Main thread is available and we're blocking
+            // the Main thread waiting for it to complete.
+            // This will deadlock unless the AsyncLazyExecution joins
+            // the action's JoinableTaskFactory with the currently blocking one.
+            lazy.Initialize();
+
+            // Now that the action has completed, the earlier acquired
+            // task should have no problem completing.
+            Assert.True(resultTask.Wait(AsyncDelay));
+        }
+
+        [Fact]
+        public async Task Initialize_Canceled()
+        {
+            var cts = new CancellationTokenSource();
+            var evt = new AsyncManualResetEvent();
+            var lazy = new AsyncLazyInitializer(evt.WaitAsync);
+            Task lazyTask = Task.Run(() => lazy.Initialize(cts.Token));
+            cts.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => lazyTask);
+        }
+
+        [Fact]
+        public async Task InitializeAsync_Canceled()
+        {
+            var cts = new CancellationTokenSource();
+            var evt = new AsyncManualResetEvent();
+            var lazy = new AsyncLazyInitializer(evt.WaitAsync);
+            Task lazyTask = lazy.InitializeAsync(cts.Token);
+            cts.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => lazyTask);
+        }
+
+        [Fact]
+        public void Initialize_Precanceled()
+        {
+            bool invoked = false;
+            var evt = new AsyncManualResetEvent();
+            var lazy = new AsyncLazyInitializer(delegate
+            {
+                invoked = true;
+                return evt.WaitAsync();
+            });
+            Assert.ThrowsAny<OperationCanceledException>(() => lazy.Initialize(new CancellationToken(canceled: true)));
+            Assert.False(invoked);
+        }
+
+        [Fact]
+        public async Task InitializeAsync_Precanceled()
+        {
+            bool invoked = false;
+            var evt = new AsyncManualResetEvent();
+            var lazy = new AsyncLazyInitializer(delegate
+            {
+                invoked = true;
+                return evt.WaitAsync();
+            });
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => lazy.InitializeAsync(new CancellationToken(canceled: true)));
+            Assert.False(invoked);
+        }
+
+        private JoinableTaskContext InitializeJTCAndSC()
+        {
+            SynchronizationContext.SetSynchronizationContext(SingleThreadedSynchronizationContext.New());
+            return new JoinableTaskContext();
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Threading/AsyncLazyInitializer.cs
+++ b/src/Microsoft.VisualStudio.Threading/AsyncLazyInitializer.cs
@@ -16,7 +16,10 @@ namespace Microsoft.VisualStudio.Threading
     /// </summary>
     public class AsyncLazyInitializer
     {
-        private AsyncLazy<EmptyStruct> lazy;
+        /// <summary>
+        /// The lazy instance we use internally for the bulk of the behavior we want.
+        /// </summary>
+        private readonly AsyncLazy<EmptyStruct> lazy;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AsyncLazyInitializer"/> class.

--- a/src/Microsoft.VisualStudio.Threading/AsyncLazyInitializer.cs
+++ b/src/Microsoft.VisualStudio.Threading/AsyncLazyInitializer.cs
@@ -1,0 +1,63 @@
+﻿/********************************************************
+*                                                        *
+*   © Copyright (C) Microsoft. All rights reserved.      *
+*                                                        *
+*********************************************************/
+
+namespace Microsoft.VisualStudio.Threading
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Lazily executes a delegate that has some side effect (typically initializing something)
+    /// such that the delegate runs at most once.
+    /// </summary>
+    public class AsyncLazyInitializer
+    {
+        private AsyncLazy<EmptyStruct> lazy;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AsyncLazyInitializer"/> class.
+        /// </summary>
+        /// <param name="action">The action to perform at most once, that has some desirable side-effect.</param>
+        /// <param name="joinableTaskFactory">The factory to use when invoking the <paramref name="action"/> in <see cref="InitializeAsync(CancellationToken)"/> to avoid deadlocks when the main thread is required by the <paramref name="action"/>.</param>
+        public AsyncLazyInitializer(Func<Task> action, JoinableTaskFactory joinableTaskFactory = null)
+        {
+            Requires.NotNull(action, nameof(action));
+            this.lazy = new AsyncLazy<EmptyStruct>(
+                async delegate
+                {
+                    await action().ConfigureAwaitRunInline();
+                    return default;
+                },
+                joinableTaskFactory);
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the action has executed completely, regardless of whether it threw an exception.
+        /// </summary>
+        public bool IsCompleted => this.lazy.IsValueFactoryCompleted;
+
+        /// <summary>
+        /// Gets a value indicating whether the action has executed completely without throwing an exception.
+        /// </summary>
+        public bool IsCompletedSuccessfully => this.lazy.IsValueFactoryCompleted && this.lazy.GetValueAsync().Status == TaskStatus.RanToCompletion;
+
+        /// <summary>
+        /// Executes the action given in the constructor if it has not yet been executed,
+        /// or waits for it to complete if in progress from a prior call.
+        /// </summary>
+        /// <exception cref="Exception">Any exception thrown by the action is rethrown here.</exception>
+        public void Initialize(CancellationToken cancellationToken = default) => this.lazy.GetValue(cancellationToken);
+
+        /// <summary>
+        /// Executes the action given in the constructor if it has not yet been executed,
+        /// or waits for it to complete if in progress from a prior call.
+        /// </summary>
+        /// <returns>A task that tracks completion of the action.</returns>
+        /// <exception cref="Exception">Any exception thrown by the action is rethrown here.</exception>
+        public Task InitializeAsync(CancellationToken cancellationToken = default) => this.lazy.GetValueAsync(cancellationToken);
+    }
+}


### PR DESCRIPTION
This addresses the need that people have used AsyncLazy<object> for, where the returned value from the value factory was not important.