### PR TITLE
Remove unused resourcesAcquiredWithinWriteLock field

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/AsyncReaderWriterResourceLock.cs
+++ b/src/Microsoft.VisualStudio.Threading/AsyncReaderWriterResourceLock.cs
@@ -574,7 +574,7 @@ namespace Microsoft.VisualStudio.Threading
                 bool match = false;
                 lock (this.service.SyncObject)
                 {
-                    if (!ambientLock.HasWriteLock && ambientLock.HasUpgradeableReadLock)
+                    if (ambientLock.HasWriteLock || ambientLock.HasUpgradeableReadLock)
                     {
                         foreach (var resource in this.resourcePreparationTasks)
                         {


### PR DESCRIPTION
The current code only adds items to the collection, and clears it later.  The content is never used.