### PR TITLE
Fix CodeAnalysis build warning

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/ThreadingTools.cs
+++ b/src/Microsoft.VisualStudio.Threading/ThreadingTools.cs
@@ -70,7 +70,7 @@ namespace Microsoft.VisualStudio.Threading
         /// <c>false</c> if the location's value remained the same because the last invocation of <paramref name="applyChange"/> returned the existing value.
         /// </returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1045:DoNotPassTypesByReference", MessageId = "0#")]
-        public static bool ApplyChangeOptimistically<T, TArg>(ref T hotLocation, in TArg applyChangeArgument, Func<T, TArg, T> applyChange)
+        public static bool ApplyChangeOptimistically<T, TArg>(ref T hotLocation, TArg applyChangeArgument, Func<T, TArg, T> applyChange)
             where T : class
         {
             Requires.NotNull(applyChange, nameof(applyChange));


### PR DESCRIPTION
This removes the `in` modifier from the parameter in a newly introduced method.

This I guess is a binary breaking change, but the method itself has only been in place for a few days, so it shouldn't break anyone if we act fast, and it removes a Code Analysis build warning.

The build warning could also be suppressed, but the perf argument for passing in `TArg` by ref is only interesting if `TArg` is a large struct such that we would want to avoid copying. But then we'd need to also stop using `Func<T, TArg, T>` in favor of a custom delegate that also takes the `TArg` as an `in` parameter. So I suspect this `in` modifier was unintentional in the first place.