### PR TITLE
Don't test sign on hosted build agents

### DIFF
--- a/azure-pipelines/variables/SignType.ps1
+++ b/azure-pipelines/variables/SignType.ps1
@@ -1,5 +1,5 @@
 if ($env:SignType) {
-    $env:SignType
-} else {
-    'test'
+  $env:SignType
+} elseif ($env:SYSTEM_COLLECTIONID -eq '011b8bdf-6d56-4f87-be0d-0092136884d9') {
+  'test'
 }

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/Microsoft.VisualStudio.Threading.Analyzers.Tests.csproj
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/Microsoft.VisualStudio.Threading.Analyzers.Tests.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="MicroBuild.Nonshipping" Version="$(MicroBuildVersion)" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="..\Microsoft.VisualStudio.Threading.Analyzers\build\AdditionalFiles\**" LinkBase="BuiltIn.AdditionalFiles">
+    <EmbeddedResource Include="..\Microsoft.VisualStudio.Threading.Analyzers.CodeFixes\build\AdditionalFiles\**" LinkBase="BuiltIn.AdditionalFiles">
       <LogicalName>AdditionalFiles.%(FileName)%(Extension)</LogicalName>
     </EmbeddedResource>
     <EmbeddedResource Include="AdditionalFiles\**">
@@ -45,7 +45,7 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Update="..\Microsoft.VisualStudio.Threading.Analyzers\build\AdditionalFiles\VSTHRD010.MainThreadSwitchingMethods.txt">
+    <EmbeddedResource Update="..\Microsoft.VisualStudio.Threading.Analyzers.CodeFixes\build\AdditionalFiles\VSTHRD010.MainThreadSwitchingMethods.txt">
       <CustomToolNamespace>AdditionalFiles</CustomToolNamespace>
     </EmbeddedResource>
   </ItemGroup>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/Microsoft.VisualStudio.Threading.Analyzers.Tests.csproj
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/Microsoft.VisualStudio.Threading.Analyzers.Tests.csproj
@@ -5,6 +5,7 @@
     <CodeAnalysisRuleSet>Microsoft.VisualStudio.Threading.Analyzers.Tests.ruleset</CodeAnalysisRuleSet>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>

--- a/src/Microsoft.VisualStudio.Threading.Tests/Microsoft.VisualStudio.Threading.Tests.csproj
+++ b/src/Microsoft.VisualStudio.Threading.Tests/Microsoft.VisualStudio.Threading.Tests.csproj
@@ -9,6 +9,7 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
 
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>


### PR DESCRIPTION
Using SignType=test on hosted agents was breaking most of the test runs