### PR TITLE
Drop support for oldest target frameworks

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/Microsoft.VisualStudio.Threading.csproj
+++ b/src/Microsoft.VisualStudio.Threading/Microsoft.VisualStudio.Threading.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.1;netstandard1.3;netstandard2.0;portable-net45+win8+wpa81;net45;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;netstandard1.3;netstandard2.0;net45;net46</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisRuleSet>FxCopRules.ruleset</CodeAnalysisRuleSet>
 
     <TargetsDesktop Condition=" '$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'net46' ">true</TargetsDesktop>
     <DefineConstants Condition=" '$(TargetsDesktop)' == 'true' ">$(DefineConstants);DESKTOP</DefineConstants>
-    <DefineConstants Condition=" '$(TargetFramework)' != 'netstandard1.1' and '$(TargetFramework)' != 'portable-net45+win8+wpa81' ">$(DefineConstants);EXECUTIONCONTEXT</DefineConstants>
+    <DefineConstants Condition=" '$(TargetFramework)' != 'netstandard1.1' ">$(DefineConstants);EXECUTIONCONTEXT</DefineConstants>
     <DefineConstants Condition=" '$(TargetFramework)' == 'net46' or '$(TargetFramework)' == 'netstandard1.3' or '$(TargetFramework)' == 'netstandard2.0' ">$(DefineConstants);ASYNCLOCAL</DefineConstants>
     <DefineConstants Condition=" '$(TargetFramework)' == 'net46' or '$(TargetFramework)' == 'netstandard1.3' or '$(TargetFramework)' == 'netstandard2.0' ">$(DefineConstants);TRYSETCANCELEDCT</DefineConstants>
     <DefineConstants Condition=" '$(TargetsDesktop)' == 'true' ">$(DefineConstants);CALLCONTEXT</DefineConstants>
@@ -23,11 +23,8 @@
     <PackageReleaseNotes>https://go.microsoft.com/fwlink/?LinkID=746387</PackageReleaseNotes>
 
     <DebugType>full</DebugType>
-    <RunCodeAnalysis Condition=" '$(TargetFramework)' != 'portable-net45+win8+wpa81' and '$(TargetFramework)' != 'netstandard2.0' and '$(Configuration)' != 'Debug' ">true</RunCodeAnalysis>
+    <RunCodeAnalysis Condition=" '$(TargetFramework)' != 'netstandard2.0' and '$(Configuration)' != 'Debug' ">true</RunCodeAnalysis>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-
-    <!-- Reference directly to use 4.3.1 and suppress package restore warnings. See https://github.com/dotnet/corefx/issues/29907 and https://github.com/AArnott/vs-threading/commit/357f279e44d150d2dbc305cf81fd549f2cbaed2d -->
-    <RuntimeIdentifiers Condition="'$(TargetFramework)' == 'portable-net45+win8+wpa81'">;</RuntimeIdentifiers>
   </PropertyGroup>
   <PropertyGroup Label="MultilingualAppToolkit">
     <MultilingualAppToolkitVersion>4.0</MultilingualAppToolkitVersion>
@@ -66,7 +63,6 @@
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.3.0" />
     <PackageReference Include="Microsoft.VisualStudio.Validation" Version="15.3.15" />
     <PackageReference Include="MicroBuild.VisualStudio" Version="$(MicroBuildVersion)" PrivateAssets="all" />
-    <PackageReference Include="MSBuild.SDK.Extras" Version="1.0.6" PrivateAssets="all" />
     <PackageReference Include="GitLink" Version="3.2.0-unstable0014" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
@@ -75,7 +71,6 @@
     <ProjectReference Include="..\Microsoft.VisualStudio.Threading.Analyzers\Microsoft.VisualStudio.Threading.Analyzers.csproj"
       PrivateAssets="none" />
   </ItemGroup>
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\Microsoft.Multilingual.ResxResources.targets" Label="MultilingualAppToolkit" Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\v$(MultilingualAppToolkitVersion)\Microsoft.Multilingual.ResxResources.targets')" />
   <Target Name="MATPrerequisite" BeforeTargets="PrepareForBuild" Condition="!Exists('$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\Microsoft.Multilingual.ResxResources.targets')" Label="MultilingualAppToolkit">
     <Warning Text="$(MSBuildProjectFile) is Multilingual build enabled, but the Multilingual App Toolkit is unavailable during the build. If building with Visual Studio, please check to ensure that toolkit is properly installed." />

--- a/src/Microsoft.VisualStudio.Threading/Microsoft.VisualStudio.Threading.csproj
+++ b/src/Microsoft.VisualStudio.Threading/Microsoft.VisualStudio.Threading.csproj
@@ -1,12 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.1;netstandard1.3;netstandard2.0;net45;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;net45;net46</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisRuleSet>FxCopRules.ruleset</CodeAnalysisRuleSet>
 
     <TargetsDesktop Condition=" '$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'net46' ">true</TargetsDesktop>
     <DefineConstants Condition=" '$(TargetsDesktop)' == 'true' ">$(DefineConstants);DESKTOP</DefineConstants>
-    <DefineConstants Condition=" '$(TargetFramework)' != 'netstandard1.1' ">$(DefineConstants);EXECUTIONCONTEXT</DefineConstants>
     <DefineConstants Condition=" '$(TargetFramework)' == 'net46' or '$(TargetFramework)' == 'netstandard1.3' or '$(TargetFramework)' == 'netstandard2.0' ">$(DefineConstants);ASYNCLOCAL</DefineConstants>
     <DefineConstants Condition=" '$(TargetFramework)' == 'net46' or '$(TargetFramework)' == 'netstandard1.3' or '$(TargetFramework)' == 'netstandard2.0' ">$(DefineConstants);TRYSETCANCELEDCT</DefineConstants>
     <DefineConstants Condition=" '$(TargetsDesktop)' == 'true' ">$(DefineConstants);CALLCONTEXT</DefineConstants>

--- a/src/Microsoft.VisualStudio.Threading/SingleThreadedSynchronizationContext.cs
+++ b/src/Microsoft.VisualStudio.Threading/SingleThreadedSynchronizationContext.cs
@@ -162,14 +162,10 @@ namespace Microsoft.VisualStudio.Threading
 
                     if (message.Context != null)
                     {
-#if EXECUTIONCONTEXT
                         ExecutionContext.Run(
                             message.Context,
                             new ContextCallback(message.Callback),
                             message.State);
-#else
-                        throw Assumes.NotReachable();
-#endif
                     }
                     else
                     {
@@ -195,17 +191,6 @@ namespace Microsoft.VisualStudio.Threading
                 this.Context = ctxt;
             }
         }
-
-#if !EXECUTIONCONTEXT
-        private class ExecutionContext
-        {
-            private ExecutionContext()
-            {
-            }
-
-            internal static ExecutionContext Capture() => null;
-        }
-#endif
 
         /// <summary>
         /// A message pumping frame that may be pushed with <see cref="PushFrame(Frame)"/> to pump messages


### PR DESCRIPTION
This change drops `portable-net45+win8+wpa81` and `netstandard1.1` as target frameworks to the core library.

.netstandard 1.3 is still a target. This effectively drops old PCL-based libraries and Windows 8.x Store app and Windows Phone 8.x support.

The lack of PCL targets removes our need to use the MSBuild.Sdk.Extras, so I've removed that as well.