### PR TITLE
Fix deadlock in AsyncQueue<T>.DequeueAsync cancellation

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/FxCopRules.ruleset
+++ b/src/Microsoft.VisualStudio.Threading/FxCopRules.ruleset
@@ -43,5 +43,6 @@
     <Rule Id="SA1204" Action="Hidden" />
     <Rule Id="SA1207" Action="Hidden" />
     <Rule Id="SA1133" Action="Hidden" />
+    <Rule Id="SA1108" Action="Hidden" />
   </Rules>
 </RuleSet>


### PR DESCRIPTION
I made a few changes for this:

1. Added another couple of checks to reduce the likelihood of the race condition and reduce work where it can be optimized away.
1. Within the task.ContinueWith delegate, I check whether we are executing inline. If we are, we divert the CTR.Dispose call to the threadpool.
1. We only reschedule the work to the threadpool if the CancellationToken hasn't already been canceled, since once it has, there is no need to dispose of the CTR anyway since all the memory has been released. So I added a check to skip the threadpool scheduling where we can.

That last point means that basically the `ThreadPool.QueueUserWorkItem` delegate is dead code, since the *only* caller for `AttachCancellation` right now will never complete the TaskCompletionSource while this method is executing, leaving only the cancellation case. But since this method might be used in other places in the future, I thought we should make sure it is fully implemented. I used the debugger to manually test that code path to ensure correctness.

Fixes #458