### PR TITLE
Use Equals method when comparing ITypeSymbol in analyzers

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Utils.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Utils.cs
@@ -78,7 +78,7 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
 
         internal static bool IsEqualToOrDerivedFrom(ITypeSymbol type, ITypeSymbol expectedType)
         {
-            return type?.OriginalDefinition == expectedType || IsDerivedFrom(type, expectedType);
+            return EqualityComparer<ITypeSymbol>.Default.Equals(type?.OriginalDefinition, expectedType) || IsDerivedFrom(type, expectedType);
         }
 
         internal static bool IsDerivedFrom(ITypeSymbol type, ITypeSymbol expectedType)
@@ -86,7 +86,7 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
             type = type?.BaseType;
             while (type != null)
             {
-                if (type.OriginalDefinition == expectedType)
+                if (EqualityComparer<ITypeSymbol>.Default.Equals(type.OriginalDefinition, expectedType))
                 {
                     return true;
                 }
@@ -285,7 +285,7 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
             var objectType = compilation.GetTypeByMetadataName(typeof(object).FullName);
             var eventArgsType = compilation.GetTypeByMetadataName(typeof(EventArgs).FullName);
             return methodSymbol.Parameters.Length == 2
-                && methodSymbol.Parameters[0].Type.OriginalDefinition == objectType
+                && EqualityComparer<ITypeSymbol>.Default.Equals(methodSymbol.Parameters[0].Type.OriginalDefinition, objectType)
                 && methodSymbol.Parameters[0].Name == "sender"
                 && Utils.IsEqualToOrDerivedFrom(methodSymbol.Parameters[1].Type, eventArgsType);
         }


### PR DESCRIPTION
Roslyn may have multiple (equivalent) instances for an ITypeSymbol, making the == operator sometimes return false when the Equals method would return true.