### PR TITLE
Add code fix provider for VSTHRD109

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD109AvoidAssertInAsyncMethodsAnalyzerTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD109AvoidAssertInAsyncMethodsAnalyzerTests.cs
@@ -2,7 +2,7 @@
 {
     using System.Threading.Tasks;
     using Xunit;
-    using Verify = CSharpCodeFixVerifier<VSTHRD109AvoidAssertInAsyncMethodsAnalyzer, CodeAnalysis.Testing.EmptyCodeFixProvider>;
+    using Verify = CSharpCodeFixVerifier<VSTHRD109AvoidAssertInAsyncMethodsAnalyzer, VSTHRD109AvoidAssertInAsyncMethodsCodeFix>;
 
     public class VSTHRD109AvoidAssertInAsyncMethodsAnalyzerTests
     {
@@ -22,8 +22,56 @@ class Test {
 }
 ";
 
+            var fix = @"
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+using Task = System.Threading.Tasks.Task;
+
+class Test {
+    async Task FooAsync() {
+        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+        await Task.Yield();
+    }
+}
+";
+
             var expected = Verify.Diagnostic().WithSpan(8, 22, 8, 42);
-            await Verify.VerifyAnalyzerAsync(test, expected);
+            await Verify.VerifyCodeFixAsync(test, expected, fix);
+        }
+
+        [Fact]
+        public async Task AsyncMethodAsserts_CodeFixReusesCancellationToken()
+        {
+            var test = @"
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+using Task = System.Threading.Tasks.Task;
+
+class Test {
+    async Task FooAsync(CancellationToken ct) {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        await Task.Yield();
+    }
+}
+";
+
+            var fix = @"
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+using Task = System.Threading.Tasks.Task;
+
+class Test {
+    async Task FooAsync(CancellationToken ct) {
+        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(ct);
+        await Task.Yield();
+    }
+}
+";
+
+            var expected = Verify.Diagnostic().WithSpan(9, 22, 9, 42);
+            await Verify.VerifyCodeFixAsync(test, expected, fix);
         }
 
         [Fact]
@@ -42,8 +90,21 @@ class Test {
 }
 ";
 
+            var fix = @"
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+using Task = System.Threading.Tasks.Task;
+
+class Test {
+    async Task<int> FooAsync() {
+        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+        return 1;
+    }
+}
+";
+
             var expected = Verify.Diagnostic().WithSpan(8, 22, 8, 42);
-            await Verify.VerifyAnalyzerAsync(test, expected);
+            await Verify.VerifyCodeFixAsync(test, expected, fix);
         }
 
         [Fact]
@@ -100,12 +161,103 @@ class Test {
 }
 ";
 
+            var fix = @"
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+using Task = System.Threading.Tasks.Task;
+
+class Test {
+    void Foo() {
+        Task.Run(async delegate {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            await Task.Yield();
+        });
+    }
+}
+";
+
             var expected = Verify.Diagnostic().WithSpan(9, 26, 9, 46);
-            await Verify.VerifyAnalyzerAsync(test, expected);
+            await Verify.VerifyCodeFixAsync(test, expected, fix);
+        }
+
+        [Fact]
+        public async Task AsyncAnonymousFunctionInsideVoidMethod_CodeFixReusesCancellationToken()
+        {
+            var test = @"
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+using Task = System.Threading.Tasks.Task;
+
+class Test {
+    void Foo(CancellationToken ct) {
+        Task.Run(async delegate {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            await Task.Yield();
+        });
+    }
+}
+";
+
+            var fix = @"
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+using Task = System.Threading.Tasks.Task;
+
+class Test {
+    void Foo(CancellationToken ct) {
+        Task.Run(async delegate {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(ct);
+            await Task.Yield();
+        });
+    }
+}
+";
+
+            var expected = Verify.Diagnostic().WithSpan(10, 26, 10, 46);
+            await Verify.VerifyCodeFixAsync(test, expected, fix);
         }
 
         [Fact]
         public async Task TaskReturningLambdaInsideVoidMethod_GeneratesDiagnostic()
