### PR TITLE
Fix a JTF scalability issue when it handles a large amount of tasks joins to a JTF collection

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
@@ -23,10 +23,10 @@ namespace Microsoft.VisualStudio.Threading
     /// deadlocks while synchronously blocking the Main thread for the operation's completion.
     /// </summary>
     /// <remarks>
-    /// For more complete comments please see the <see cref="JoinableTaskContext"/>.
+    /// For more complete comments please see the <see cref="Threading.JoinableTaskContext"/>.
     /// </remarks>
     [DebuggerDisplay("IsCompleted: {IsCompleted}, Method = {EntryMethodInfo != null ? EntryMethodInfo.Name : null}")]
-    public partial class JoinableTask
+    public partial class JoinableTask : JoinableTaskDependentNode
     {
         /// <summary>
         /// Stores the top-most JoinableTask that is completing on the current thread, if any.
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.Threading
         private static readonly ThreadLocal<JoinableTask> CompletingTask = new ThreadLocal<JoinableTask>();
 
         /// <summary>
-        /// The <see cref="JoinableTaskContext"/> that began the async operation.
+        /// The <see cref="Threading.JoinableTaskContext"/> that began the async operation.
         /// </summary>
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private readonly JoinableTaskFactory owner;
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio.Threading
         /// The collections that this job is a member of.
         /// </summary>
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private ListOfOftenOne<JoinableTaskCollection> collectionMembership;
+        private ListOfOftenOne<JoinableTaskDependentNode> dependencyParents;
 
         /// <summary>
         /// The Task returned by the async delegate that this JoinableTask originally executed.
@@ -67,15 +67,6 @@ namespace Microsoft.VisualStudio.Threading
         /// </value>
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private Task wrappedTask;
-
-        /// <summary>
-        /// A map of jobs that we should be willing to dequeue from when we control the UI thread, and a ref count. Lazily constructed.
-        /// </summary>
-        /// <remarks>
-        /// When the value in an entry is decremented to 0, the entry is removed from the map.
-        /// </remarks>
-        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private WeakKeyDictionary<JoinableTask, int> childOrJoinedJobs;
 
         /// <summary>
         /// An event that is signaled when any queue in the dependent has item to process.  Lazily constructed.
@@ -191,14 +182,19 @@ namespace Microsoft.VisualStudio.Threading
             SynchronouslyBlockingMainThread = 0x20,
         }
 
