### PR TITLE
Disable generated code analysis for VSTHRD012 and VSTHRD105

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD012SpecifyJtfWhereAllowed.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD012SpecifyJtfWhereAllowed.cs
@@ -1,11 +1,8 @@
 ﻿namespace Microsoft.VisualStudio.Threading.Analyzers
 {
-    using System;
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
     using CodeAnalysis;
     using CodeAnalysis.CSharp;
     using CodeAnalysis.CSharp.Syntax;
@@ -29,6 +26,8 @@
 
         public override void Initialize(AnalysisContext context)
         {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             context.RegisterSyntaxNodeAction(Utils.DebuggableWrapper(this.AnalyzeInvocation), SyntaxKind.InvocationExpression);
             context.RegisterSyntaxNodeAction(Utils.DebuggableWrapper(this.AnalyzerObjectCreation), SyntaxKind.ObjectCreationExpression);
         }

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD105AvoidImplicitTaskSchedulerCurrentAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD105AvoidImplicitTaskSchedulerCurrentAnalyzer.cs
@@ -48,6 +48,8 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
 
         public override void Initialize(AnalysisContext context)
         {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
             context.RegisterSyntaxNodeAction(Utils.DebuggableWrapper(this.AnalyzeInvocation), SyntaxKind.InvocationExpression);
         }
 


### PR DESCRIPTION
📝 If either of these is *supposed* to analyze generated code, let me know and I can update it to explicitly state this.