+        {
+            var test = @"
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+using Task = System.Threading.Tasks.Task;
+
+class Test {
+    void Foo() {
+        Task.Run<int>(() => {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            return Task.FromResult(1);
+        });
+    }
+}
+";
+
+            var fix = @"
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+using Task = System.Threading.Tasks.Task;
+
+class Test {
+    void Foo() {
+        Task.Run<int>(async () => {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            return 1;
+        });
+    }
+}
+";
+
+            var expected = Verify.Diagnostic().WithSpan(9, 26, 9, 46);
+            await Verify.VerifyCodeFixAsync(test, expected, fix);
+        }
+
+        [Fact(Skip = "Fails because the semantic model claims the anonymous func returns Task instead of Task<int>. We should probably skip that check and always preserve return statements.")]
+        public async Task TaskReturningLambdaInsideVoidMethod_NoTypeArg_GeneratesDiagnostic()
         {
             var test = @"
 using System.Threading.Tasks;
@@ -122,8 +274,23 @@ class Test {
 }
 ";
 
+            var fix = @"
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+using Task = System.Threading.Tasks.Task;
+
+class Test {
+    void Foo() {
+        Task.Run(async () => {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            return 1;
+        });
+    }
+}
+";
+
             var expected = Verify.Diagnostic().WithSpan(9, 26, 9, 46);
-            await Verify.VerifyAnalyzerAsync(test, expected);
+            await Verify.VerifyCodeFixAsync(test, expected, fix);
         }
 
         [Fact]

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/CommonInterest.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/CommonInterest.cs
@@ -11,6 +11,7 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
@@ -171,18 +172,19 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
         {
             foreach (string line in ReadAdditionalFiles(analyzerOptions, fileNamePattern, cancellationToken))
             {
-                Match match = MemberReferenceRegex.Match(line);
-                if (!match.Success)
-                {
-                    throw new InvalidOperationException($"Parsing error on line: {line}");
-                }
-
-                string methodName = match.Groups["memberName"].Value;
-                string[] typeNameElements = match.Groups["typeName"].Value.Split(QualifiedIdentifierSeparators);
-                string typeName = typeNameElements[typeNameElements.Length - 1];
-                var containingType = new QualifiedType(typeNameElements.Take(typeNameElements.Length - 1).ToImmutableArray(), typeName);
-                yield return new QualifiedMember(containingType, methodName);
+                yield return ParseAdditionalFileMethodLine(line);
             }
+        }
+
+        internal static async Task<ImmutableArray<QualifiedMember>> ReadMethodsAsync(CodeFixContext codeFixContext, Regex fileNamePattern, CancellationToken cancellationToken)
+        {
+            var result = ImmutableArray.CreateBuilder<QualifiedMember>();
+            foreach (string line in await ReadAdditionalFilesAsync(codeFixContext.Document.Project.AdditionalDocuments, fileNamePattern, cancellationToken))
+            {
+                result.Add(ParseAdditionalFileMethodLine(line));
+            }
+
+            return result.ToImmutable();
         }
 
         internal static IEnumerable<TypeMatchSpec> ReadTypesAndMembers(AnalyzerOptions analyzerOptions, Regex fileNamePattern, CancellationToken cancellationToken)
@@ -205,6 +207,32 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
             }
         }
 
+        internal static async Task<ImmutableArray<string>> ReadAdditionalFilesAsync(IEnumerable<TextDocument> additionalFiles, Regex fileNamePattern, CancellationToken cancellationToken)
+        {
+            if (additionalFiles == null)
+            {
+                throw new ArgumentNullException(nameof(additionalFiles));
+            }
+
+            if (fileNamePattern == null)
+            {
+                throw new ArgumentNullException(nameof(fileNamePattern));
+            }
+
+            var docs = from doc in additionalFiles.OrderBy(x => x.FilePath, StringComparer.Ordinal)
+                       let fileName = Path.GetFileName(doc.Name)
+                       where fileNamePattern.IsMatch(fileName)
+                       select doc;
+            var result = ImmutableArray.CreateBuilder<string>();
+            foreach (var doc in docs)
+            {
+                var text = await doc.GetTextAsync(cancellationToken);
+                result.AddRange(ReadLinesFromAdditionalFile(text));
+            }
+
+            return result.ToImmutable();
+        }
+
         internal static IEnumerable<string> ReadAdditionalFiles(AnalyzerOptions analyzerOptions, Regex fileNamePattern, CancellationToken cancellationToken)
         {
             if (analyzerOptions == null)
@@ -217,21 +245,12 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
                 throw new ArgumentNullException(nameof(fileNamePattern));
             }
 
