### PR TITLE
Add ReentrantSemaphore.ExecuteAsync<T> overload

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Tests/ReentrantSemaphoreTestBase.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/ReentrantSemaphoreTestBase.cs
@@ -121,12 +121,71 @@ public abstract class ReentrantSemaphoreTestBase : TestBase, IDisposable
 
     [Theory]
     [MemberData(nameof(AllModes))]
+    public void ExecuteAsync_OfT_InvokesDelegateInOriginalContext_NoContention(ReentrantSemaphore.ReentrancyMode mode)
+    {
+        this.semaphore = this.CreateSemaphore(mode);
+        int originalThreadId = Environment.CurrentManagedThreadId;
+        this.ExecuteOnDispatcher(async delegate
+        {
+            bool executed = false;
+            int result = await this.semaphore.ExecuteAsync(
+                delegate
+                {
+                    Assert.Equal(originalThreadId, Environment.CurrentManagedThreadId);
+                    executed = true;
+                    return new ValueTask<int>(5);
+                }, this.TimeoutToken);
+            Assert.Equal(5, result);
+            Assert.True(executed);
+        });
+    }
+
+    [Theory]
+    [MemberData(nameof(AllModes))]
+    public void ExecuteAsync_OfT_InvokesDelegateInOriginalContext_WithContention(ReentrantSemaphore.ReentrancyMode mode)
+    {
+        this.semaphore = this.CreateSemaphore(mode);
+        int originalThreadId = Environment.CurrentManagedThreadId;
+        this.ExecuteOnDispatcher(async delegate
+        {
+            var releaseHolder = new AsyncManualResetEvent();
+            var holder = this.semaphore.ExecuteAsync(() => releaseHolder.WaitAsync());
+
+            bool executed = false;
+            var waiter = this.semaphore.ExecuteAsync(
+                delegate
+                {
+                    Assert.Equal(originalThreadId, Environment.CurrentManagedThreadId);
+                    executed = true;
+                    return new ValueTask<int>(5);
+                }, this.TimeoutToken);
+
+            releaseHolder.Set();
+            int result = await waiter.AsTask().WithCancellation(this.TimeoutToken);
+            Assert.Equal(5, result);
+            Assert.True(executed);
+        });
+    }
+
+    [Theory]
+    [MemberData(nameof(AllModes))]
     public void ExecuteAsync_NullDelegate(ReentrantSemaphore.ReentrancyMode mode)
     {
         this.semaphore = this.CreateSemaphore(mode);
         this.ExecuteOnDispatcher(async delegate
         {
             await Assert.ThrowsAsync<ArgumentNullException>(() => this.semaphore.ExecuteAsync(null, this.TimeoutToken));
+        });
+    }
+
+    [Theory]
+    [MemberData(nameof(AllModes))]
+    public void ExecuteAsync_OfT_NullDelegate(ReentrantSemaphore.ReentrancyMode mode)
+    {
+        this.semaphore = this.CreateSemaphore(mode);
+        this.ExecuteOnDispatcher(async delegate
+        {
+            await Assert.ThrowsAsync<ArgumentNullException>(() => this.semaphore.ExecuteAsync<int>(null, this.TimeoutToken).AsTask());
         });
     }
 

--- a/src/Microsoft.VisualStudio.Threading/Microsoft.VisualStudio.Threading.csproj
+++ b/src/Microsoft.VisualStudio.Threading/Microsoft.VisualStudio.Threading.csproj
@@ -63,6 +63,7 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />
     <PackageReference Include="Microsoft.VisualStudio.Validation" Version="15.3.15" />
     <PackageReference Include="MicroBuild.VisualStudio" Version="$(MicroBuildVersion)" PrivateAssets="all" />
     <PackageReference Include="MSBuild.SDK.Extras" Version="1.0.6" PrivateAssets="all" />


### PR DESCRIPTION
This change adds this overload to `ReentrantSemaphore`, allowing delegates to more conveniently return values to their caller:

```cs
public ValueTask<T> ExecuteAsync<T>(Func<ValueTask<T>> operation, CancellationToken cancellationToken = default);
```

This introduces the first use of `ValueTask<T>` to the vs-threading library. It allows for alloc-free async methods when they don't yield. `Task<T>` on the other hand, often has to be allocated even if the method didn't yield since `Task<T>` itself is a class.

Closes #401 