### PR TITLE
Explicitly configure VSTHRD012 and VSTHRD105 for generated code analysis

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD012SpecifyJtfWhereAllowed.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD012SpecifyJtfWhereAllowed.cs
@@ -1,11 +1,8 @@
 ﻿namespace Microsoft.VisualStudio.Threading.Analyzers
 {
-    using System;
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
     using CodeAnalysis;
     using CodeAnalysis.CSharp;
     using CodeAnalysis.CSharp.Syntax;
@@ -29,6 +26,8 @@
 
         public override void Initialize(AnalysisContext context)
         {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+
             context.RegisterSyntaxNodeAction(Utils.DebuggableWrapper(this.AnalyzeInvocation), SyntaxKind.InvocationExpression);
             context.RegisterSyntaxNodeAction(Utils.DebuggableWrapper(this.AnalyzerObjectCreation), SyntaxKind.ObjectCreationExpression);
         }

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD105AvoidImplicitTaskSchedulerCurrentAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD105AvoidImplicitTaskSchedulerCurrentAnalyzer.cs
@@ -48,6 +48,8 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
 
         public override void Initialize(AnalysisContext context)
         {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+
             context.RegisterSyntaxNodeAction(Utils.DebuggableWrapper(this.AnalyzeInvocation), SyntaxKind.InvocationExpression);
         }
 


### PR DESCRIPTION
These are correctness rules, not style rules, so diagnostics are equally relevant in generated code and user code.