### PR TITLE
Target System.Threading.Tasks.Extensions 4.3.0 instead of 4.5.1

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/Microsoft.VisualStudio.Threading.csproj
+++ b/src/Microsoft.VisualStudio.Threading/Microsoft.VisualStudio.Threading.csproj
@@ -63,7 +63,7 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.3.0" />
     <PackageReference Include="Microsoft.VisualStudio.Validation" Version="15.3.15" />
     <PackageReference Include="MicroBuild.VisualStudio" Version="$(MicroBuildVersion)" PrivateAssets="all" />
     <PackageReference Include="MSBuild.SDK.Extras" Version="1.0.6" PrivateAssets="all" />


### PR DESCRIPTION
This allows us to match the version of the assembly VS is already shipping.