-            var lines = from file in analyzerOptions.AdditionalFiles.OrderBy(x => x.Path, StringComparer.Ordinal)
+            var docs = from file in analyzerOptions.AdditionalFiles.OrderBy(x => x.Path, StringComparer.Ordinal)
                         let fileName = Path.GetFileName(file.Path)
                         where fileNamePattern.IsMatch(fileName)
                         let text = file.GetText(cancellationToken)
-                        from line in text.Lines
-                        select line;
-            foreach (TextLine line in lines)
-            {
-                string lineText = line.ToString();
-
-                if (!string.IsNullOrWhiteSpace(lineText) && !lineText.StartsWith("#"))
-                {
-                    yield return lineText;
-                }
-            }
+                        select text;
+            return docs.SelectMany(ReadLinesFromAdditionalFile);
         }
 
         internal static bool Contains(this ImmutableArray<QualifiedMember> methods, ISymbol symbol)
@@ -267,6 +286,39 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
             }
 
             return !matching.IsEmpty && !matching.InvertedLogic;
+        }
+
+        private static IEnumerable<string> ReadLinesFromAdditionalFile(SourceText text)
+        {
+            if (text == null)
+            {
+                throw new ArgumentNullException(nameof(text));
+            }
+
+            foreach (TextLine line in text.Lines)
+            {
+                string lineText = line.ToString();
+
+                if (!string.IsNullOrWhiteSpace(lineText) && !lineText.StartsWith("#"))
+                {
+                    yield return lineText;
+                }
+            }
+        }
+
+        private static QualifiedMember ParseAdditionalFileMethodLine(string line)
+        {
+            Match match = MemberReferenceRegex.Match(line);
+            if (!match.Success)
+            {
+                throw new InvalidOperationException($"Parsing error on line: {line}");
+            }
+
+            string methodName = match.Groups["memberName"].Value;
+            string[] typeNameElements = match.Groups["typeName"].Value.Split(QualifiedIdentifierSeparators);
+            string typeName = typeNameElements[typeNameElements.Length - 1];
+            var containingType = new QualifiedType(typeNameElements.Take(typeNameElements.Length - 1).ToImmutableArray(), typeName);
+            return new QualifiedMember(containingType, methodName);
         }
 
         internal struct TypeMatchSpec

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Utils.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Utils.cs
@@ -773,6 +773,131 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
             return $"https://github.com/Microsoft/vs-threading/blob/master/doc/analyzers/{analyzerId}.md";
         }
 
