### PR TITLE
Mark structs as readonly where appropriate

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Analyzers/CommonInterest.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/CommonInterest.cs
@@ -277,7 +277,7 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
             return new QualifiedMember(containingType, methodName);
         }
 
-        internal struct TypeMatchSpec
+        internal readonly struct TypeMatchSpec
         {
             internal TypeMatchSpec(QualifiedType type, QualifiedMember member, bool inverted)
             {
@@ -350,7 +350,7 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
             }
         }
 
-        internal struct QualifiedType
+        internal readonly struct QualifiedType
         {
             public QualifiedType(IReadOnlyList<string> containingTypeNamespace, string typeName)
             {
@@ -371,7 +371,7 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
             public override string ToString() => string.Join(".", this.Namespace.Concat(new[] { this.Name }));
         }
 
-        internal struct QualifiedMember
+        internal readonly struct QualifiedMember
         {
             public QualifiedMember(QualifiedType containingType, string methodName)
             {
@@ -393,7 +393,7 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
         }
 
         [DebuggerDisplay("{" + nameof(Method) + "} -> {" + nameof(AsyncAlternativeMethodName) + "}")]
-        internal struct SyncBlockingMethod
+        internal readonly struct SyncBlockingMethod
         {
             public SyncBlockingMethod(QualifiedMember method, string asyncAlternativeMethodName = null, IReadOnlyList<string> extensionMethodNamespace = null)
             {

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Utils.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Utils.cs
@@ -729,7 +729,7 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
             return true;
         }
 
-        internal struct ContainingFunctionData
+        internal readonly struct ContainingFunctionData
         {
             internal ContainingFunctionData(CSharpSyntaxNode function, bool isAsync, ParameterListSyntax parameterList, CSharpSyntaxNode blockOrExpression)
             {
@@ -739,15 +739,15 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
                 this.BlockOrExpression = blockOrExpression;
             }
 
-            internal CSharpSyntaxNode Function { get; set; }
+            internal CSharpSyntaxNode Function { get; }
 
 #pragma warning disable AvoidAsyncSuffix // Avoid Async suffix
-            internal bool IsAsync { get; set; }
+            internal bool IsAsync { get; }
 #pragma warning restore AvoidAsyncSuffix // Avoid Async suffix
 
-            internal ParameterListSyntax ParameterList { get; set; }
+            internal ParameterListSyntax ParameterList { get; }
 
-            internal CSharpSyntaxNode BlockOrExpression { get; set; }
+            internal CSharpSyntaxNode BlockOrExpression { get; }
         }
     }
 }

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD010MainThreadUsageAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD010MainThreadUsageAnalyzer.cs
@@ -238,7 +238,7 @@
                         callerToCalleeMap[caller] = callees = new List<CallInfo>();
                     }
 
-                    callees.Add(new CallInfo { MethodSymbol = callee, InvocationSyntax = locationToBlame });
+                    callees.Add(new CallInfo(methodSymbol: callee, invocationSyntax: locationToBlame));
                 }
             }
         }
@@ -257,18 +257,24 @@
                         result[callee.MethodSymbol] = callers = new List<CallInfo>();
                     }
 
-                    callers.Add(new CallInfo { MethodSymbol = caller, InvocationSyntax = callee.InvocationSyntax });
+                    callers.Add(new CallInfo(methodSymbol: caller, callee.InvocationSyntax));
                 }
             }
 
             return result;
         }
 
-        private struct CallInfo
+        private readonly struct CallInfo
         {
-            public IMethodSymbol MethodSymbol { get; set; }
+            public CallInfo(IMethodSymbol methodSymbol, SyntaxNode invocationSyntax)
+            {
+                this.MethodSymbol = methodSymbol;
+                this.InvocationSyntax = invocationSyntax;
+            }
 
-            public SyntaxNode InvocationSyntax { get; set; }
+            public IMethodSymbol MethodSymbol { get; }
+
+            public SyntaxNode InvocationSyntax { get; }
         }
 
         private class MethodAnalyzer

--- a/src/Microsoft.VisualStudio.Threading.Tests/AsyncReaderWriterLockTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/AsyncReaderWriterLockTests.cs
@@ -5013,18 +5013,17 @@
                 throw new CriticalErrorException(ex);
             }
 
