### PR TITLE
Fix VSTHRD003 when field is defined in another document

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD003UseJtfRunAsyncAnalyzerTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD003UseJtfRunAsyncAnalyzerTests.cs
@@ -1080,6 +1080,42 @@ class Tests
             await Verify.VerifyAnalyzerAsync(test, expected);
         }
 
+        [Fact(Skip = "Test is not yet implemented since it needs TWO source files.")]
+        public async Task TaskReturningMethodIncludeArgumentFromOtherSyntaxTree()
+        {
+            // This is a regression test for a bug that only repro'd when the field was defined in a different document from where it was used
+            // as input to a return value from a Task-returning method.
+            var source1 = @"
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+
+internal class Test
+{
+    private Task<ImmutableHashSet<string>> SomethingAsync()
+    {
+        return Task.FromResult(OtherClass.ProjectSystem);
+    }
+}
+";
+            var source2 = @"
+using System.Collections.Immutable;
+
+class OtherClass
+{
+    internal static readonly ImmutableHashSet<string> ProjectSystem =
+        ImmutableHashSet<string>.Empty.Union(new[]
+        {
+            ""a""
+        });
+}
+";
+
+            // TODO: add source2 to this test.
+            var test = new Verify.Test { TestCode = source1 };
+            test.TestCode = source2; // also
+            await test.RunAsync();
+        }
+
         private DiagnosticResult CreateDiagnostic(int line, int column, int length) =>
             Verify.Diagnostic().WithSpan(line, column, line, column + length);
     }


### PR DESCRIPTION
The issue was when VSTHRD003 recursively drills into the inputs of the return statement of a `Task`-returning method, it may end up needing the semantic model of other documents that define those inputs. But we were using `context.SemanticModel` indiscriminately, and it throws when you pass it a `SyntaxNode` from another document that it wasn't made for.