+        /// <summary>
+        /// Gets JoinableTaskContext for <see cref="JoinableTaskContextNode"/> to access locks.
+        /// </summary>
+        internal sealed override JoinableTaskContext JoinableTaskContext => this.owner.Context;
+
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private Task QueueNeedProcessEvent
         {
             get
             {
-                using (this.Factory.Context.NoMessagePumpSynchronizationContext.Apply())
+                using (this.JoinableTaskContext.NoMessagePumpSynchronizationContext.Apply())
                 {
-                    lock (this.owner.Context.SyncContextLock)
+                    lock (this.JoinableTaskContext.SyncContextLock)
                     {
                         if (this.queueNeedProcessEvent == null)
                         {
@@ -231,9 +227,9 @@ namespace Microsoft.VisualStudio.Threading
         {
             get
             {
-                using (this.Factory.Context.NoMessagePumpSynchronizationContext.Apply())
+                using (this.JoinableTaskContext.NoMessagePumpSynchronizationContext.Apply())
                 {
-                    lock (this.owner.Context.SyncContextLock)
+                    lock (this.JoinableTaskContext.SyncContextLock)
                     {
                         if (!this.IsCompleteRequested)
                         {
@@ -263,9 +259,9 @@ namespace Microsoft.VisualStudio.Threading
         {
             get
             {
-                using (this.Factory.Context.NoMessagePumpSynchronizationContext.Apply())
+                using (this.JoinableTaskContext.NoMessagePumpSynchronizationContext.Apply())
                 {
-                    lock (this.owner.Context.SyncContextLock)
+                    lock (this.JoinableTaskContext.SyncContextLock)
                     {
                         // If this assumes ever fails, we need to add the ability to synthesize a task
                         // that we'll complete when the wrapped task that we eventually are assigned completes.
@@ -297,11 +293,11 @@ namespace Microsoft.VisualStudio.Threading
         {
             get
             {
-                using (this.Factory.Context.NoMessagePumpSynchronizationContext.Apply())
+                using (this.JoinableTaskContext.NoMessagePumpSynchronizationContext.Apply())
                 {
-                    lock (this.owner.Context.SyncContextLock)
+                    lock (this.JoinableTaskContext.SyncContextLock)
                     {
-                        if (this.Factory.Context.IsOnMainThread)
+                        if (this.JoinableTaskContext.IsOnMainThread)
                         {
                             if (this.mainThreadJobSyncContext == null)
                             {
@@ -364,28 +360,9 @@ namespace Microsoft.VisualStudio.Threading
         {
             get
             {
-                Assumes.True(Monitor.IsEntered(this.owner.Context.SyncContextLock));
+                Assumes.True(Monitor.IsEntered(this.JoinableTaskContext.SyncContextLock));
                 return (this.mainThreadQueue != null && this.mainThreadQueue.Count > 0)
                     || (this.threadPoolQueue != null && this.threadPoolQueue.Count > 0);
-            }
-        }
-
-        /// <summary>
-        /// Gets a snapshot of all joined tasks.
-        /// FOR DIAGNOSTICS COLLECTION ONLY.
-        /// </summary>
-        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        internal IEnumerable<JoinableTask> ChildOrJoinedJobs
-        {
-            get
-            {
-                Assumes.True(Monitor.IsEntered(this.owner.Context.SyncContextLock));
-                if (this.childOrJoinedJobs == null)
-                {
-                    return Enumerable.Empty<JoinableTask>();
-                }
-
-                return this.childOrJoinedJobs.Select(p => p.Key).ToArray();
             }
         }
 
@@ -398,7 +375,7 @@ namespace Microsoft.VisualStudio.Threading
         {
             get
             {
-                Assumes.True(Monitor.IsEntered(this.owner.Context.SyncContextLock));
+                Assumes.True(Monitor.IsEntered(this.JoinableTaskContext.SyncContextLock));
                 if (this.mainThreadQueue == null)
                 {
                     return Enumerable.Empty<SingleExecuteProtector>();
@@ -417,7 +394,7 @@ namespace Microsoft.VisualStudio.Threading
         {
             get
             {
-                Assumes.True(Monitor.IsEntered(this.owner.Context.SyncContextLock));
+                Assumes.True(Monitor.IsEntered(this.JoinableTaskContext.SyncContextLock));
                 if (this.threadPoolQueue == null)
                 {
                     return Enumerable.Empty<SingleExecuteProtector>();
@@ -436,8 +413,8 @@ namespace Microsoft.VisualStudio.Threading
         {
             get
             {
-                Assumes.True(Monitor.IsEntered(this.owner.Context.SyncContextLock));
-                return this.collectionMembership.ToArray();
+                Assumes.True(Monitor.IsEntered(this.JoinableTaskContext.SyncContextLock));
+                return this.dependencyParents.OfType<JoinableTaskCollection>().ToList();
             }
         }
 
@@ -447,7 +424,7 @@ namespace Microsoft.VisualStudio.Threading
         /// Gets or sets a value indicating whether this task has had its Complete() method called..
         /// </summary>
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private bool IsCompleteRequested
+        internal bool IsCompleteRequested
         {
             get
             {
@@ -538,7 +515,7 @@ namespace Microsoft.VisualStudio.Threading
 
         internal void Post(SendOrPostCallback d, object state, bool mainThreadAffinitized)
         {
-            using (this.Factory.Context.NoMessagePumpSynchronizationContext.Apply())
+            using (this.JoinableTaskContext.NoMessagePumpSynchronizationContext.Apply())
             {
                 SingleExecuteProtector wrapper = null;
                 List<AsyncManualResetEvent> eventsNeedNotify = null; // initialized if we should pulse it at the end of the method
@@ -546,7 +523,7 @@ namespace Microsoft.VisualStudio.Threading
 
                 bool isCompleteRequested;
                 bool synchronouslyBlockingMainThread;
-                lock (this.owner.Context.SyncContextLock)
+                lock (this.JoinableTaskContext.SyncContextLock)
                 {
                     isCompleteRequested = this.IsCompleteRequested;
                     synchronouslyBlockingMainThread = this.SynchronouslyBlockingMainThread;
@@ -574,7 +551,7 @@ namespace Microsoft.VisualStudio.Threading
                         wrapper.RaiseTransitioningEvents();
                     }
 
-                    lock (this.owner.Context.SyncContextLock)
+                    lock (this.JoinableTaskContext.SyncContextLock)
                     {
                         if (mainThreadAffinitized)
                         {
@@ -679,9 +656,9 @@ namespace Microsoft.VisualStudio.Threading
         {
             Requires.NotNull(wrappedTask, nameof(wrappedTask));
 
-            using (this.Factory.Context.NoMessagePumpSynchronizationContext.Apply())
+            using (this.JoinableTaskContext.NoMessagePumpSynchronizationContext.Apply())
             {
-                lock (this.owner.Context.SyncContextLock)
+                lock (this.JoinableTaskContext.SyncContextLock)
                 {
                     Assumes.Null(this.wrappedTask);
                     this.wrappedTask = wrappedTask;
@@ -709,10 +686,10 @@ namespace Microsoft.VisualStudio.Threading
         /// </summary>
         internal void Complete()
         {
-            using (this.Factory.Context.NoMessagePumpSynchronizationContext.Apply())
+            using (this.JoinableTaskContext.NoMessagePumpSynchronizationContext.Apply())
             {
                 AsyncManualResetEvent queueNeedProcessEvent = null;
-                lock (this.owner.Context.SyncContextLock)
+                lock (this.JoinableTaskContext.SyncContextLock)
                 {
                     if (!this.IsCompleteRequested)
                     {
@@ -746,52 +723,6 @@ namespace Microsoft.VisualStudio.Threading
             }
         }
 
-        internal void RemoveDependency(JoinableTask joinChild)
-        {
-            Requires.NotNull(joinChild, nameof(joinChild));
-
-            using (this.Factory.Context.NoMessagePumpSynchronizationContext.Apply())
-            {
-                lock (this.owner.Context.SyncContextLock)
-                {
-                    if (this.childOrJoinedJobs != null && this.childOrJoinedJobs.TryGetValue(joinChild, out int refCount))
-                    {
-                        if (refCount == 1)
-                        {
-                            this.childOrJoinedJobs.Remove(joinChild);
-                            this.RemoveDependingSynchronousTaskFromChild(joinChild);
-                        }
-                        else
-                        {
-                            this.childOrJoinedJobs[joinChild] = --refCount;
-                        }
-                    }
-                }
-            }
-        }
-
-        /// <summary>
-        /// Recursively adds this joinable and all its dependencies to the specified set, that are not yet completed.
-        /// </summary>
-        internal void AddSelfAndDescendentOrJoinedJobs(HashSet<JoinableTask> joinables)
-        {
-            Requires.NotNull(joinables, nameof(joinables));
-
-            if (!this.IsCompleted)
-            {
-                if (joinables.Add(this))
-                {
-                    if (this.childOrJoinedJobs != null)
-                    {
-                        foreach (var item in this.childOrJoinedJobs)
-                        {
-                            item.Key.AddSelfAndDescendentOrJoinedJobs(joinables);
-                        }
-                    }
-                }
-            }
-        }
-
         /// <summary>Runs a loop to process all queued work items, returning only when the task is completed.</summary>
         internal void CompleteOnCurrentThread()
         {
@@ -804,7 +735,7 @@ namespace Microsoft.VisualStudio.Threading
             {
                 bool onMainThread = false;
                 var additionalFlags = JoinableTaskFlags.CompletingSynchronously;
-                if (this.owner.Context.IsOnMainThread)
+                if (this.JoinableTaskContext.IsOnMainThread)
                 {
                     additionalFlags |= JoinableTaskFlags.SynchronouslyBlockingMainThread;
                     onMainThread = true;
@@ -819,9 +750,9 @@ namespace Microsoft.VisualStudio.Threading
                         ThreadingEventSource.Instance.CompleteOnCurrentThreadStart(this.GetHashCode(), onMainThread);
                     }
 
-                    using (this.Factory.Context.NoMessagePumpSynchronizationContext.Apply())
+                    using (this.JoinableTaskContext.NoMessagePumpSynchronizationContext.Apply())
                     {
-                        lock (this.owner.Context.SyncContextLock)
+                        lock (this.JoinableTaskContext.SyncContextLock)
                         {
                             this.pendingEventCount = 0;
 
@@ -832,7 +763,7 @@ namespace Microsoft.VisualStudio.Threading
 
                     if (onMainThread)
                     {
-                        this.owner.Context.OnSynchronousJoinableTaskToCompleteOnMainThread(this);
+                        this.JoinableTaskContext.OnSynchronousJoinableTaskToCompleteOnMainThread(this);
                     }
 
                     try
@@ -840,7 +771,7 @@ namespace Microsoft.VisualStudio.Threading
                         // Don't use IsCompleted as the condition because that
                         // includes queues of posted work that don't have to complete for the
                         // JoinableTask to be ready to return from the JTF.Run method.
-                        HashSet<JoinableTask> visited = null;
+                        HashSet<JoinableTaskDependentNode> visited = null;
                         while (!this.IsCompleteRequested)
                         {
                             if (this.TryDequeueSelfOrDependencies(onMainThread, ref visited, out SingleExecuteProtector work, out Task tryAgainAfter))
@@ -858,9 +789,9 @@ namespace Microsoft.VisualStudio.Threading
                     }
                     finally
                     {
-                        using (this.Factory.Context.NoMessagePumpSynchronizationContext.Apply())
+                        using (this.JoinableTaskContext.NoMessagePumpSynchronizationContext.Apply())
                         {
-                            lock (this.owner.Context.SyncContextLock)
+                            lock (this.JoinableTaskContext.SyncContextLock)
                             {
                                 // Remove itself from the tracking list, after the task is completed.
                                 this.RemoveDependingSynchronousTask(this, true);
@@ -877,7 +808,7 @@ namespace Microsoft.VisualStudio.Threading
                 {
                     if (onMainThread)
                     {
-                        this.owner.Context.OnSynchronousJoinableTaskToCompleteOnMainThread(this);
+                        this.JoinableTaskContext.OnSynchronousJoinableTaskToCompleteOnMainThread(this);
                     }
                 }
 
@@ -907,11 +838,11 @@ namespace Microsoft.VisualStudio.Threading
             {
                 // Note this code may execute more than once, as multiple queue completion
                 // notifications come in.
-                this.owner.Context.OnJoinableTaskCompleted(this);
+                this.JoinableTaskContext.OnJoinableTaskCompleted(this);
 
-                foreach (var collection in this.collectionMembership)
+                foreach (var collection in this.dependencyParents)
                 {
-                    collection.Remove(this);
+                    collection.RemoveDependency(this);
                 }
 
                 if (this.mainThreadJobSyncContext != null)
@@ -930,41 +861,65 @@ namespace Microsoft.VisualStudio.Threading
             }
         }
 
-        internal void OnAddedToCollection(JoinableTaskCollection collection)
+        internal override void OnAddedToDependency(JoinableTaskDependentNode parentNode)
         {
-            Requires.NotNull(collection, nameof(collection));
-            this.collectionMembership.Add(collection);
+            Requires.NotNull(parentNode, nameof(parentNode));
+            this.dependencyParents.Add(parentNode);
         }
 
-        internal void OnRemovedFromCollection(JoinableTaskCollection collection)
+        internal override void OnRemovedFromDependency(JoinableTaskDependentNode parentNode)
         {
-            Requires.NotNull(collection, nameof(collection));
-            this.collectionMembership.Remove(collection);
+            Requires.NotNull(parentNode, nameof(parentNode));
+            this.dependencyParents.Remove(parentNode);
         }
 
         /// <summary>
-        /// Adds the specified flags to the <see cref="state"/> field.
+        /// Get the number of pending messages to be process for the synchronous task.
         /// </summary>
-        private void AddStateFlags(JoinableTaskFlags flags)
+        /// <param name="synchronousTask">The synchronous task</param>
+        /// <returns>The number of events need be processed by the synchronous task in the current JoinableTask.</returns>
+        internal int GetPendingEventCountForSynchronousTask(JoinableTask synchronousTask)
         {
-            // Try to avoid taking a lock if the flags are already set appropriately.
-            if ((this.state & flags) != flags)
-            {
-                using (this.Factory.Context.NoMessagePumpSynchronizationContext.Apply())
-                {
-                    lock (this.owner.Context.SyncContextLock)
-                    {
-                        this.state |= flags;
-                    }
-                }
-            }
+            Requires.NotNull(synchronousTask, nameof(synchronousTask));
+            var queue = ((synchronousTask.state & JoinableTaskFlags.SynchronouslyBlockingMainThread) == JoinableTaskFlags.SynchronouslyBlockingMainThread)
+                ? this.mainThreadQueue
+                : this.threadPoolQueue;
+            return queue != null ? queue.Count : 0;
         }
 
-        private bool TryDequeueSelfOrDependencies(bool onMainThread, ref HashSet<JoinableTask> visited, out SingleExecuteProtector work, out Task tryAgainAfter)
+        /// <summary>
+        /// This is a helper method to parepare notifing all sychronous tasks for pending events.
+        /// It must be called inside JTF lock, and returns a collection of event to trigger later. (Those events must be triggered out of the JTF lock.)
+        /// </summary>
+        internal static List<AsyncManualResetEvent> ProcessPendingNotifications(IReadOnlyCollection<PendingNotification> tasksNeedNotify)
         {
-            using (this.Factory.Context.NoMessagePumpSynchronizationContext.Apply())
+            Requires.NotNull(tasksNeedNotify, nameof(tasksNeedNotify));
+
+            var eventsNeedNotify = new List<AsyncManualResetEvent>(tasksNeedNotify.Count);
+            foreach (var taskToNotify in tasksNeedNotify)
             {
-                lock (this.owner.Context.SyncContextLock)
+                if (taskToNotify.SynchronousTask.pendingEventSource == null || taskToNotify.TaskHasPendingMessages == taskToNotify.SynchronousTask)
+                {
+                    taskToNotify.SynchronousTask.pendingEventSource = new WeakReference<JoinableTask>(taskToNotify.TaskHasPendingMessages);
+                }
+
+                taskToNotify.SynchronousTask.pendingEventCount += taskToNotify.NewPendingMessagesCount;
+
+                var notifyEvent = taskToNotify.SynchronousTask.queueNeedProcessEvent;
+                if (notifyEvent != null)
+                {
+                    eventsNeedNotify.Add(notifyEvent);
+                }
+            }
+
+            return eventsNeedNotify;
+        }
+
+        private bool TryDequeueSelfOrDependencies(bool onMainThread, ref HashSet<JoinableTaskDependentNode> visited, out SingleExecuteProtector work, out Task tryAgainAfter)
+        {
+            using (this.JoinableTaskContext.NoMessagePumpSynchronizationContext.Apply())
+            {
+                lock (this.JoinableTaskContext.SyncContextLock)
                 {
                     if (this.IsCompleted)
                     {
@@ -999,14 +954,14 @@ namespace Microsoft.VisualStudio.Threading
 
                         if (visited == null)
                         {
-                            visited = new HashSet<JoinableTask>();
+                            visited = new HashSet<JoinableTaskDependentNode>();
                         }
                         else
                         {
                             visited.Clear();
                         }
 
-                        if (this.TryDequeueSelfOrDependencies(onMainThread, visited, out work))
+                        if (TryDequeueSelfOrDependencies(this, onMainThread, visited, out work))
                         {
                             tryAgainAfter = null;
                             return true;
@@ -1022,28 +977,33 @@ namespace Microsoft.VisualStudio.Threading
             }
         }
 
-        private bool TryDequeueSelfOrDependencies(bool onMainThread, HashSet<JoinableTask> visited, out SingleExecuteProtector work)
+        private static bool TryDequeueSelfOrDependencies(JoinableTaskDependentNode currentNode, bool onMainThread, HashSet<JoinableTaskDependentNode> visited, out SingleExecuteProtector work)
         {
+            Requires.NotNull(currentNode, nameof(currentNode));
             Requires.NotNull(visited, nameof(visited));
-            Report.IfNot(Monitor.IsEntered(this.owner.Context.SyncContextLock));
+            Report.IfNot(Monitor.IsEntered(currentNode.JoinableTaskContext.SyncContextLock));
 
             // We only need to find the first work item.
             work = null;
-            if (visited.Add(this))
+            if (visited.Add(currentNode))
             {
-                var queue = onMainThread ? this.mainThreadQueue : this.threadPoolQueue;
-                if (queue != null && !queue.IsCompleted)
+                JoinableTask joinableTask = currentNode as JoinableTask;
+                if (joinableTask != null)
                 {
-                    queue.TryDequeue(out work);
+                    var queue = onMainThread ? joinableTask.mainThreadQueue : joinableTask.threadPoolQueue;
+                    if (queue != null && !queue.IsCompleted)
+                    {
+                        queue.TryDequeue(out work);
+                    }
                 }
 
                 if (work == null)
                 {
-                    if (this.childOrJoinedJobs != null && !this.IsCompleted)
+                    if (joinableTask?.IsCompleted != true)
                     {
-                        foreach (var item in this.childOrJoinedJobs)
+                        foreach (var item in currentNode.DirectDependentNodes)
                         {
-                            if (item.Key.TryDequeueSelfOrDependencies(onMainThread, visited, out work))
+                            if (TryDequeueSelfOrDependencies(item, onMainThread, visited, out work))
                             {
                                 break;
                             }
@@ -1056,66 +1016,20 @@ namespace Microsoft.VisualStudio.Threading
         }
 
         /// <summary>
-        /// Adds a <see cref="JoinableTask"/> instance as one that is relevant to the async operation.
+        /// Adds the specified flags to the <see cref="state"/> field.
         /// </summary>
-        /// <param name="joinChild">The <see cref="JoinableTask"/> to join as a child.</param>
-        internal JoinRelease AddDependency(JoinableTask joinChild)
+        private void AddStateFlags(JoinableTaskFlags flags)
         {
-            Requires.NotNull(joinChild, nameof(joinChild));
-            if (this == joinChild)
+            // Try to avoid taking a lock if the flags are already set appropriately.
+            if ((this.state & flags) != flags)
             {
-                // Joining oneself would be pointless.
-                return default(JoinRelease);
-            }
-
-            using (this.Factory.Context.NoMessagePumpSynchronizationContext.Apply())
-            {
-                List<AsyncManualResetEvent> eventsNeedNotify = null;
-                lock (this.owner.Context.SyncContextLock)
+                using (this.JoinableTaskContext.NoMessagePumpSynchronizationContext.Apply())
                 {
-                    if (this.childOrJoinedJobs == null)
+                    lock (this.JoinableTaskContext.SyncContextLock)
                     {
-                        this.childOrJoinedJobs = new WeakKeyDictionary<JoinableTask, int>(capacity: 3);
-                    }
-
-                    this.childOrJoinedJobs.TryGetValue(joinChild, out int refCount);
-                    this.childOrJoinedJobs[joinChild] = ++refCount;
-                    if (refCount == 1)
-                    {
-                        // This constitutes a significant change, so we should apply synchronous task tracking to the new child.
-                        var tasksNeedNotify = this.AddDependingSynchronousTaskToChild(joinChild);
-                        if (tasksNeedNotify.Count > 0)
-                        {
-                            eventsNeedNotify = new List<AsyncManualResetEvent>(tasksNeedNotify.Count);
-                            foreach (var taskToNotify in tasksNeedNotify)
-                            {
-                                if (taskToNotify.SynchronousTask.pendingEventSource == null || taskToNotify.TaskHasPendingMessages == taskToNotify.SynchronousTask)
-                                {
-                                    taskToNotify.SynchronousTask.pendingEventSource = new WeakReference<JoinableTask>(taskToNotify.TaskHasPendingMessages);
-                                }
-
-                                taskToNotify.SynchronousTask.pendingEventCount += taskToNotify.NewPendingMessagesCount;
-
-                                var notifyEvent = taskToNotify.SynchronousTask.queueNeedProcessEvent;
-                                if (notifyEvent != null)
-                                {
-                                    eventsNeedNotify.Add(notifyEvent);
-                                }
-                            }
-                        }
+                        this.state |= flags;
                     }
                 }
-
-                // We explicitly do this outside our lock.
-                if (eventsNeedNotify != null)
-                {
-                    foreach (var queueEvent in eventsNeedNotify)
-                    {
-                        queueEvent.PulseAll();
-                    }
-                }
-
-                return new JoinRelease(this, joinChild);
             }
         }
 
@@ -1123,7 +1037,7 @@ namespace Microsoft.VisualStudio.Threading
         {
             if (!this.IsCompleted)
             {
-                var ambientJob = this.owner.Context.AmbientTask;
+                var ambientJob = this.JoinableTaskContext.AmbientTask;
                 if (ambientJob != null && ambientJob != this)
                 {
                     return ambientJob.AddDependency(this);

--- a/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
@@ -986,7 +986,7 @@ namespace Microsoft.VisualStudio.Threading
                 {
                     if (joinableTask?.IsCompleted != true)
                     {
-                        foreach (var item in currentNode.DirectDependentNodes)
+                        foreach (var item in currentNode.GetDirectDependentNodes())
                         {
                             if (TryDequeueSelfOrDependencies(item, onMainThread, visited, out work))
                             {

--- a/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
@@ -711,7 +711,7 @@ namespace Microsoft.VisualStudio.Threading
                         // will likely want to know that the JoinableTask has completed.
                         queueNeedProcessEvent = this.queueNeedProcessEvent;
 
-                        this.CleanupDependingSynchronousTask();
+                        this.OnDependentNodeCompleted();
                     }
                 }
 

--- a/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
@@ -754,10 +754,10 @@ namespace Microsoft.VisualStudio.Threading
                     {
                         lock (this.JoinableTaskContext.SyncContextLock)
                         {
-                            this.pendingEventCount = 0;
+                            this.OnSynchronousTaskStartToBlockWaiting(out JoinableTask pendingRequestTask, out this.pendingEventCount);
 
                             // Add the task to the depending tracking list of itself, so it will monitor the event queue.
-                            this.pendingEventSource = new WeakReference<JoinableTask>(this.AddDependingSynchronousTask(this, ref this.pendingEventCount));
+                            this.pendingEventSource = new WeakReference<JoinableTask>(pendingRequestTask);
                         }
                     }
 
@@ -789,14 +789,7 @@ namespace Microsoft.VisualStudio.Threading
                     }
                     finally
                     {
-                        using (this.JoinableTaskContext.NoMessagePumpSynchronizationContext.Apply())
-                        {
-                            lock (this.JoinableTaskContext.SyncContextLock)
-                            {
-                                // Remove itself from the tracking list, after the task is completed.
-                                this.RemoveDependingSynchronousTask(this, true);
-                            }
-                        }
+                        this.OnSynchronousTaskEndToBlockWaiting();
                     }
 
                     if (ThreadingEventSource.Instance.IsEnabled())

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskCollection.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskCollection.cs
@@ -180,7 +180,7 @@ namespace Microsoft.VisualStudio.Threading
                 var joinables = new List<JoinableTask>();
                 lock (this.Context.SyncContextLock)
                 {
-                    foreach (var item in this.DirectDependentNodes)
+                    foreach (var item in this.GetDirectDependentNodes())
                     {
                         if (item is JoinableTask joinableTask)
                         {

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskCollection.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskCollection.cs
@@ -18,23 +18,8 @@ namespace Microsoft.VisualStudio.Threading
     /// A collection of joinable tasks.
     /// </summary>
     [DebuggerDisplay("JoinableTaskCollection: {displayName ?? \"(anonymous)\"}")]
-    public class JoinableTaskCollection : IEnumerable<JoinableTask>
+    public class JoinableTaskCollection : JoinableTaskDependentNode, IEnumerable<JoinableTask>
     {
-        /// <summary>
-        /// The set of joinable tasks that belong to this collection -- that is, the set of joinable tasks that are implicitly Joined
-        /// when folks Join this collection.
-        /// The value is the number of times the joinable was added to this collection (and not yet removed)
-        /// if this collection is ref counted; otherwise the value is always 1.
-        /// </summary>
-        private readonly WeakKeyDictionary<JoinableTask, int> joinables = new WeakKeyDictionary<JoinableTask, int>(capacity: 2);
-
-        /// <summary>
-        /// The set of joinable tasks that have Joined this collection -- that is, the set of joinable tasks that are interested
-        /// in the completion of any and all joinable tasks that belong to this collection.
-        /// The value is the number of times a particular joinable task has Joined this collection.
-        /// </summary>
-        private readonly WeakKeyDictionary<JoinableTask, int> joiners = new WeakKeyDictionary<JoinableTask, int>(capacity: 2);
-
         /// <summary>
         /// A value indicating whether joinable tasks are only removed when completed or removed as many times as they were added.
         /// </summary>
@@ -70,7 +55,7 @@ namespace Microsoft.VisualStudio.Threading
         /// <summary>
         /// Gets the <see cref="JoinableTaskContext"/> to which this collection belongs.
         /// </summary>
-        public JoinableTaskContext Context { get; private set; }
+        public JoinableTaskContext Context { get; }
 
         /// <summary>
         /// Gets or sets a human-readable name that may appear in hang reports.
@@ -87,6 +72,16 @@ namespace Microsoft.VisualStudio.Threading
         }
 
         /// <summary>
+        /// Gets JoinableTaskContext for <see cref="JoinableTaskDependentNode"/> to access locks.
+        /// </summary>
+        internal sealed override JoinableTaskContext JoinableTaskContext => this.Context;
+
+        /// <summary>
+        /// Gets a value indicating whether we need count reference for child dependent nodes.
+        /// </summary>
+        internal sealed override bool NeedRefCountChildDependencies => this.refCountAddedJobs;
+
+        /// <summary>
         /// Adds the specified joinable task to this collection.
         /// </summary>
         /// <param name="joinableTask">The joinable task to add to the collection.</param>
@@ -100,34 +95,7 @@ namespace Microsoft.VisualStudio.Threading
 
             if (!joinableTask.IsCompleted)
             {
-                using (this.Context.NoMessagePumpSynchronizationContext.Apply())
-                {
-                    lock (this.Context.SyncContextLock)
-                    {
-                        if (!this.joinables.TryGetValue(joinableTask, out int refCount) || this.refCountAddedJobs)
-                        {
-                            this.joinables[joinableTask] = refCount + 1;
-                            if (refCount == 0)
-                            {
-                                joinableTask.OnAddedToCollection(this);
-
-                                // Now that we've added a joinable task to our collection, any folks who
-                                // have already joined this collection should be joined to this joinable task.
-                                foreach (var joiner in this.joiners)
-                                {
-                                    // We can discard the JoinRelease result of AddDependency
-                                    // because we directly disjoin without that helper struct.
-                                    joiner.Key.AddDependency(joinableTask);
-                                }
-                            }
-                        }
-
-                        if (this.emptyEvent != null)
-                        {
-                            this.emptyEvent.Reset();
-                        }
-                    }
-                }
+                this.AddDependency(joinableTask);
             }
         }
 
@@ -139,40 +107,7 @@ namespace Microsoft.VisualStudio.Threading
         public void Remove(JoinableTask joinableTask)
         {
             Requires.NotNull(joinableTask, nameof(joinableTask));
-
-            using (this.Context.NoMessagePumpSynchronizationContext.Apply())
-            {
-                lock (this.Context.SyncContextLock)
-                {
-                    if (this.joinables.TryGetValue(joinableTask, out int refCount))
-                    {
-                        if (refCount == 1 || joinableTask.IsCompleted)
-                        { // remove regardless of ref count if job is completed
-                            this.joinables.Remove(joinableTask);
-                            joinableTask.OnRemovedFromCollection(this);
-
-                            // Now that we've removed a joinable task from our collection, any folks who
-                            // have already joined this collection should be disjoined to this joinable task
-                            // as an efficiency improvement so we don't grow our weak collections unnecessarily.
-                            foreach (var joiner in this.joiners)
-                            {
-                                // We can discard the JoinRelease result of AddDependency
-                                // because we directly disjoin without that helper struct.
-                                joiner.Key.RemoveDependency(joinableTask);
-                            }
-
-                            if (this.emptyEvent != null && this.joinables.Count == 0)
-                            {
-                                this.emptyEvent.Set();
-                            }
-                        }
-                        else
-                        {
-                            this.joinables[joinableTask] = refCount - 1;
-                        }
-                    }
-                }
-            }
+            this.RemoveDependency(joinableTask);
         }
 
         /// <summary>
@@ -192,25 +127,7 @@ namespace Microsoft.VisualStudio.Threading
                 return default(JoinRelease);
             }
 
-            using (this.Context.NoMessagePumpSynchronizationContext.Apply())
-            {
-                lock (this.Context.SyncContextLock)
-                {
-                    this.joiners.TryGetValue(ambientJob, out int count);
-                    this.joiners[ambientJob] = count + 1;
-                    if (count == 0)
-                    {
-                        // The joining job was not previously joined to this collection,
-                        // so we need to join each individual job within the collection now.
-                        foreach (var joinable in this.joinables)
-                        {
-                            ambientJob.AddDependency(joinable.Key);
-                        }
-                    }
-
-                    return new JoinRelease(this, ambientJob);
-                }
-            }
+            return ambientJob.AddDependency(this);
         }
 
         /// <summary>
@@ -229,7 +146,7 @@ namespace Microsoft.VisualStudio.Threading
                     {
                         // We use interlocked here to mitigate race conditions in lazily initializing this field.
                         // We *could* take a write lock above, but that would needlessly increase lock contention.
-                        var nowait = Interlocked.CompareExchange(ref this.emptyEvent, new AsyncManualResetEvent(this.joinables.Count == 0), null);
+                        var nowait = Interlocked.CompareExchange(ref this.emptyEvent, new AsyncManualResetEvent(this.HasNoChildDependentNode), null);
                     }
                 }
             }
@@ -251,7 +168,7 @@ namespace Microsoft.VisualStudio.Threading
             {
                 lock (this.Context.SyncContextLock)
                 {
-                    return this.joinables.ContainsKey(joinableTask);
+                    return this.HasDirectDependency(joinableTask);
                 }
             }
         }
@@ -266,9 +183,12 @@ namespace Microsoft.VisualStudio.Threading
                 var joinables = new List<JoinableTask>();
                 lock (this.Context.SyncContextLock)
                 {
-                    foreach (var item in this.joinables)
+                    foreach (var item in this.DirectDependentNodes)
                     {
-                        joinables.Add(item.Key);
+                        if (item is JoinableTask joinableTask)
+                        {
+                            joinables.Add(joinableTask);
+                        }
                     }
                 }
 
@@ -284,32 +204,35 @@ namespace Microsoft.VisualStudio.Threading
             return this.GetEnumerator();
         }
 
-        /// <summary>
-        /// Breaks a join formed between the specified joinable task and this collection.
-        /// </summary>
-        /// <param name="joinableTask">The joinable task that had previously joined this collection, and that now intends to revert it.</param>
-        internal void Disjoin(JoinableTask joinableTask)
+        internal override JoinRelease AddDependency(JoinableTaskDependentNode joinChild)
         {
-            Requires.NotNull(joinableTask, nameof(joinableTask));
-
+            JoinRelease result;
             using (this.Context.NoMessagePumpSynchronizationContext.Apply())
             {
                 lock (this.Context.SyncContextLock)
                 {
-                    this.joiners.TryGetValue(joinableTask, out int count);
-                    if (count == 1)
+                    result = base.AddDependency(joinChild);
+                    if (this.emptyEvent != null && joinChild is JoinableTask)
                     {
-                        this.joiners.Remove(joinableTask);
-
-                        // We also need to disjoin this joinable task from all joinable tasks in this collection.
-                        foreach (var joinable in this.joinables)
-                        {
-                            joinableTask.RemoveDependency(joinable.Key);
-                        }
+                        this.emptyEvent.Reset();
                     }
-                    else
+                }
+            }
+
+            return result;
+        }
+
+        internal override void RemoveDependency(JoinableTaskDependentNode joinChild)
+        {
+            using (this.Context.NoMessagePumpSynchronizationContext.Apply())
+            {
+                lock (this.JoinableTaskContext.SyncContextLock)
+                {
+                    this.RemoveDependency(joinChild);
+
+                    if (this.emptyEvent != null && this.HasNoChildDependentNode)
                     {
-                        this.joiners[joinableTask] = count - 1;
+                        this.emptyEvent.Set();
                     }
                 }
             }
@@ -321,38 +244,21 @@ namespace Microsoft.VisualStudio.Threading
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes")]
         public struct JoinRelease : IDisposable
         {
-            private JoinableTask joinedJob;
-            private JoinableTask joiner;
-            private JoinableTaskCollection joinedJobCollection;
+            private JoinableTaskDependentNode parentDependencyNode;
+            private JoinableTaskDependentNode childDependencyNode;
 
             /// <summary>
             /// Initializes a new instance of the <see cref="JoinRelease"/> struct.
             /// </summary>
-            /// <param name="joined">The Main thread controlling SingleThreadSynchronizationContext to use to accelerate execution of Main thread bound work.</param>
-            /// <param name="joiner">The instance that created this value.</param>
-            internal JoinRelease(JoinableTask joined, JoinableTask joiner)
+            /// <param name="parentDependencyNode">The Main thread controlling SingleThreadSynchronizationContext to use to accelerate execution of Main thread bound work.</param>
+            /// <param name="childDependencyNode">The instance that created this value.</param>
+            internal JoinRelease(JoinableTaskDependentNode parentDependencyNode, JoinableTaskDependentNode childDependencyNode)
             {
-                Requires.NotNull(joined, nameof(joined));
-                Requires.NotNull(joiner, nameof(joiner));
+                Requires.NotNull(parentDependencyNode, nameof(parentDependencyNode));
+                Requires.NotNull(childDependencyNode, nameof(childDependencyNode));
 
-                this.joinedJobCollection = null;
-                this.joinedJob = joined;
-                this.joiner = joiner;
-            }
-
-            /// <summary>
-            /// Initializes a new instance of the <see cref="JoinRelease"/> struct.
-            /// </summary>
-            /// <param name="jobCollection">The collection of joinable tasks that has been joined.</param>
-            /// <param name="joiner">The instance that created this value.</param>
-            internal JoinRelease(JoinableTaskCollection jobCollection, JoinableTask joiner)
-            {
-                Requires.NotNull(jobCollection, nameof(jobCollection));
-                Requires.NotNull(joiner, nameof(joiner));
-
-                this.joinedJobCollection = jobCollection;
-                this.joinedJob = null;
-                this.joiner = joiner;
+                this.parentDependencyNode = parentDependencyNode;
+                this.childDependencyNode = childDependencyNode;
             }
 
             /// <summary>
@@ -360,19 +266,13 @@ namespace Microsoft.VisualStudio.Threading
             /// </summary>
             public void Dispose()
             {
-                if (this.joinedJob != null)
+                if (this.parentDependencyNode != null)
                 {
-                    this.joinedJob.RemoveDependency(this.joiner);
-                    this.joinedJob = null;
+                    this.parentDependencyNode.RemoveDependency(this.childDependencyNode);
+                    this.parentDependencyNode = null;
                 }
 
-                if (this.joinedJobCollection != null)
-                {
-                    this.joinedJobCollection.Disjoin(this.joiner);
-                    this.joinedJobCollection = null;
-                }
-
-                this.joiner = null;
+                this.childDependencyNode = null;
             }
         }
     }

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskContext+HangReportContributor.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskContext+HangReportContributor.cs
@@ -71,7 +71,7 @@ namespace Microsoft.VisualStudio.Threading
             var links = new List<XElement>();
             foreach (var joinableTaskAndElement in pendingTasksElements)
             {
-                foreach (var joinedTask in joinableTaskAndElement.Key.ChildOrJoinedJobs)
+                foreach (var joinedTask in joinableTaskAndElement.Key.GetAllDirectlyDependentJoinableTasks())
                 {
                     if (pendingTasksElements.TryGetValue(joinedTask, out XElement joinedTaskElement))
                     {

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskContext.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskContext.cs
@@ -337,24 +337,27 @@ namespace Microsoft.VisualStudio.Threading
                 {
                     lock (this.SyncContextLock)
                     {
-                        var allJoinedJobs = new HashSet<JoinableTask>();
                         lock (this.initializingSynchronouslyMainThreadTasks)
                         {
-                            // our read lock doesn't cover this collection
-                            foreach (var initializingTask in this.initializingSynchronouslyMainThreadTasks)
+                            if (this.initializingSynchronouslyMainThreadTasks.Count > 0)
                             {
-                                if (!initializingTask.HasMainThreadSynchronousTaskWaiting)
+                                // our read lock doesn't cover this collection
+                                var allJoinedJobs = new HashSet<JoinableTask>();
+                                foreach (var initializingTask in this.initializingSynchronouslyMainThreadTasks)
                                 {
-                                    // This task blocks the main thread. If it has joined the ambient task
-                                    // directly or indirectly, then our ambient task is considered blocking
-                                    // the main thread.
-                                    initializingTask.AddSelfAndDescendentOrJoinedJobs(allJoinedJobs);
-                                    if (allJoinedJobs.Contains(ambientTask))
+                                    if (!initializingTask.HasMainThreadSynchronousTaskWaiting)
                                     {
-                                        return true;
-                                    }
+                                        // This task blocks the main thread. If it has joined the ambient task
+                                        // directly or indirectly, then our ambient task is considered blocking
+                                        // the main thread.
+                                        initializingTask.AddSelfAndDescendentOrJoinedJobs(allJoinedJobs);
+                                        if (allJoinedJobs.Contains(ambientTask))
+                                        {
+                                            return true;
+                                        }
 
-                                    allJoinedJobs.Clear();
+                                        allJoinedJobs.Clear();
+                                    }
                                 }
                             }
                         }

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskDependentNode.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskDependentNode.cs
@@ -646,44 +646,31 @@ namespace Microsoft.VisualStudio.Threading
         /// </summary>
         internal struct PendingNotification
         {
-            private readonly JoinableTask synchronousTask;
-            private readonly JoinableTask taskHasPendingMessages;
-            private readonly int newPendingMessagesCount;
-
             public PendingNotification(JoinableTask synchronousTask, JoinableTask taskHasPendingMessages, int newPendingMessagesCount)
             {
                 Requires.NotNull(synchronousTask, nameof(synchronousTask));
                 Requires.NotNull(taskHasPendingMessages, nameof(taskHasPendingMessages));
 
-                this.synchronousTask = synchronousTask;
-                this.taskHasPendingMessages = taskHasPendingMessages;
-                this.newPendingMessagesCount = newPendingMessagesCount;
+                this.SynchronousTask = synchronousTask;
+                this.TaskHasPendingMessages = taskHasPendingMessages;
+                this.NewPendingMessagesCount = newPendingMessagesCount;
             }
 
             /// <summary>
             /// Gets the synchronous task which need process new messages.
             /// </summary>
-            public JoinableTask SynchronousTask
-            {
-                get { return this.synchronousTask; }
-            }
+            public JoinableTask SynchronousTask { get; }
 
             /// <summary>
             /// Gets one JoinableTask which may have pending messages. We may have multiple new JoinableTasks which contains pending messages.
             /// This is just one of them.  It gives the synchronous task a way to start quickly without searching all messages.
             /// </summary>
-            public JoinableTask TaskHasPendingMessages
-            {
-                get { return this.taskHasPendingMessages; }
-            }
+            public JoinableTask TaskHasPendingMessages { get; }
 
             /// <summary>
             /// Gets the total number of new pending messages.  The real number could be less than that, but should not be more than that.
             /// </summary>
-            public int NewPendingMessagesCount
-            {
-                get { return this.newPendingMessagesCount; }
-            }
+            public int NewPendingMessagesCount { get; }
         }
 
         /// <summary>
@@ -706,7 +693,7 @@ namespace Microsoft.VisualStudio.Threading
             /// <summary>
             /// Gets the synchronous task
             /// </summary>
-            internal JoinableTask SynchronousTask { get; private set; }
+            internal JoinableTask SynchronousTask { get; }
 
             /// <summary>
             /// Gets or sets the reference count.  We remove the item from the list, if it reaches 0.

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskDependentNode.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskDependentNode.cs
@@ -460,7 +460,7 @@ namespace Microsoft.VisualStudio.Threading
         /// Remove all synchronous tasks tracked by the this task.
         /// This is called when this task is completed
         /// </summary>
-        internal void CleanupDependingSynchronousTask()
+        internal void OnDependentNodeCompleted()
         {
             Assumes.True(Monitor.IsEntered(this.JoinableTaskContext.SyncContextLock));
             if (this.dependingSynchronousTaskTracking != null)

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskDependentNode.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskDependentNode.cs
@@ -454,6 +454,7 @@ namespace Microsoft.VisualStudio.Threading
         /// </summary>
         internal void CleanupDependingSynchronousTask()
         {
+            Assumes.True(Monitor.IsEntered(this.JoinableTaskContext.SyncContextLock));
             if (this.dependingSynchronousTaskTracking != null)
             {
                 DependentSynchronousTask existingTaskTracking = this.dependingSynchronousTaskTracking;

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskDependentNode.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskDependentNode.cs
@@ -519,9 +519,9 @@ namespace Microsoft.VisualStudio.Threading
 
             if (this.childDependentNodes != null)
             {
-                foreach (var item in this.childDependentNodes)
+                foreach (var item in this.childDependentNodes.Keys)
                 {
-                    var childTiggeringTask = item.Key.AddDependingSynchronousTask(synchronousTask, ref totalEventsPending);
+                    var childTiggeringTask = item.AddDependingSynchronousTask(synchronousTask, ref totalEventsPending);
                     if (eventTriggeringTask == null)
                     {
                         eventTriggeringTask = childTiggeringTask;
@@ -613,9 +613,9 @@ namespace Microsoft.VisualStudio.Threading
 
                     if (this.childDependentNodes != null)
                     {
-                        foreach (var item in this.childDependentNodes)
+                        foreach (var item in this.childDependentNodes.Keys)
                         {
-                            item.Key.ComputeSelfAndDescendentOrJoinedJobsAndRemainTasks(reachableNodes, remainNodes);
+                            item.ComputeSelfAndDescendentOrJoinedJobsAndRemainTasks(reachableNodes, remainNodes);
                         }
                     }
                 }
@@ -695,9 +695,9 @@ namespace Microsoft.VisualStudio.Threading
 
             if (removed && this.childDependentNodes != null)
             {
-                foreach (var item in this.childDependentNodes)
+                foreach (var item in this.childDependentNodes.Keys)
                 {
-                    item.Key.RemoveDependingSynchronousTask(task, reachableNodes, ref remainingDependentNodes);
+                    item.RemoveDependingSynchronousTask(task, reachableNodes, ref remainingDependentNodes);
                 }
             }
         }

--- a/src/Microsoft.VisualStudio.Threading/WeakKeyDictionary.cs
+++ b/src/Microsoft.VisualStudio.Threading/WeakKeyDictionary.cs
@@ -70,7 +70,7 @@ namespace Microsoft.VisualStudio.Threading
         /// <summary>
         /// Gets all key values in the dictionary.
         /// </summary>
-        public KeyEnumerable Keys
+        internal IEnumerable<TKey> Keys
         {
             get
             {
@@ -210,103 +210,19 @@ namespace Microsoft.VisualStudio.Threading
         }
 
         /// <summary>
-        /// A helper structure to enumerate keys in the dictionary.
+        /// Whether the collection contains any item
         /// </summary>
-        public struct KeyEnumerable : IEnumerable<TKey>
+        internal bool Any()
         {
-            private WeakKeyDictionary<TKey, TValue> dictionary;
-
-            internal KeyEnumerable(WeakKeyDictionary<TKey, TValue> dictionary)
+            foreach (var item in this.dictionary)
             {
-                Requires.NotNull(dictionary, nameof(dictionary));
-                this.dictionary = dictionary;
-            }
-
-            /// <summary>
-            /// Gets the Enumerator
-            /// </summary>
-            /// <returns>A new KeyEnumerator.</returns>
-            public KeyEnumerator GetEnumerator()
-            {
-                return new KeyEnumerator(this.dictionary);
-            }
-
-            /// <summary>
-            /// Implements <see cref="IEnumerable{T}.GetEnumerator"/>
-            /// </summary>
-            IEnumerator<TKey> IEnumerable<TKey>.GetEnumerator()
-            {
-                return this.GetEnumerator();
-            }
-
-            /// <summary>
-            /// Implements <see cref="System.Collections.IEnumerable.GetEnumerator"/>
-            /// </summary>
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
-            {
-                return this.GetEnumerator();
-            }
-        }
-
-        /// <summary>
-        /// A helper structure to implement <see cref="IEnumerator{T}"/>
-        /// </summary>
-        public struct KeyEnumerator : IEnumerator<TKey>
-        {
-            private Dictionary<WeakReference<TKey>, TValue>.Enumerator enumerator;
-
-            internal KeyEnumerator(WeakKeyDictionary<TKey, TValue> dictionary)
-            {
-                Requires.NotNull(dictionary, nameof(dictionary));
-
-                this.enumerator = dictionary.dictionary.GetEnumerator();
-                this.Current = default(TKey);
-            }
-
-            /// <summary>
-            /// Gets the current item of the enumerator.
-            /// </summary>
-            public TKey Current { get; private set; }
-
-            object System.Collections.IEnumerator.Current
-            {
-                get { return this.Current; }
-            }
-
-            /// <summary>
-            /// Implements <see cref="System.Collections.IEnumerator.MoveNext"/>
-            /// </summary>
-            public bool MoveNext()
-            {
-                TKey key = null;
-
-                while (this.enumerator.MoveNext())
+                if (item.Key.IsAlive)
                 {
-                    key = this.enumerator.Current.Key.Target;
-                    if (key != null)
-                    {
-                        this.Current = key;
-                        return true;
-                    }
+                    return true;
                 }
-
-                return false;
             }
 
-            void System.Collections.IEnumerator.Reset()
-            {
-                // Calling reset on the dictionary enumerator would require boxing it in the cast to the explicit interface method.
-                // But boxing a valuetype means that any changes you make will not be brought back to the value type field
-                // so the Reset() will probably have no effect.
-                // If we ever have to support this, we'll probably have to do box the enumerator and then retain the boxed
-                // version and use that in this enumerator for the rest of its lifetime.
-                throw new NotSupportedException();
-            }
-
-            public void Dispose()
-            {
-                this.enumerator.Dispose();
-            }
+            return false;
         }
 
         public struct Enumerator : IEnumerator<KeyValuePair<TKey, TValue>>
@@ -442,6 +358,106 @@ namespace Microsoft.VisualStudio.Threading
                 }
 
                 return false;
+            }
+        }
+
+        /// <summary>
+        /// A helper structure to enumerate keys in the dictionary.
+        /// </summary>
+        internal class KeyEnumerable : IEnumerable<TKey>
+        {
+            private WeakKeyDictionary<TKey, TValue> dictionary;
+
+            internal KeyEnumerable(WeakKeyDictionary<TKey, TValue> dictionary)
+            {
+                Requires.NotNull(dictionary, nameof(dictionary));
+                this.dictionary = dictionary;
+            }
+
+            /// <summary>
+            /// Implements <see cref="IEnumerable{T}.GetEnumerator"/>
+            /// </summary>
+            IEnumerator<TKey> IEnumerable<TKey>.GetEnumerator()
+            {
+                return this.GetEnumerator();
+            }
+
+            /// <summary>
+            /// Implements <see cref="System.Collections.IEnumerable.GetEnumerator"/>
+            /// </summary>
+            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+            {
+                return this.GetEnumerator();
+            }
+
+            /// <summary>
+            /// Gets the Enumerator
+            /// </summary>
+            /// <returns>A new KeyEnumerator.</returns>
+            private KeyEnumerator GetEnumerator()
+            {
+                return new KeyEnumerator(this.dictionary);
+            }
+        }
+
+        /// <summary>
+        /// A helper structure to implement <see cref="IEnumerator{T}"/>
+        /// </summary>
+        private class KeyEnumerator : IEnumerator<TKey>
+        {
+            private Dictionary<WeakReference<TKey>, TValue>.Enumerator enumerator;
+
+            internal KeyEnumerator(WeakKeyDictionary<TKey, TValue> dictionary)
+            {
+                Requires.NotNull(dictionary, nameof(dictionary));
+
+                this.enumerator = dictionary.dictionary.GetEnumerator();
+                this.Current = default(TKey);
+            }
+
+            /// <summary>
+            /// Gets the current item of the enumerator.
+            /// </summary>
+            public TKey Current { get; private set; }
+
+            object System.Collections.IEnumerator.Current
+            {
+                get { return this.Current; }
+            }
+
+            /// <summary>
+            /// Implements <see cref="System.Collections.IEnumerator.MoveNext"/>
+            /// </summary>
+            public bool MoveNext()
+            {
+                TKey key = null;
+
+                while (this.enumerator.MoveNext())
+                {
+                    key = this.enumerator.Current.Key.Target;
+                    if (key != null)
+                    {
+                        this.Current = key;
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            void System.Collections.IEnumerator.Reset()
+            {
+                // Calling reset on the dictionary enumerator would require boxing it in the cast to the explicit interface method.
+                // But boxing a valuetype means that any changes you make will not be brought back to the value type field
+                // so the Reset() will probably have no effect.
+                // If we ever have to support this, we'll probably have to do box the enumerator and then retain the boxed
+                // version and use that in this enumerator for the rest of its lifetime.
+                throw new NotSupportedException();
+            }
+
+            public void Dispose()
+            {
+                this.enumerator.Dispose();
             }
         }
 

--- a/src/Microsoft.VisualStudio.Threading/WeakKeyDictionary.cs
+++ b/src/Microsoft.VisualStudio.Threading/WeakKeyDictionary.cs
@@ -68,6 +68,17 @@ namespace Microsoft.VisualStudio.Threading
         }
 
         /// <summary>
+        /// Gets all key values in the dictionary.
+        /// </summary>
+        public KeyEnumerable Keys
+        {
+            get
+            {
+                return new KeyEnumerable(this);
+            }
+        }
+
+        /// <summary>
         /// Obtains the value for a given key.
         /// </summary>
         public TValue this[TKey key]
@@ -196,6 +207,106 @@ namespace Microsoft.VisualStudio.Threading
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
         {
             return this.GetEnumerator();
+        }
+
+        /// <summary>
+        /// A helper structure to enumerate keys in the dictionary.
+        /// </summary>
+        public struct KeyEnumerable : IEnumerable<TKey>
+        {
+            private WeakKeyDictionary<TKey, TValue> dictionary;
+
+            internal KeyEnumerable(WeakKeyDictionary<TKey, TValue> dictionary)
+            {
+                Requires.NotNull(dictionary, nameof(dictionary));
+                this.dictionary = dictionary;
+            }
+
+            /// <summary>
+            /// Gets the Enumerator
+            /// </summary>
+            /// <returns>A new KeyEnumerator.</returns>
+            public KeyEnumerator GetEnumerator()
+            {
+                return new KeyEnumerator(this.dictionary);
+            }
+
+            /// <summary>
+            /// Implements <see cref="IEnumerable{T}.GetEnumerator"/>
+            /// </summary>
+            IEnumerator<TKey> IEnumerable<TKey>.GetEnumerator()
+            {
+                return this.GetEnumerator();
+            }
+
+            /// <summary>
+            /// Implements <see cref="System.Collections.IEnumerable.GetEnumerator"/>
+            /// </summary>
+            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+            {
+                return this.GetEnumerator();
+            }
+        }
+
+        /// <summary>
+        /// A helper structure to implement <see cref="IEnumerator{T}"/>
+        /// </summary>
+        public struct KeyEnumerator : IEnumerator<TKey>
+        {
+            private Dictionary<WeakReference<TKey>, TValue>.Enumerator enumerator;
+
+            internal KeyEnumerator(WeakKeyDictionary<TKey, TValue> dictionary)
+            {
+                Requires.NotNull(dictionary, nameof(dictionary));
+
+                this.enumerator = dictionary.dictionary.GetEnumerator();
+                this.Current = default(TKey);
+            }
+
+            /// <summary>
+            /// Gets the current item of the enumerator.
+            /// </summary>
+            public TKey Current { get; private set; }
+
+            object System.Collections.IEnumerator.Current
+            {
+                get { return this.Current; }
+            }
+
+            /// <summary>
+            /// Implements <see cref="System.Collections.IEnumerator.MoveNext"/>
+            /// </summary>
+            public bool MoveNext()
+            {
+                TKey key = null;
+
+                while (this.enumerator.MoveNext())
+                {
+                    key = this.enumerator.Current.Key.Target;
+                    if (key != null)
+                    {
+                        this.Current = key;
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            void System.Collections.IEnumerator.Reset()
+            {
+                // Calling reset on the dictionary enumerator would require boxing it in the cast to the explicit interface method.
+                // But boxing a valuetype means that any changes you make will not be brought back to the value type field
+                // so the Reset() will probably have no effect.
+                // If we ever have to support this, we'll probably have to do box the enumerator and then retain the boxed
+                // version and use that in this enumerator for the rest of its lifetime.
+                throw new NotSupportedException();
+            }
+
+            public void Dispose()
+            {
+                this.enumerator.Dispose();
+            }
         }
 
         public struct Enumerator : IEnumerator<KeyValuePair<TKey, TValue>>


### PR DESCRIPTION
The new file watcher change exposed a scalability issue in the current JTF data structure.  The primary problem is that JTF collection is copied to the internal dictionary of each JTF task joins to the collection.  It doesn't work in the file watcher scenario, because there are huge amount of tasks created to use a semaphore, all join to the semaphore JoinableCollection, and once it gets the semaphore, the semaphore creates/closes a task in the collection.  The data structure is O(n^2), and we saw 18k requests in a trace.

This change is to make JoinableTask/JoinableTaskCollection the same in the JTF dependency graph to eliminate the need to copy the collection.  The collection to track child/dependent tasks are now moved to the common base class.  The joiner collection in the JTF collection is no longer needed.

The change is based on 15.8 branch, because the master is moved to 16.0, which contains changes not yet in preview 1.

I still need test it in the product, but want to start code review sessions.