+        /// <summary>
+        /// Looks for a symbol that represents a <see cref="CancellationToken"/> near
+        /// some document location that might be consumed in some generated invocation.
+        /// </summary>
+        /// <param name="semanticModel">The semantic model of the document.</param>
+        /// <param name="positionForLookup">The position in the document that must have access to any candidate <see cref="CancellationToken"/>.</param>
+        /// <param name="cancellationToken">A token that represents lost interest in this inquiry.</param>
+        /// <returns>Candidate <see cref="CancellationToken"/> symbols.</returns>
+        internal static IEnumerable<ISymbol> FindCancellationToken(SemanticModel semanticModel, int positionForLookup, CancellationToken cancellationToken)
+        {
+            if (semanticModel == null)
+            {
+                throw new ArgumentNullException(nameof(semanticModel));
+            }
+
+            var enclosingSymbol = semanticModel.GetEnclosingSymbol(positionForLookup, cancellationToken);
+            if (enclosingSymbol == null)
+            {
+                return null;
+            }
+
+            var cancellationTokenSymbols = semanticModel.LookupSymbols(positionForLookup)
+                .Where(s => (s.IsStatic || !enclosingSymbol.IsStatic) && s.CanBeReferencedByName && IsSymbolTheRightType(s, nameof(CancellationToken), Namespaces.SystemThreading))
+                .OrderBy(s => s.ContainingSymbol.Equals(enclosingSymbol) ? 1 : s.ContainingType.Equals(enclosingSymbol.ContainingType) ? 2 : 3); // prefer locality
+            return cancellationTokenSymbols;
+        }
+
+        /// <summary>
+        /// Find a set of methods that match a given method's fully qualified name.
+        /// </summary>
+        /// <param name="semanticModel">The semantic model of the document that must be able to access the methods.</param>
+        /// <param name="methodAsString">The fully-qualified name of the method.</param>
+        /// <returns>An enumeration of method symbols with a matching name.</returns>
+        internal static IEnumerable<IMethodSymbol> FindMethodGroup(SemanticModel semanticModel, string methodAsString)
+        {
+            if (semanticModel == null)
+            {
+                throw new ArgumentNullException(nameof(semanticModel));
+            }
+
+            if (string.IsNullOrEmpty(methodAsString))
+            {
+                throw new ArgumentException("A non-empty value is required.", nameof(methodAsString));
+            }
+
+            var (fullTypeName, methodName) = SplitOffLastElement(methodAsString);
+            var (ns, leafTypeName) = SplitOffLastElement(fullTypeName);
+            string[] namespaces = ns?.Split('.');
+            if (fullTypeName == null)
+            {
+                return Enumerable.Empty<IMethodSymbol>();
+            }
+
+            var proposedType = semanticModel.Compilation.GetTypeByMetadataName(fullTypeName);
+
+            return proposedType?.GetMembers(methodName).OfType<IMethodSymbol>() ?? Enumerable.Empty<IMethodSymbol>();
+        }
+
+        /// <summary>
+        /// Find a set of methods that match a given method's fully qualified name.
+        /// </summary>
+        /// <param name="semanticModel">The semantic model of the document that must be able to access the methods.</param>
+        /// <param name="method">The fully-qualified name of the method.</param>
+        /// <returns>An enumeration of method symbols with a matching name.</returns>
+        internal static IEnumerable<IMethodSymbol> FindMethodGroup(SemanticModel semanticModel, CommonInterest.QualifiedMember method)
+        {
+            if (semanticModel == null)
+            {
+                throw new ArgumentNullException(nameof(semanticModel));
+            }
+
+            var proposedType = semanticModel.Compilation.GetTypeByMetadataName(method.ContainingType.ToString());
+            return proposedType?.GetMembers(method.Name).OfType<IMethodSymbol>() ?? Enumerable.Empty<IMethodSymbol>();
+        }
+
+        /// <summary>
+        /// Finds a local variable, field, property, or static member on another type
+        /// that is typed to return a value of a given type.
+        /// </summary>
+        /// <param name="typeSymbol">The type of value required.</param>
+        /// <param name="semanticModel">The semantic model of the document that must be able to access the value.</param>
+        /// <param name="positionForLookup">The position in the document where the value must be accessible.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>An enumeration of symbols that can provide a value of the required type, together with a flag indicating whether they are accessible using "local" syntax (i.e. the symbol is a local variable or a field on the enclosing type).</returns>
+        internal static IEnumerable<Tuple<bool, ISymbol>> FindInstanceOf(INamedTypeSymbol typeSymbol, SemanticModel semanticModel, int positionForLookup, CancellationToken cancellationToken)
+        {
+            if (typeSymbol == null)
+            {
+                throw new ArgumentNullException(nameof(typeSymbol));
+            }
+
+            if (semanticModel == null)
+            {
+                throw new ArgumentNullException(nameof(semanticModel));
+            }
+
+            var enclosingSymbol = semanticModel.GetEnclosingSymbol(positionForLookup, cancellationToken);
+
+            // Search fields on the declaring type.
+            // Consider local variables too, if they're captured in a closure from some surrounding code block
+            // such that they would presumably be initialized by the time the first statement in our own code block runs.
+            ITypeSymbol enclosingTypeSymbol = enclosingSymbol as ITypeSymbol ?? enclosingSymbol.ContainingType;
+            if (enclosingTypeSymbol != null)
+            {
+                var candidateMembers = from symbol in semanticModel.LookupSymbols(positionForLookup, enclosingTypeSymbol)
+                                       where symbol.IsStatic || !enclosingSymbol.IsStatic
+                                       where IsSymbolTheRightType(symbol, typeSymbol.Name, typeSymbol.ContainingNamespace)
+                                       select symbol;
+                foreach (var candidate in candidateMembers)
+                {
+                    yield return Tuple.Create(true, candidate);
+                }
+            }
+
+            // Find static fields/properties that return the matching type from other public, non-generic types.
+            var candidateStatics = from offering in semanticModel.LookupStaticMembers(positionForLookup).OfType<ITypeSymbol>()
+                                   from symbol in offering.GetMembers()
+                                   where symbol.IsStatic && symbol.CanBeReferencedByName && IsSymbolTheRightType(symbol, typeSymbol.Name, typeSymbol.ContainingNamespace)
+                                   select symbol;
+            foreach (var candidate in candidateStatics)
+            {
+                yield return Tuple.Create(false, candidate);
+            }
+        }
+
         internal static T FirstAncestor<T>(this SyntaxNode startingNode, IReadOnlyCollection<Type> doNotPassNodeTypes)
             where T : SyntaxNode
         {
@@ -798,6 +923,49 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
             }
 
             return default(T);
