### PR TITLE
Add CancellationToken method overloads

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Tests/AsyncManualResetEventTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/AsyncManualResetEventTests.cs
@@ -227,5 +227,15 @@
                 Assert.True(presignaledEvent.WaitAsync().IsCompleted);
             }
         }
+
+        [Fact]
+        public async Task WaitAsyncWithCancellationToken()
+        {
+            var cts = new CancellationTokenSource();
+            Task waitTask = this.evt.WaitAsync(cts.Token);
+            cts.Cancel();
+            var ex = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => waitTask);
+            Assert.Equal(cts.Token, ex.CancellationToken);
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.Threading.Tests/JoinableTaskCollectionTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/JoinableTaskCollectionTests.cs
@@ -112,6 +112,25 @@
         }
 
         [StaFact]
+        public void JoinTillEmptyAsync_CancellationToken()
+        {
+            var tcs = new TaskCompletionSource<object>();
+            var joinable = this.JoinableFactory.RunAsync(async delegate
+            {
+                await tcs.Task;
+            });
+
+            this.context.Factory.Run(async delegate
+            {
+                var cts = new CancellationTokenSource();
+                Task joinTask = this.joinableCollection.JoinTillEmptyAsync(cts.Token);
+                cts.Cancel();
+                var ex = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => joinTask);
+                Assert.Equal(cts.Token, ex.CancellationToken);
+            });
+        }
+
+        [StaFact]
         public void AddTwiceRemoveOnceRemovesWhenNotRefCounting()
         {
             var finishTaskEvent = new AsyncManualResetEvent();

--- a/src/Microsoft.VisualStudio.Threading/AsyncManualResetEvent.cs
+++ b/src/Microsoft.VisualStudio.Threading/AsyncManualResetEvent.cs
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.Threading
         private readonly object syncObject = new object();
 
         /// <summary>
-        /// The source of the task to return from <see cref="WaitAsync"/>.
+        /// The source of the task to return from <see cref="WaitAsync()"/>.
         /// </summary>
         /// <devremarks>
         /// This should not need the volatile modifier because it is
@@ -60,10 +60,10 @@ namespace Microsoft.VisualStudio.Threading
         /// </summary>
         /// <param name="initialState">A value indicating whether the event should be initially signaled.</param>
         /// <param name="allowInliningAwaiters">
-        /// A value indicating whether to allow <see cref="WaitAsync"/> callers' continuations to execute
+        /// A value indicating whether to allow <see cref="WaitAsync()"/> callers' continuations to execute
         /// on the thread that calls <see cref="SetAsync()"/> before the call returns.
         /// <see cref="SetAsync()"/> callers should not hold private locks if this value is <c>true</c> to avoid deadlocks.
-        /// When <c>false</c>, the task returned from <see cref="WaitAsync"/> may not have fully transitioned to
+        /// When <c>false</c>, the task returned from <see cref="WaitAsync()"/> may not have fully transitioned to
         /// its completed state by the time <see cref="SetAsync()"/> returns to its caller.
         /// </param>
         public AsyncManualResetEvent(bool initialState = false, bool allowInliningAwaiters = false)
@@ -104,7 +104,14 @@ namespace Microsoft.VisualStudio.Threading
         }
 
         /// <summary>
-        /// Sets this event to unblock callers of <see cref="WaitAsync"/>.
+        /// Returns a task that will be completed when this event is set.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>A task that completes when the event is set, or cancels with the <paramref name="cancellationToken"/>.</returns>
+        public Task WaitAsync(CancellationToken cancellationToken) => this.WaitAsync().WithCancellation(cancellationToken);
+
+        /// <summary>
+        /// Sets this event to unblock callers of <see cref="WaitAsync()"/>.
         /// </summary>
         /// <returns>A task that completes when the signal has been set.</returns>
         /// <remarks>
@@ -145,7 +152,7 @@ namespace Microsoft.VisualStudio.Threading
         }
 
         /// <summary>
-        /// Sets this event to unblock callers of <see cref="WaitAsync"/>.
+        /// Sets this event to unblock callers of <see cref="WaitAsync()"/>.
         /// </summary>
         public void Set()
         {
@@ -155,7 +162,7 @@ namespace Microsoft.VisualStudio.Threading
         }
 
         /// <summary>
-        /// Resets this event to a state that will block callers of <see cref="WaitAsync"/>.
+        /// Resets this event to a state that will block callers of <see cref="WaitAsync()"/>.
         /// </summary>
         public void Reset()
         {

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskCollection.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskCollection.cs
@@ -217,8 +217,17 @@ namespace Microsoft.VisualStudio.Threading
         /// Joins the caller's context to this collection till the collection is empty.
         /// </summary>
         /// <returns>A task that completes when this collection is empty.</returns>
-        public async Task JoinTillEmptyAsync()
+        public Task JoinTillEmptyAsync() => this.JoinTillEmptyAsync(CancellationToken.None);
+
+        /// <summary>
+        /// Joins the caller's context to this collection till the collection is empty.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>A task that completes when this collection is empty, or is canceled when <paramref name="cancellationToken"/> is canceled.</returns>
+        public async Task JoinTillEmptyAsync(CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             if (this.emptyEvent == null)
             {
                 // We need a read lock to protect against the emptiness of this collection changing
@@ -236,7 +245,7 @@ namespace Microsoft.VisualStudio.Threading
 
             using (this.Join())
             {
-                await this.emptyEvent.WaitAsync().ConfigureAwait(false);
+                await this.emptyEvent.WaitAsync().WithCancellation(cancellationToken).ConfigureAwait(false);
             }
         }
 


### PR DESCRIPTION
The `AsyncManualResetEvent.WaitAsync(CancellationToken)` overload doesn't do anything the caller can't do anyway, but I occasionally get questions from folks asking how to do it right with a `CancellationToken`, so adding the overload just makes the API easier to consume.