### PR TITLE
Add missing handling for OperationCanceledException in DebuggableWrapper

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Utils.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Utils.cs
@@ -36,6 +36,10 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
                 {
                     handler(ctxt);
                 }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
                 catch (Exception ex) when (LaunchDebuggerExceptionFilter())
                 {
                     throw new Exception($"Analyzer failure while processing syntax at {ctxt.Node.SyntaxTree.FilePath}({ctxt.Node.GetLocation()?.GetLineSpan().StartLinePosition.Line + 1},{ctxt.Node.GetLocation()?.GetLineSpan().StartLinePosition.Character + 1}): {ex.GetType()} {ex.Message}. Syntax: {ctxt.Node}", ex);


### PR DESCRIPTION
Without this, analyzers observing cancellation end up re-wrapping the exception and showing errors in Visual Studio.