-            internal struct InternalLockHandle
+            internal readonly struct InternalLockHandle
             {
                 internal InternalLockHandle(bool upgradeableRead, bool write)
-                    : this()
                 {
                     this.IsUpgradeableReadLock = upgradeableRead;
                     this.IsWriteLock = write;
                 }
 
-                internal bool IsUpgradeableReadLock { get; private set; }
+                internal bool IsUpgradeableReadLock { get; }
 
-                internal bool IsWriteLock { get; private set; }
+                internal bool IsWriteLock { get; }
             }
         }
 

--- a/src/Microsoft.VisualStudio.Threading.Tests/TestUtilities.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/TestUtilities.cs
@@ -276,7 +276,7 @@
 
         private static string AssemblyCommandLineArguments(params string[] args) => string.Join(" ", args.Select(a => $"\"{a}\""));
 
-        internal struct YieldAndNotifyAwaitable
+        internal readonly struct YieldAndNotifyAwaitable
         {
             private readonly INotifyCompletion baseAwaiter;
             private readonly AsyncManualResetEvent yieldingSignal;
@@ -297,7 +297,7 @@
             }
         }
 
-        internal struct YieldAndNotifyAwaiter : INotifyCompletion
+        internal readonly struct YieldAndNotifyAwaiter : INotifyCompletion
         {
             private readonly INotifyCompletion baseAwaiter;
             private readonly AsyncManualResetEvent yieldingSignal;
@@ -340,7 +340,7 @@
             }
         }
 
