### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ Analyzers: [![NuGet package](https://img.shields.io/nuget/v/Microsoft.VisualStud
 ## Supported platforms
 
 * .NET 4.5
-* .NET Standard 1.1
-* .NET Portable (Profile111)
+* .NET 4.6
+* .NET Standard 1.3
+* .NET Standard 2.0
 
 [1]: https://nuget.org/packages/Microsoft.VisualStudio.Threading "Microsoft.VisualStudio.Threading NuGet package"


### PR DESCRIPTION
PCL has been removed and the supported .NET Standard version bumped from 1.1 to 1.3.
https://github.com/Microsoft/vs-threading/blob/master/src/Microsoft.VisualStudio.Threading/Microsoft.VisualStudio.Threading.csproj

Relevant commits:
"Remove PCL target" https://github.com/Microsoft/vs-threading/commit/c19ea202181d23f04e2469b806f9810f1110a935
"Remove the netstandard1.1 target" https://github.com/Microsoft/vs-threading/commit/ce633375f2ded91034363f59e4b0d8bbe6ee63da