### PR TITLE
Overload ApplyChangeOptimistically to take operand

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Tests/ThreadingToolsTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/ThreadingToolsTests.cs
@@ -28,6 +28,14 @@
         }
 
         [Fact]
+        public void ApplyChangeOptimisticallyWithItem()
+        {
+            var n = new GenericParameterHelper(1);
+            Assert.True(ThreadingTools.ApplyChangeOptimistically(ref n, 2, (i, j) => new GenericParameterHelper(i.Data + j)));
+            Assert.Equal(3, n.Data);
+        }
+
+        [Fact]
         public void WithCancellationNull()
         {
             Assert.Throws<ArgumentNullException>(new Action(() =>

--- a/src/Microsoft.VisualStudio.Threading/ThreadingTools.cs
+++ b/src/Microsoft.VisualStudio.Threading/ThreadingTools.cs
@@ -70,7 +70,7 @@ namespace Microsoft.VisualStudio.Threading
         /// <c>false</c> if the location's value remained the same because the last invocation of <paramref name="applyChange"/> returned the existing value.
         /// </returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1045:DoNotPassTypesByReference", MessageId = "0#")]
-        public static bool ApplyChangeOptimistically<TData, TItem>(ref TData hotLocation, TItem item, Func<TData, TItem, TData> applyChange)
+        public static bool ApplyChangeOptimistically<TData, TItem>(ref TData hotLocation, in TItem item, Func<TData, TItem, TData> applyChange)
             where TData : class
         {
             Requires.NotNull(applyChange, nameof(applyChange));

--- a/src/Microsoft.VisualStudio.Threading/ThreadingTools.cs
+++ b/src/Microsoft.VisualStudio.Threading/ThreadingTools.cs
@@ -52,6 +52,49 @@ namespace Microsoft.VisualStudio.Threading
         }
 
         /// <summary>
+        /// Optimistically performs some value transformation based on some field and tries to apply it back to the field,
+        /// retrying as many times as necessary until no other thread is manipulating the same field.
+        /// </summary>
+        /// <remarks>
+        /// Use this overload when <paramref name="applyChange"/> requires a single item, as is common when updating immutable
+        /// collection types. By passing the item as a method operand, the caller may be able to avoid allocating a closure
+        /// object for every call.
+        /// </remarks>
+        /// <typeparam name="TData">The type of data.</typeparam>
+        /// <typeparam name="TItem">The type of item.</typeparam>
+        /// <param name="hotLocation">The field that may be manipulated by multiple threads.</param>
+        /// <param name="item">A data value to pass to <paramref name="applyChange"/>.</param>
+        /// <param name="applyChange">A function that receives both the unchanged value and <paramref name="item"/>, then returns the changed value.</param>
+        /// <returns>
+        /// <c>true</c> if the location's value is changed by applying the result of the <paramref name="applyChange"/> function;
+        /// <c>false</c> if the location's value remained the same because the last invocation of <paramref name="applyChange"/> returned the existing value.
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1045:DoNotPassTypesByReference", MessageId = "0#")]
+        public static bool ApplyChangeOptimistically<TData, TItem>(ref TData hotLocation, TItem item, Func<TData, TItem, TData> applyChange)
+            where TData : class
+        {
+            Requires.NotNull(applyChange, nameof(applyChange));
+
+            bool successful;
+            do
+            {
+                TData oldValue = Volatile.Read(ref hotLocation);
+                TData newValue = applyChange(oldValue, item);
+                if (object.ReferenceEquals(oldValue, newValue))
+                {
+                    // No change was actually required.
+                    return false;
+                }
+
+                TData actualOldValue = Interlocked.CompareExchange<TData>(ref hotLocation, newValue, oldValue);
+                successful = object.ReferenceEquals(oldValue, actualOldValue);
+            }
+            while (!successful);
+
+            return true;
+        }
+
+        /// <summary>
         /// Wraps a task with one that will complete as cancelled based on a cancellation token,
         /// allowing someone to await a task but be able to break out early by cancelling the token.
         /// </summary>


### PR DESCRIPTION
This allows elimination of closure allocations in many common cases.

Consider adding an item to an immutable collection. With this change, the item to be added can be passed on the stack, making the lambda 'static', and avoiding a per-call closure heap allocation.

```c#
ImmutableList<T> list;
ThreadingTools.ApplyChangeOptimistically(
    ref list, itemToAdd, (list, item) => list.Add(item));
```

This [sharplab example](https://sharplab.io/#v2:EYLgZgpghgLgrgJwgZwLQFEAeAHJzkCWA9gHYBqUCBUwANigD4ACADAARMCMA3ALABQApgGYOAJjYBhAQG8BbBR1FMALGwCynABQESMNgQCUbeYrn9FlqVGzwkWrcYC8APgNsnTti0N8LigF9TBWClDjV1MR09A2NQ8ytFADkiSRs7CB0AGjYAKw83fM9vX1Cg/xCKtmAiIlprW0RMpgBWAB4aurcwOBIAY2du3r7HP0tQzvqUtMb7XX0CHNa2+ZzJof7Bth7+nV9x/gCgA=) shows the difference and benefit.

---

I considered having one overload call the other but wanted to avoid the extra layer of indirection, but I'm happy to change that if preferred.