-        internal struct DebugAssertionRevert : IDisposable
+        internal readonly struct DebugAssertionRevert : IDisposable
         {
             public void Dispose()
             {

--- a/src/Microsoft.VisualStudio.Threading/AsyncReaderWriterLock.cs
+++ b/src/Microsoft.VisualStudio.Threading/AsyncReaderWriterLock.cs
@@ -1757,7 +1757,7 @@ namespace Microsoft.VisualStudio.Threading
         /// <summary>
         /// An awaitable that is returned from asynchronous lock requests.
         /// </summary>
-        public struct Awaitable
+        public readonly struct Awaitable
         {
             /// <summary>
             /// The awaiter to return from the <see cref="GetAwaiter"/> method.
@@ -1804,7 +1804,7 @@ namespace Microsoft.VisualStudio.Threading
         /// A value whose disposal releases a held lock.
         /// </summary>
         [DebuggerDisplay("{awaiter.kind}")]
-        public struct Releaser : IDisposable
+        public readonly struct Releaser : IDisposable
         {
             /// <summary>
             /// The awaiter who manages the lifetime of a lock.
@@ -1891,7 +1891,7 @@ namespace Microsoft.VisualStudio.Threading
         /// <summary>
         /// A value whose disposal restores visibility of any locks held by the caller.
         /// </summary>
-        public struct Suppression : IDisposable
+        public readonly struct Suppression : IDisposable
         {
             /// <summary>
             /// The locking class.
@@ -1932,7 +1932,7 @@ namespace Microsoft.VisualStudio.Threading
         /// <summary>
         /// A "public" representation of a specific lock.
         /// </summary>
-        protected struct LockHandle
+        protected readonly struct LockHandle
         {
             /// <summary>
             /// The awaiter this lock handle wraps.
@@ -2697,7 +2697,7 @@ namespace Microsoft.VisualStudio.Threading
                 }
             }
 
-            internal struct LoanBack : IDisposable
+            internal readonly struct LoanBack : IDisposable
             {
                 private readonly NonConcurrentSynchronizationContext syncContext;
                 private readonly AsyncReaderWriterLock asyncLock;

--- a/src/Microsoft.VisualStudio.Threading/AsyncReaderWriterResourceLock.cs
+++ b/src/Microsoft.VisualStudio.Threading/AsyncReaderWriterResourceLock.cs
@@ -260,7 +260,7 @@ namespace Microsoft.VisualStudio.Threading
         /// An awaitable that is returned from asynchronous lock requests.
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes")]
-        public struct ResourceAwaitable
+        public readonly struct ResourceAwaitable
         {
             /// <summary>
             /// The underlying lock awaitable.
@@ -298,7 +298,7 @@ namespace Microsoft.VisualStudio.Threading
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes")]
         [DebuggerDisplay("{awaiter.kind}")]
-        public struct ResourceAwaiter : ICriticalNotifyCompletion
+        public readonly struct ResourceAwaiter : ICriticalNotifyCompletion
         {
             /// <summary>
             /// The underlying lock awaiter.
@@ -389,7 +389,7 @@ namespace Microsoft.VisualStudio.Threading
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes")]
         [DebuggerDisplay("{releaser.awaiter.kind}")]
-        public struct ResourceReleaser : IDisposable
+        public readonly struct ResourceReleaser : IDisposable
         {
             /// <summary>
             /// The underlying lock releaser.

--- a/src/Microsoft.VisualStudio.Threading/AsyncReaderWriterResourceLock.cs
+++ b/src/Microsoft.VisualStudio.Threading/AsyncReaderWriterResourceLock.cs
@@ -792,7 +792,7 @@ namespace Microsoft.VisualStudio.Threading
             /// <summary>
             /// Tracks a task that prepares a resource for either concurrent or exclusive use.
             /// </summary>
-            private struct ResourcePreparationTaskAndValidity
+            private readonly struct ResourcePreparationTaskAndValidity
             {
                 /// <summary>
                 /// Initializes a new instance of the <see cref="ResourcePreparationTaskAndValidity"/> struct.
@@ -808,12 +808,12 @@ namespace Microsoft.VisualStudio.Threading
                 /// <summary>
                 /// Gets the task that is preparing the resource.
                 /// </summary>
-                internal Task PreparationTask { get; private set; }
+                internal Task PreparationTask { get; }
 
                 /// <summary>
                 /// Gets the state the resource will be in when <see cref="PreparationTask"/> has completed.
                 /// </summary>
-                internal ResourceState State { get; private set; }
+                internal ResourceState State { get; }
             }
         }
     }

--- a/src/Microsoft.VisualStudio.Threading/AsyncSemaphore.cs
+++ b/src/Microsoft.VisualStudio.Threading/AsyncSemaphore.cs
@@ -167,7 +167,7 @@ namespace Microsoft.VisualStudio.Threading
         /// A value whose disposal triggers the release of a lock.
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes")]
-        public struct Releaser : IDisposable
+        public readonly struct Releaser : IDisposable
         {
             /// <summary>
             /// The lock instance to release.

--- a/src/Microsoft.VisualStudio.Threading/AwaitExtensions.cs
+++ b/src/Microsoft.VisualStudio.Threading/AwaitExtensions.cs
@@ -450,7 +450,7 @@ namespace Microsoft.VisualStudio.Threading
         /// An awaitable that executes continuations on the specified task scheduler.
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes")]
-        public struct TaskSchedulerAwaitable
+        public readonly struct TaskSchedulerAwaitable
         {
             /// <summary>
             /// The scheduler for continuations.
@@ -490,7 +490,7 @@ namespace Microsoft.VisualStudio.Threading
         /// An awaiter returned from <see cref="GetAwaiter(TaskScheduler)"/>.
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes")]
-        public struct TaskSchedulerAwaiter : ICriticalNotifyCompletion
+        public readonly struct TaskSchedulerAwaiter : ICriticalNotifyCompletion
         {
             /// <summary>
             /// The scheduler for continuations.
@@ -598,7 +598,7 @@ namespace Microsoft.VisualStudio.Threading
         /// then immediately resume, possibly on the original <see cref="SynchronizationContext"/>.
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes")]
-        public struct ConfiguredTaskYieldAwaitable
+        public readonly struct ConfiguredTaskYieldAwaitable
         {
             /// <summary>
             /// A value indicating whether the continuation should run on the captured <see cref="SynchronizationContext"/>, if any.
@@ -627,7 +627,7 @@ namespace Microsoft.VisualStudio.Threading
         /// then immediately resume, possibly on the original <see cref="SynchronizationContext"/>.
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes")]
-        public struct ConfiguredTaskYieldAwaiter : ICriticalNotifyCompletion
+        public readonly struct ConfiguredTaskYieldAwaiter : ICriticalNotifyCompletion
         {
             /// <summary>
             /// A value indicating whether the continuation should run on the captured <see cref="SynchronizationContext"/>, if any.
@@ -700,7 +700,7 @@ namespace Microsoft.VisualStudio.Threading
         /// A Task awaitable that has affinity to executing callbacks synchronously on the completing callstack.
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes")]
-        public struct ExecuteContinuationSynchronouslyAwaitable
+        public readonly struct ExecuteContinuationSynchronouslyAwaitable
         {
             /// <summary>
             /// The task whose completion will execute the continuation.
@@ -729,7 +729,7 @@ namespace Microsoft.VisualStudio.Threading
         /// A Task awaiter that has affinity to executing callbacks synchronously on the completing callstack.
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes")]
-        public struct ExecuteContinuationSynchronouslyAwaiter : INotifyCompletion
+        public readonly struct ExecuteContinuationSynchronouslyAwaiter : INotifyCompletion
         {
             /// <summary>
             /// The task whose completion will execute the continuation.
@@ -778,7 +778,7 @@ namespace Microsoft.VisualStudio.Threading
         /// </summary>
         /// <typeparam name="T">The type of value returned by the awaited <see cref="Task"/>.</typeparam>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes")]
-        public struct ExecuteContinuationSynchronouslyAwaitable<T>
+        public readonly struct ExecuteContinuationSynchronouslyAwaitable<T>
         {
             /// <summary>
             /// The task whose completion will execute the continuation.
@@ -808,7 +808,7 @@ namespace Microsoft.VisualStudio.Threading
         /// </summary>
         /// <typeparam name="T">The type of value returned by the awaited <see cref="Task"/>.</typeparam>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes")]
-        public struct ExecuteContinuationSynchronouslyAwaiter<T> : INotifyCompletion
+        public readonly struct ExecuteContinuationSynchronouslyAwaiter<T> : INotifyCompletion
         {
             /// <summary>
             /// The task whose completion will execute the continuation.

--- a/src/Microsoft.VisualStudio.Threading/EmptyStruct.cs
+++ b/src/Microsoft.VisualStudio.Threading/EmptyStruct.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.Threading
     /// <remarks>
     /// This can save 4 bytes over System.Object when a type argument is required for a generic type, but entirely unused.
     /// </remarks>
-    internal struct EmptyStruct
+    internal readonly struct EmptyStruct
     {
         /// <summary>
         /// Gets an instance of the empty struct.

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskContext.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskContext.cs
@@ -584,11 +584,11 @@ namespace Microsoft.VisualStudio.Threading
         /// A structure that clears CallContext and SynchronizationContext async/thread statics and
         /// restores those values when this structure is disposed.
         /// </summary>
-        public struct RevertRelevance : IDisposable
+        public readonly struct RevertRelevance : IDisposable
         {
             private readonly JoinableTaskContext pump;
-            private SpecializedSyncContext temporarySyncContext;
-            private JoinableTask oldJoinable;
+            private readonly SpecializedSyncContext temporarySyncContext;
+            private readonly JoinableTask oldJoinable;
 
             /// <summary>
             /// Initializes a new instance of the <see cref="RevertRelevance"/> struct.

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskDependencyGraph.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskDependencyGraph.cs
@@ -856,7 +856,7 @@ namespace Microsoft.VisualStudio.Threading
             /// <summary>
             /// The record of a pending notification we need send to the synchronous task that we have some new messages to process.
             /// </summary>
-            private struct PendingNotification
+            private readonly struct PendingNotification
             {
                 internal PendingNotification(JoinableTask synchronousTask, JoinableTask taskHasPendingMessages, int newPendingMessagesCount)
                 {

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
@@ -712,7 +712,7 @@ namespace Microsoft.VisualStudio.Threading
         /// An awaitable struct that facilitates an asynchronous transition to the Main thread.
         /// </summary>
         [SuppressMessage("Microsoft.Design", "CA1034:NestedTypesShouldNotBeVisible"), SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes")]
-        public struct MainThreadAwaitable
+        public readonly struct MainThreadAwaitable
         {
             private readonly JoinableTaskFactory jobFactory;
 
@@ -985,7 +985,7 @@ namespace Microsoft.VisualStudio.Threading
         /// A value to construct with a C# using block in all the Run method overloads
         /// to setup and teardown the boilerplate stuff.
         /// </summary>
-        private struct RunFramework : IDisposable
+        private readonly struct RunFramework : IDisposable
         {
             private readonly JoinableTaskFactory factory;
             private readonly SpecializedSyncContext syncContextRevert;

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
@@ -749,7 +749,7 @@ namespace Microsoft.VisualStudio.Threading
         /// An awaiter struct that facilitates an asynchronous transition to the Main thread.
         /// </summary>
         [SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes")]
-        public struct MainThreadAwaiter : ICriticalNotifyCompletion
+        public readonly struct MainThreadAwaiter : ICriticalNotifyCompletion
         {
             private static readonly Action<object> SafeCancellationAction = state => ThreadPool.QueueUserWorkItem(SingleExecuteProtector.ExecuteOnceWaitCallback, state);
 
@@ -782,7 +782,7 @@ namespace Microsoft.VisualStudio.Threading
             /// then this will hold a default value of <see cref="CancellationTokenRegistration"/>, and <see cref="OnCompleted(Action)"/>
             /// would not touch it.
             /// </remarks>
-            private StrongBox<CancellationTokenRegistration?> cancellationRegistrationPtr;
+            private readonly StrongBox<CancellationTokenRegistration?> cancellationRegistrationPtr;
 
             /// <summary>
             /// Initializes a new instance of the <see cref="MainThreadAwaiter"/> struct.

--- a/src/Microsoft.VisualStudio.Threading/ReentrantSemaphore.cs
+++ b/src/Microsoft.VisualStudio.Threading/ReentrantSemaphore.cs
@@ -257,7 +257,7 @@ namespace Microsoft.VisualStudio.Threading
         /// A structure that hides any evidence that the caller has entered a <see cref="ReentrantSemaphore"/> till this value is disposed.
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes")]
-        public struct RevertRelevance : IDisposable
+        public readonly struct RevertRelevance : IDisposable
         {
             /// <summary>
             /// The delegate to invoke on disposal.

--- a/src/Microsoft.VisualStudio.Threading/SingleThreadedSynchronizationContext.cs
+++ b/src/Microsoft.VisualStudio.Threading/SingleThreadedSynchronizationContext.cs
@@ -178,7 +178,7 @@ namespace Microsoft.VisualStudio.Threading
             }
         }
 
-        private struct Message
+        private readonly struct Message
         {
             internal readonly SendOrPostCallback Callback;
             internal readonly object State;

--- a/src/Microsoft.VisualStudio.Threading/SpecializedSyncContext.cs
+++ b/src/Microsoft.VisualStudio.Threading/SpecializedSyncContext.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.Threading
     /// A structure that applies and reverts changes to the <see cref="SynchronizationContext"/>.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes")]
-    public struct SpecializedSyncContext : IDisposable
+    public readonly struct SpecializedSyncContext : IDisposable
     {
         /// <summary>
         /// A flag indicating whether the non-default constructor was invoked.

--- a/src/Microsoft.VisualStudio.Threading/TplExtensions.cs
+++ b/src/Microsoft.VisualStudio.Threading/TplExtensions.cs
@@ -213,15 +213,14 @@ namespace Microsoft.VisualStudio.Threading
 
             if (ultimateCancellation.CanBeCanceled)
             {
-                var sourceState = tcs.SourceState;
-                sourceState.RegisteredCallback = ultimateCancellation.Register(
+                var registeredCallback = ultimateCancellation.Register(
                     state =>
                     {
                         var tuple = (Tuple<TaskCompletionSource<FollowCancelableTaskState<T>, T>, CancellationToken>)state;
                         tuple.Item1.TrySetCanceled(tuple.Item2);
                     },
                     Tuple.Create(tcs, ultimateCancellation));
-                tcs.SourceState = sourceState; // copy back in, since it's a struct
+                tcs.SourceState = tcs.SourceState.WithRegisteredCallback(registeredCallback);
             }
 
             FollowCancelableTaskToCompletionHelper(tcs, taskToFollow());
@@ -765,7 +764,7 @@ namespace Microsoft.VisualStudio.Threading
         /// A state bag for the <see cref="FollowCancelableTaskToCompletion"/> method.
         /// </summary>
         /// <typeparam name="T">The type of value ultimately returned.</typeparam>
-        private struct FollowCancelableTaskState<T>
+        private readonly struct FollowCancelableTaskState<T>
         {
             /// <summary>
             /// The delegate that returns the task to follow.
@@ -778,23 +777,34 @@ namespace Microsoft.VisualStudio.Threading
             /// <param name="getTaskToFollow">The get task to follow.</param>
             /// <param name="cancellationToken">The cancellation token.</param>
             internal FollowCancelableTaskState(Func<Task<T>> getTaskToFollow, CancellationToken cancellationToken)
-                : this()
+                : this(getTaskToFollow, registeredCallback: default, cancellationToken)
+            {
+            }
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="FollowCancelableTaskState{T}"/> struct.
+            /// </summary>
+            /// <param name="getTaskToFollow">The get task to follow.</param>
+            /// <param name="registeredCallback">The cancellation token registration to dispose of when the task completes normally.</param>
+            /// <param name="cancellationToken">The cancellation token.</param>
+            private FollowCancelableTaskState(Func<Task<T>> getTaskToFollow, CancellationTokenRegistration registeredCallback, CancellationToken cancellationToken)
             {
                 Requires.NotNull(getTaskToFollow, nameof(getTaskToFollow));
 
                 this.getTaskToFollow = getTaskToFollow;
+                this.RegisteredCallback = registeredCallback;
                 this.UltimateCancellation = cancellationToken;
             }
 
             /// <summary>
             /// Gets the ultimate cancellation token.
             /// </summary>
-            internal CancellationToken UltimateCancellation { get; private set; }
+            internal CancellationToken UltimateCancellation { get; }
 
             /// <summary>
-            /// Gets or sets the cancellation token registration to dispose of when the task completes normally.
+            /// Gets the cancellation token registration to dispose of when the task completes normally.
             /// </summary>
-            internal CancellationTokenRegistration RegisteredCallback { get; set; }
+            internal CancellationTokenRegistration RegisteredCallback { get; }
 
             /// <summary>
             /// Gets the current task to follow.
@@ -808,6 +818,9 @@ namespace Microsoft.VisualStudio.Threading
                     return task;
                 }
             }
+
+            internal FollowCancelableTaskState<T> WithRegisteredCallback(CancellationTokenRegistration registeredCallback)
+                => new FollowCancelableTaskState<T>(this.getTaskToFollow, registeredCallback, this.UltimateCancellation);
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.Threading/TplExtensions.cs
+++ b/src/Microsoft.VisualStudio.Threading/TplExtensions.cs
@@ -660,7 +660,7 @@ namespace Microsoft.VisualStudio.Threading
         /// An awaitable that wraps a task and never throws an exception when waited on.
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes")]
-        public struct NoThrowTaskAwaitable
+        public readonly struct NoThrowTaskAwaitable
         {
             /// <summary>
             /// The task.
@@ -699,7 +699,7 @@ namespace Microsoft.VisualStudio.Threading
         /// An awaiter that wraps a task and never throws an exception when waited on.
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes")]
-        public struct NoThrowTaskAwaiter : ICriticalNotifyCompletion
+        public readonly struct NoThrowTaskAwaiter : ICriticalNotifyCompletion
         {
             /// <summary>
             /// The task

--- a/src/Microsoft.VisualStudio.Threading/WeakKeyDictionary.cs
+++ b/src/Microsoft.VisualStudio.Threading/WeakKeyDictionary.cs
@@ -287,25 +287,25 @@ namespace Microsoft.VisualStudio.Threading
         /// the target's hash code so that it can be used in a hashtable.
         /// </summary>
         /// <typeparam name="T">Type of the target of the weak reference</typeparam>
-        private struct WeakReference<T> : IEquatable<WeakReference<T>>
+        private readonly struct WeakReference<T> : IEquatable<WeakReference<T>>
             where T : class
         {
             /// <summary>
             /// Cache the hashcode so that it is still available even if the target has been
             /// collected. This allows this object to be still found in a table so it can be removed.
             /// </summary>
-            private int hashcode;
+            private readonly int hashcode;
 
             /// <summary>
             /// Backing weak reference
             /// </summary>
-            private WeakReference weakReference;
+            private readonly WeakReference weakReference;
 
             /// <summary>
             /// Some of the instances are around just to do existence checks, and don't want
             /// to allocate WeakReference objects as they are short-lived.
             /// </summary>
-            private T notSoWeakTarget;
+            private readonly T notSoWeakTarget;
 
             /// <summary>
             /// Initializes a new instance of the <see cref="WeakReference{T}"/> struct.


### PR DESCRIPTION
⚠️ While these cases are all readonly today, it is a breaking semantic change to change a `readonly struct` by removing the `readonly` keyword. Any types for which you would like to reserve the right to make the type mutable in the future should be excluded from this change.

With that said, at this point I'm not sure you would actually need to make any changes like this.