### PR TITLE
Switch from legacy RunCodeAnalysis to FxCopAnalyzers

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/AsyncAutoResetEvent.cs
+++ b/src/Microsoft.VisualStudio.Threading/AsyncAutoResetEvent.cs
@@ -98,7 +98,7 @@ namespace Microsoft.VisualStudio.Threading
                 }
                 else
                 {
-                    var waiter = new WaiterCompletionSource(this, cancellationToken, this.allowInliningAwaiters);
+                    var waiter = new WaiterCompletionSource(this, this.allowInliningAwaiters, cancellationToken);
                     if (cancellationToken.IsCancellationRequested)
                     {
                         waiter.TrySetCanceled(cancellationToken);
@@ -171,9 +171,9 @@ namespace Microsoft.VisualStudio.Threading
             /// Initializes a new instance of the <see cref="WaiterCompletionSource"/> class.
             /// </summary>
             /// <param name="owner">The event that is initializing this value.</param>
-            /// <param name="cancellationToken">The cancellation token associated with the waiter.</param>
             /// <param name="allowInliningContinuations"><c>true</c> to allow continuations to be inlined upon the completer's callstack.</param>
-            public WaiterCompletionSource(AsyncAutoResetEvent owner, CancellationToken cancellationToken, bool allowInliningContinuations)
+            /// <param name="cancellationToken">The cancellation token associated with the waiter.</param>
+            public WaiterCompletionSource(AsyncAutoResetEvent owner, bool allowInliningContinuations, CancellationToken cancellationToken)
                 : base(allowInliningContinuations)
             {
                 this.CancellationToken = cancellationToken;

--- a/src/Microsoft.VisualStudio.Threading/AsyncReaderWriterLock+HangReportContributor.cs
+++ b/src/Microsoft.VisualStudio.Threading/AsyncReaderWriterLock+HangReportContributor.cs
@@ -17,11 +17,6 @@ namespace Microsoft.VisualStudio.Threading
 
     partial class AsyncReaderWriterLock : IHangReportContributor
     {
-        /// <summary>
-        /// The namespace that all DGML nodes appear in.
-        /// </summary>
-        private const string DgmlNamespace = "http://schemas.microsoft.com/vs/2009/dgml";
-
         [Flags]
         private enum AwaiterCollection
         {

--- a/src/Microsoft.VisualStudio.Threading/AsyncReaderWriterLock.cs
+++ b/src/Microsoft.VisualStudio.Threading/AsyncReaderWriterLock.cs
@@ -1376,14 +1376,7 @@ namespace Microsoft.VisualStudio.Threading
             Exception prereqException = null;
             try
             {
-                if (SynchronizationContext.Current is NonConcurrentSynchronizationContext)
-                {
-                    await beginAfterPrerequisite;
-                }
-                else
-                {
-                    await beginAfterPrerequisite.ConfigureAwait(false);
-                }
+                await beginAfterPrerequisite.ConfigureAwait(SynchronizationContext.Current is NonConcurrentSynchronizationContext);
             }
             catch (Exception ex)
             {
@@ -1527,7 +1520,7 @@ namespace Microsoft.VisualStudio.Threading
                 {
                     try
                     {
-                        await callback();
+                        await callback().ConfigureAwait(true);
                     }
                     catch (Exception ex)
                     {

--- a/src/Microsoft.VisualStudio.Threading/FxCopRules.ruleset
+++ b/src/Microsoft.VisualStudio.Threading/FxCopRules.ruleset
@@ -6,6 +6,7 @@
     <Rule Id="CA1026" Action="None" />
     <Rule Id="CA1034" Action="None" />
     <Rule Id="CA1500" Action="None" />
+    <Rule Id="CA1825" Action="Hidden" />
     <Rule Id="CA2210" Action="None" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
@@ -741,7 +741,7 @@ namespace Microsoft.VisualStudio.Threading
             [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
             public MainThreadAwaiter GetAwaiter()
             {
-                return new MainThreadAwaiter(this.jobFactory, this.job, this.cancellationToken, this.alwaysYield);
+                return new MainThreadAwaiter(this.jobFactory, this.job, this.alwaysYield, this.cancellationToken);
             }
         }
 
@@ -787,7 +787,7 @@ namespace Microsoft.VisualStudio.Threading
             /// <summary>
             /// Initializes a new instance of the <see cref="MainThreadAwaiter"/> struct.
             /// </summary>
-            internal MainThreadAwaiter(JoinableTaskFactory jobFactory, JoinableTask job, CancellationToken cancellationToken, bool alwaysYield)
+            internal MainThreadAwaiter(JoinableTaskFactory jobFactory, JoinableTask job, bool alwaysYield, CancellationToken cancellationToken)
             {
                 this.jobFactory = jobFactory;
                 this.job = job;

--- a/src/Microsoft.VisualStudio.Threading/LightUps`1.cs
+++ b/src/Microsoft.VisualStudio.Threading/LightUps`1.cs
@@ -13,6 +13,8 @@ namespace Microsoft.VisualStudio.Threading
     using System.Threading;
     using System.Threading.Tasks;
 
+#pragma warning disable CA1812 // unused code is common, based on target framework
+
     /// <summary>
     /// Light-up functionality that requires a generic type argument.
     /// </summary>

--- a/src/Microsoft.VisualStudio.Threading/Microsoft.VisualStudio.Threading.csproj
+++ b/src/Microsoft.VisualStudio.Threading/Microsoft.VisualStudio.Threading.csproj
@@ -21,7 +21,6 @@
     <PackageIconUrl>https://aka.ms/VsExtensibilityIcon</PackageIconUrl>
     <PackageReleaseNotes>https://go.microsoft.com/fwlink/?LinkID=746387</PackageReleaseNotes>
 
-    <RunCodeAnalysis Condition=" '$(TargetFramework)' != 'netstandard2.0' and '$(Configuration)' != 'Debug' ">true</RunCodeAnalysis>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Label="MultilingualAppToolkit">
@@ -61,6 +60,7 @@
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.3.0" />
     <PackageReference Include="Microsoft.VisualStudio.Validation" Version="15.3.15" />
     <PackageReference Include="MicroBuild.VisualStudio" Version="$(MicroBuildVersion)" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <!-- Don't consume the analyzers in this library itself,

--- a/src/Microsoft.VisualStudio.Threading/NoMessagePumpSyncContext.cs
+++ b/src/Microsoft.VisualStudio.Threading/NoMessagePumpSyncContext.cs
@@ -53,9 +53,9 @@ namespace Microsoft.VisualStudio.Threading
         /// <summary>
         /// Synchronously blocks without a message pump.
         /// </summary>
-        /// <param name="waitHandles">An array of type <see cref="T:System.IntPtr" /> that contains the native operating system handles.</param>
+        /// <param name="waitHandles">An array of type <see cref="IntPtr" /> that contains the native operating system handles.</param>
         /// <param name="waitAll">true to wait for all handles; false to wait for any handle.</param>
-        /// <param name="millisecondsTimeout">The number of milliseconds to wait, or <see cref="F:System.Threading.Timeout.Infinite" /> (-1) to wait indefinitely.</param>
+        /// <param name="millisecondsTimeout">The number of milliseconds to wait, or <see cref="Timeout.Infinite" /> (-1) to wait indefinitely.</param>
         /// <returns>
         /// The array index of the object that satisfied the wait.
         /// </returns>

--- a/src/Microsoft.VisualStudio.Threading/ProgressWithCompletion.cs
+++ b/src/Microsoft.VisualStudio.Threading/ProgressWithCompletion.cs
@@ -81,7 +81,9 @@ namespace Microsoft.VisualStudio.Threading
         /// <param name="value">The value representing the updated progress.</param>
         protected virtual void Report(T value)
         {
+#pragma warning disable CA2008 // Do not create tasks without passing a TaskScheduler
             var reported = this.taskFactory.StartNew(() => this.handler(value)).Unwrap();
+#pragma warning restore CA2008 // Do not create tasks without passing a TaskScheduler
             lock (this.syncObject)
             {
                 this.outstandingTasks.Add(reported);

--- a/src/Microsoft.VisualStudio.Threading/ReentrantSemaphore.cs
+++ b/src/Microsoft.VisualStudio.Threading/ReentrantSemaphore.cs
@@ -750,7 +750,9 @@ namespace Microsoft.VisualStudio.Threading
                                     {
                                         // When the semaphore faults, we will drain and throw for awaiting tasks one by one.
                                         this.faulted = true;
+#pragma warning disable CA2219 // Do not raise exceptions in finally clauses
                                         throw Verify.FailOperation(Strings.SemaphoreStackNestingViolated, ReentrancyMode.Stack);
+#pragma warning restore CA2219 // Do not raise exceptions in finally clauses
                                     }
                                 }
                             }
@@ -862,7 +864,9 @@ namespace Microsoft.VisualStudio.Threading
                                     {
                                         // When the semaphore faults, we will drain and throw for awaiting tasks one by one.
                                         this.faulted = true;
+#pragma warning disable CA2219 // Do not raise exceptions in finally clauses
                                         throw Verify.FailOperation(Strings.SemaphoreStackNestingViolated, ReentrancyMode.Stack);
+#pragma warning restore CA2219 // Do not raise exceptions in finally clauses
                                     }
                                 }
                             }

--- a/src/Microsoft.VisualStudio.Threading/ThreadingTools.cs
+++ b/src/Microsoft.VisualStudio.Threading/ThreadingTools.cs
@@ -238,7 +238,7 @@ namespace Microsoft.VisualStudio.Threading
                 }
                 else
                 {
-                    var tuple = new CancelableTaskCompletionSource<T>(taskCompletionSource, cancellationToken, cancellationCallback);
+                    var tuple = new CancelableTaskCompletionSource<T>(taskCompletionSource, cancellationCallback, cancellationToken);
                     tuple.CancellationTokenRegistration = cancellationToken.Register(
                         s =>
                         {
@@ -337,9 +337,9 @@ namespace Microsoft.VisualStudio.Threading
             /// Initializes a new instance of the <see cref="CancelableTaskCompletionSource{T}"/> class.
             /// </summary>
             /// <param name="taskCompletionSource">The task completion source.</param>
-            /// <param name="cancellationToken">The cancellation token.</param>
             /// <param name="cancellationCallback">A callback to invoke when cancellation occurs.</param>
-            internal CancelableTaskCompletionSource(TaskCompletionSource<T> taskCompletionSource, CancellationToken cancellationToken, ICancellationNotification cancellationCallback)
+            /// <param name="cancellationToken">The cancellation token.</param>
+            internal CancelableTaskCompletionSource(TaskCompletionSource<T> taskCompletionSource, ICancellationNotification cancellationCallback, CancellationToken cancellationToken)
             {
                 this.TaskCompletionSource = taskCompletionSource ?? throw new ArgumentNullException(nameof(taskCompletionSource));
                 this.CancellationToken = cancellationToken;

--- a/src/Microsoft.VisualStudio.Threading/TplExtensions.cs
+++ b/src/Microsoft.VisualStudio.Threading/TplExtensions.cs
@@ -277,7 +277,7 @@ namespace Microsoft.VisualStudio.Threading
                 {
                     try
                     {
-                        await handler(sender, args);
+                        await handler(sender, args).ConfigureAwait(true);
                     }
                     catch (Exception ex)
                     {
@@ -318,7 +318,7 @@ namespace Microsoft.VisualStudio.Threading
                 {
                     try
                     {
-                        await handler(sender, args);
+                        await handler(sender, args).ConfigureAwait(true);
                     }
                     catch (Exception ex)
                     {

--- a/src/Microsoft.VisualStudio.Threading/WeakKeyDictionary.cs
+++ b/src/Microsoft.VisualStudio.Threading/WeakKeyDictionary.cs
@@ -287,7 +287,7 @@ namespace Microsoft.VisualStudio.Threading
         /// the target's hash code so that it can be used in a hashtable.
         /// </summary>
         /// <typeparam name="T">Type of the target of the weak reference</typeparam>
-        private struct WeakReference<T>
+        private struct WeakReference<T> : IEquatable<WeakReference<T>>
             where T : class
         {
             /// <summary>
@@ -352,13 +352,11 @@ namespace Microsoft.VisualStudio.Threading
                 // We can't implement equals in the same terms as GetHashCode() because
                 // our target object may have been collected.  Instead just go based on
                 // equality of our weak references.
-                if (obj is WeakReference<T> other)
-                {
-                    return this.weakReference.Equals(other.weakReference);
-                }
-
-                return false;
+                return obj is WeakReference<T> other && this.Equals(other);
             }
+
+            /// <inheritdoc />
+            public bool Equals(WeakReference<T> other) => this.weakReference.Equals(other.weakReference);
         }
 
         /// <summary>


### PR DESCRIPTION
We're getting build warnings about using the old FxCop system. This gets us onto the new one, and resolves the several new warnings we were seeing in the switch.

The changes are all very low risk: implement an interface on an internal type, reorder parameters on internal methods, etc.