+        }
+
+        internal static Tuple<string, string> SplitOffLastElement(string qualifiedName)
+        {
+            if (qualifiedName == null)
+            {
+                return Tuple.Create<string, string>(null, null);
+            }
+
+            int lastPeriod = qualifiedName.LastIndexOf('.');
+            if (lastPeriod < 0)
+            {
+                return Tuple.Create<string, string>(null, qualifiedName);
+            }
+
+            return Tuple.Create(qualifiedName.Substring(0, lastPeriod), qualifiedName.Substring(lastPeriod + 1));
+        }
+
+        /// <summary>
+        /// Determines whether a given parameter accepts a <see cref="CancellationToken"/>.
+        /// </summary>
+        /// <param name="parameterSymbol">The parameter.</param>
+        /// <returns><c>true</c> if the parameter takes a <see cref="CancellationToken"/>; <c>false</c> otherwise.</returns>
+        internal static bool IsCancellationTokenParameter(IParameterSymbol parameterSymbol) => parameterSymbol?.Type.Name == nameof(CancellationToken) && parameterSymbol.Type.BelongsToNamespace(Namespaces.SystemThreading);
+
+        private static bool IsSymbolTheRightType(ISymbol symbol, string typeName, IReadOnlyList<string> namespaces)
+        {
+            var fieldSymbol = symbol as IFieldSymbol;
+            var propertySymbol = symbol as IPropertySymbol;
+            var parameterSymbol = symbol as IParameterSymbol;
+            var localSymbol = symbol as ILocalSymbol;
+            var memberType = fieldSymbol?.Type ?? propertySymbol?.Type ?? parameterSymbol?.Type ?? localSymbol?.Type;
+            return memberType?.Name == typeName && memberType.BelongsToNamespace(namespaces);
+        }
+
+        private static bool IsSymbolTheRightType(ISymbol symbol, string typeName, INamespaceSymbol namespaces)
+        {
+            var fieldSymbol = symbol as IFieldSymbol;
+            var propertySymbol = symbol as IPropertySymbol;
+            var parameterSymbol = symbol as IParameterSymbol;
+            var localSymbol = symbol as ILocalSymbol;
+            var memberType = fieldSymbol?.Type ?? propertySymbol?.Type ?? parameterSymbol?.Type ?? localSymbol?.Type;
+            return memberType?.Name == typeName && memberType.ContainingNamespace.Equals(namespaces);
         }
 
         private static CSharpSyntaxNode UpdateStatementsForAsyncMethod(CSharpSyntaxNode body, SemanticModel semanticModel, bool hasResultValue, CancellationToken cancellationToken)

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD109AvoidAssertInAsyncMethodsCodeFix.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD109AvoidAssertInAsyncMethodsCodeFix.cs
@@ -1,0 +1,152 @@
+﻿namespace Microsoft.VisualStudio.Threading.Analyzers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Linq;
+    using System.Text;
+    using System.Text.RegularExpressions;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CodeActions;
+    using Microsoft.CodeAnalysis.CodeFixes;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Formatting;
+    using Microsoft.CodeAnalysis.Simplification;
+    using Microsoft.VisualStudio.Threading;
+
+    [ExportCodeFixProvider(LanguageNames.CSharp)]
+    public class VSTHRD109AvoidAssertInAsyncMethodsCodeFix : CodeFixProvider
+    {
+        private static readonly ImmutableArray<string> ReusableFixableDiagnosticIds = ImmutableArray.Create(
+            VSTHRD109AvoidAssertInAsyncMethodsAnalyzer.Id);
+
+        public override ImmutableArray<string> FixableDiagnosticIds => ReusableFixableDiagnosticIds;
+
+        /// <inheritdoc />
+        public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            foreach (var diagnostic in context.Diagnostics)
+            {
+                var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+                var syntaxNode = (ExpressionSyntax)root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
+
+                var container = Utils.GetContainingFunction(syntaxNode);
+                if (container.BlockOrExpression == null)
+                {
+                    return;
+                }
+
+                if (!container.IsAsync)
+                {
+                    if (!(container.Function is MethodDeclarationSyntax || container.Function is AnonymousFunctionExpressionSyntax))
+                    {
+                        // We don't support converting whatever this is into an async method.
+                        return;
+                    }
+                }
+
+                var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+                var enclosingSymbol = semanticModel.GetEnclosingSymbol(diagnostic.Location.SourceSpan.Start, context.CancellationToken);
+                if (enclosingSymbol == null)
+                {
+                    return;
+                }
+
+                var options = await CommonInterest.ReadMethodsAsync(context, CommonInterest.FileNamePatternForMethodsThatSwitchToMainThread, context.CancellationToken);
+                int positionForLookup = diagnostic.Location.SourceSpan.Start;
+                ISymbol cancellationTokenSymbol = Utils.FindCancellationToken(semanticModel, positionForLookup, context.CancellationToken).FirstOrDefault();
+                foreach (var option in options)
+                {
+                    // We're looking for methods that either require no parameters,
+                    // or (if we have one to give) that have just one parameter that is a CancellationToken.
+                    var proposedMethod = Utils.FindMethodGroup(semanticModel, option)
+                        .FirstOrDefault(m => !m.Parameters.Any(p => !p.HasExplicitDefaultValue) ||
+                            (cancellationTokenSymbol != null && m.Parameters.Length == 1 && Utils.IsCancellationTokenParameter(m.Parameters[0])));
+                    if (proposedMethod == null)
+                    {
+                        // We can't find it, so don't offer to use it.
+                        continue;
+                    }
+
+                    if (proposedMethod.IsStatic)
+                    {
+                        OfferFix(option.ToString());
+                    }
+                    else
+                    {
+                        foreach (var candidate in Utils.FindInstanceOf(proposedMethod.ContainingType, semanticModel, positionForLookup, context.CancellationToken))
+                        {
+                            if (candidate.Item1)
+                            {
+                                OfferFix($"{candidate.Item2.Name}.{proposedMethod.Name}");
+                            }
+                            else
+                            {
+                                OfferFix($"{candidate.Item2.ContainingNamespace}.{candidate.Item2.ContainingType.Name}.{candidate.Item2.Name}.{proposedMethod.Name}");
+                            }
+                        }
+                    }
+
+                    void OfferFix(string fullyQualifiedMethod)
+                    {
+                        context.RegisterCodeFix(CodeAction.Create($"Use 'await {fullyQualifiedMethod}'", ct => Fix(fullyQualifiedMethod, proposedMethod, ct), fullyQualifiedMethod), context.Diagnostics);
+                    }
+                }
+
+                async Task<Solution> Fix(string fullyQualifiedMethod, IMethodSymbol methodSymbol, CancellationToken cancellationToken)
+                {
+                    var assertionStatementToRemove = syntaxNode.FirstAncestorOrSelf<StatementSyntax>();
+
+                    int typeAndMethodDelimiterIndex = fullyQualifiedMethod.LastIndexOf('.');
+                    IdentifierNameSyntax methodName = SyntaxFactory.IdentifierName(fullyQualifiedMethod.Substring(typeAndMethodDelimiterIndex + 1));
+                    ExpressionSyntax invokedMethod = Utils.MemberAccess(fullyQualifiedMethod.Substring(0, typeAndMethodDelimiterIndex).Split('.'), methodName)
+                        .WithAdditionalAnnotations(Simplifier.Annotation);
+                    var invocationExpression = SyntaxFactory.InvocationExpression(invokedMethod);
+                    var cancellationTokenParameter = methodSymbol.Parameters.FirstOrDefault(Utils.IsCancellationTokenParameter);
+                    if (cancellationTokenParameter != null && cancellationTokenSymbol != null)
+                    {
+                        var arg = SyntaxFactory.Argument(SyntaxFactory.IdentifierName(cancellationTokenSymbol.Name));
+                        if (methodSymbol.Parameters.IndexOf(cancellationTokenParameter) > 0)
+                        {
+                            arg = arg.WithNameColon(SyntaxFactory.NameColon(SyntaxFactory.IdentifierName(cancellationTokenParameter.Name)));
+                        }
+
+                        invocationExpression = invocationExpression.AddArgumentListArguments(arg);
+                    }
+
+                    ExpressionSyntax awaitExpression = SyntaxFactory.AwaitExpression(invocationExpression);
+                    var addedStatement = SyntaxFactory.ExpressionStatement(awaitExpression)
+                        .WithAdditionalAnnotations(Simplifier.Annotation, Formatter.Annotation);
+
+                    var methodAnnotation = new SyntaxAnnotation();
+                    CSharpSyntaxNode methodSyntax = container.Function.ReplaceNode(assertionStatementToRemove, addedStatement)
+                        .WithAdditionalAnnotations(methodAnnotation);
+                    Document newDocument = context.Document.WithSyntaxRoot(root.ReplaceNode(container.Function, methodSyntax));
+                    var newSyntaxRoot = await newDocument.GetSyntaxRootAsync(cancellationToken);
+                    methodSyntax = (CSharpSyntaxNode)newSyntaxRoot.GetAnnotatedNodes(methodAnnotation).Single();
+                    if (!container.IsAsync)
+                    {
+                        switch (methodSyntax)
+                        {
+                            case AnonymousFunctionExpressionSyntax anonFunc:
+                                semanticModel = await newDocument.GetSemanticModelAsync(cancellationToken);
+                                methodSyntax = Utils.MakeMethodAsync(anonFunc, semanticModel, cancellationToken);
+                                newDocument = newDocument.WithSyntaxRoot(newSyntaxRoot.ReplaceNode(anonFunc, methodSyntax));
+                                break;
+                            case MethodDeclarationSyntax methodDecl:
+                                (newDocument, methodSyntax) = await Utils.MakeMethodAsync(methodDecl, newDocument, cancellationToken);
+                                break;
+                        }
+                    }
+
+                    return newDocument.Project.Solution;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This required some of the same code fixer functionality already found in the VSTHRD010 code fixer, so a few chunks of code got moved from that fixer into the Utils class.

There are several tested scenarios, but the crux of the fix is that it changes this:

```cs
    async Task FooAsync(CancellationToken ct) {
        ThreadHelper.ThrowIfNotOnUIThread(); // VSTHRD109 diagnostic here
        await Task.Yield();
    }
```

to this:

```cs
    async Task FooAsync(CancellationToken ct) {
        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(ct);
        await Task.Yield();
    }
```

Note that the code fix automatically finds JTF instance(s) to use (the user picks the one from the fix list), and automatically finds any local `CancellationToken` to propagate into the switch method call.

Closes #316 