### PR TITLE
Add JTF-awareness to ProgressWithCompletion<T>

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Tests/ProgressWithCompletionTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/ProgressWithCompletionTests.cs
@@ -17,15 +17,17 @@
         }
 
         [Fact]
-        public void CtorNullAction()
+        public void Ctor_Nulls()
         {
             Assert.Throws<ArgumentNullException>(() => new ProgressWithCompletion<GenericParameterHelper>((Action<GenericParameterHelper>)null));
+            Assert.Throws<ArgumentNullException>(() => new ProgressWithCompletion<GenericParameterHelper>((Func<GenericParameterHelper, Task>)null));
         }
 
         [Fact]
-        public void CtorNullFuncOfTask()
+        public void Ctor_NullJtf()
         {
-            Assert.Throws<ArgumentNullException>(() => new ProgressWithCompletion<GenericParameterHelper>((Func<GenericParameterHelper, Task>)null));
+            var progress = new ProgressWithCompletion<GenericParameterHelper>(v => { }, joinableTaskFactory: null);
+            progress = new ProgressWithCompletion<GenericParameterHelper>(v => TplExtensions.CompletedTask, joinableTaskFactory: null);
         }
 
         [Fact]
@@ -67,6 +69,31 @@
         }
 
         [Fact]
+        public async Task WaitAsync_CancellationToken()
+        {
+            var handlerMayComplete = new AsyncManualResetEvent();
+            var callback = new Func<GenericParameterHelper, Task>(
+                async p =>
+                {
+                    Assert.Equal(1, p.Data);
+                    await handlerMayComplete;
+                });
+            var progress = new ProgressWithCompletion<GenericParameterHelper>(callback);
+            IProgress<GenericParameterHelper> reporter = progress;
+            reporter.Report(new GenericParameterHelper(1));
+
+            var cts = new CancellationTokenSource();
+            var progressAwaitable = progress.WaitAsync(cts.Token);
+            await Task.Delay(AsyncDelay);
+            Assert.False(progressAwaitable.GetAwaiter().IsCompleted);
+            cts.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => progressAwaitable).WithCancellation(this.TimeoutToken);
+
+            // clean up
+            handlerMayComplete.Set();
+        }
+
+        [Fact]
         public void SynchronizationContextCaptured()
         {
             var syncContext = SingleThreadedTestSynchronizationContext.New();
@@ -98,9 +125,59 @@
 
             SingleThreadedTestSynchronizationContext.PushFrame(syncContext, frame);
             callbackResult.Task.GetAwaiter().GetResult();
+        }
+
+        [Theory]
+        [PairwiseData]
+        public void DoesNotDeadlockWhenCallbackCapturesSyncContext(bool captureMainThreadContext)
+        {
+            var syncContext = SingleThreadedTestSynchronizationContext.New();
+            SynchronizationContext.SetSynchronizationContext(syncContext);
+            var jtc = new JoinableTaskContext();
+
+            const int expectedCallbackValue = 1;
+            var actualCallbackValue = new TaskCompletionSource<int>();
+            Func<ProgressWithCompletion<GenericParameterHelper>> progressFactory = () => new ProgressWithCompletion<GenericParameterHelper>(async arg =>
             {
-                throw callbackError;
+                try
+                {
+                    Assert.Equal(captureMainThreadContext, jtc.IsOnMainThread);
+
+                    // Ensure we have a main thread dependency even if we started on a threadpool thread.
+                    await jtc.Factory.SwitchToMainThreadAsync(this.TimeoutToken);
+                    actualCallbackValue.SetResult(arg.Data);
+                }
+                catch (Exception ex)
+                {
+                    actualCallbackValue.SetException(ex);
+                }
+            }, jtc.Factory);
+
+            ProgressWithCompletion<GenericParameterHelper> progress;
+            if (captureMainThreadContext)
+            {
+                progress = progressFactory();
             }
+            else
+            {
+                var progressTask = Task.Run(progressFactory);
+                progressTask.WaitWithoutInlining();
+                progress = progressTask.Result;
+            }
+
+            IProgress<GenericParameterHelper> progressReporter = progress;
+            progressReporter.Report(new GenericParameterHelper(expectedCallbackValue));
+            Assert.False(actualCallbackValue.Task.IsCompleted);
+
+            // Block the "main thread" while waiting for the reported progress to be executed.
+            // Since the callback must execute on the main thread, this will deadlock unless
+            // the underlying code is JTF aware, which is the whole point of this test to confirm.
+            jtc.Factory.Run(async delegate
+            {
+                await progress.WaitAsync(this.TimeoutToken);
+                Assert.True(actualCallbackValue.Task.IsCompleted);
+                Assert.Equal(expectedCallbackValue, await actualCallbackValue.Task);
+            });
         }
     }
 }

--- a/src/Microsoft.VisualStudio.Threading/ProgressWithCompletion.cs
+++ b/src/Microsoft.VisualStudio.Threading/ProgressWithCompletion.cs
@@ -7,10 +7,7 @@
 namespace Microsoft.VisualStudio.Threading
 {
     using System;
-    using System.Collections.Concurrent;
     using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -23,8 +20,9 @@ namespace Microsoft.VisualStudio.Threading
     {
         /// <summary>
         /// The synchronization object.
+        /// Applicable only when <see cref="joinableTaskFactory"/> is null.
         /// </summary>
-        private readonly object syncObject = new object();
+        private readonly object syncObject;
 
         /// <summary>
         /// The handler to invoke for each progress update.
@@ -33,37 +31,97 @@ namespace Microsoft.VisualStudio.Threading
 
         /// <summary>
         /// The set of progress reports that have started (but may not have finished yet).
+        /// Applicable only when <see cref="joinableTaskFactory"/> is null.
         /// </summary>
-        private readonly HashSet<Task> outstandingTasks = new HashSet<Task>();
+        private readonly HashSet<Task> outstandingTasks;
 
         /// <summary>
-        /// The factory to use for spawning reports.
+        /// The factory to use for invoking the <see cref="handler"/>.
+        /// Applicable only when <see cref="joinableTaskFactory"/> is null.
         /// </summary>
-        private readonly TaskFactory taskFactory =
-            new TaskFactory(SynchronizationContext.Current != null ? TaskScheduler.FromCurrentSynchronizationContext() : TaskScheduler.Default);
+        private readonly TaskFactory taskFactory;
+
+        /// <summary>
+        /// A value indicating whether this instance was constructed on the main thread.
+        /// Applicable only when <see cref="joinableTaskFactory"/> is not null.
+        /// </summary>
+        private readonly bool createdOnMainThread;
+
+        /// <summary>
+        /// The <see cref="JoinableTaskFactory"/> to use when invoking the <see cref="handler"/> to mitigate deadlocks.
+        /// May be null.
+        /// </summary>
+        private readonly JoinableTaskFactory joinableTaskFactory;
+
+        /// <summary>
+        /// A collection of outstanding progress updates that have not completed execution.
+        /// Applicable only when <see cref="joinableTaskFactory"/> is not null.
+        /// </summary>
+        private readonly JoinableTaskCollection outstandingJoinableTasks;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ProgressWithCompletion{T}" /> class.
         /// </summary>
-        /// <param name="handler">The handler.</param>
+        /// <param name="handler">
+        /// A handler to invoke for each reported progress value.
+        /// Depending on the <see cref="SynchronizationContext"/> instance that is captured when this constructor is invoked,
+        /// it is possible that this handler instance could be invoked concurrently with itself.
+        /// </param>
         public ProgressWithCompletion(Action<T> handler)
+            : this(WrapSyncHandler(handler), joinableTaskFactory: null)
         {
-            Requires.NotNull(handler, nameof(handler));
-            this.handler = value =>
-            {
-                handler(value);
-                return TplExtensions.CompletedTask;
-            };
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ProgressWithCompletion{T}" /> class.
         /// </summary>
-        /// <param name="handler">The async handler.</param>
+        /// <param name="handler">
+        /// A handler to invoke for each reported progress value.
+        /// Depending on the <see cref="SynchronizationContext"/> instance that is captured when this constructor is invoked,
+        /// it is possible that this handler instance could be invoked concurrently with itself.
+        /// </param>
         public ProgressWithCompletion(Func<T, Task> handler)
+            : this(handler, joinableTaskFactory: null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProgressWithCompletion{T}" /> class.
+        /// </summary>
+        /// <param name="handler">
+        /// A handler to invoke for each reported progress value.
+        /// It is possible that this handler instance could be invoked concurrently with itself.
+        /// </param>
+        /// <param name="joinableTaskFactory">A <see cref="JoinableTaskFactory"/> instance that can be used to mitigate deadlocks when <see cref="WaitAsync(CancellationToken)"/> is called and the <paramref name="handler"/> requires the main thread.</param>
+        public ProgressWithCompletion(Action<T> handler, JoinableTaskFactory joinableTaskFactory)
+            : this(WrapSyncHandler(handler), joinableTaskFactory)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProgressWithCompletion{T}" /> class.
+        /// </summary>
+        /// <param name="handler">
+        /// A handler to invoke for each reported progress value.
+        /// It is possible that this handler instance could be invoked concurrently with itself.
+        /// </param>
+        /// <param name="joinableTaskFactory">A <see cref="JoinableTaskFactory"/> instance that can be used to mitigate deadlocks when <see cref="WaitAsync(CancellationToken)"/> is called and the <paramref name="handler"/> requires the main thread.</param>
+        public ProgressWithCompletion(Func<T, Task> handler, JoinableTaskFactory joinableTaskFactory)
         {
             Requires.NotNull(handler, nameof(handler));
             this.handler = handler;
+            if (joinableTaskFactory != null)
+            {
+                this.joinableTaskFactory = joinableTaskFactory;
+                this.outstandingJoinableTasks = joinableTaskFactory.Context.CreateCollection();
+                this.createdOnMainThread = joinableTaskFactory.Context.IsOnMainThread;
+            }
+            else
+            {
+                this.syncObject = new object();
+                this.taskFactory = new TaskFactory(SynchronizationContext.Current != null ? TaskScheduler.FromCurrentSynchronizationContext() : TaskScheduler.Default);
+                this.outstandingTasks = new HashSet<Task>();
+            }
         }
 
         /// <summary>
@@ -81,37 +139,85 @@ namespace Microsoft.VisualStudio.Threading
         /// <param name="value">The value representing the updated progress.</param>
         protected virtual void Report(T value)
         {
-#pragma warning disable CA2008 // Do not create tasks without passing a TaskScheduler
-            var reported = this.taskFactory.StartNew(() => this.handler(value)).Unwrap();
-#pragma warning restore CA2008 // Do not create tasks without passing a TaskScheduler
-            lock (this.syncObject)
+            if (this.joinableTaskFactory != null)
             {
-                this.outstandingTasks.Add(reported);
-            }
-
-            reported.ContinueWith(
-                t =>
-                {
-                    lock (this.syncObject)
+                JoinableTask joinableTask = this.joinableTaskFactory.RunAsync(
+                    async delegate
                     {
-                        this.outstandingTasks.Remove(t);
-                    }
-                },
-                CancellationToken.None,
-                TaskContinuationOptions.NotOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
-                TaskScheduler.Default);
+                        // Emulate the behavior of having captured a SynchronizationContext by invoking the handler on the main thread
+                        // if the constructor was on the main thread. Otherwise use the threadpool thread. But never invoke the handler
+                        // inline with our caller, per the behavior folks expect from this and .NET's Progress<T> class.
+                        if (this.createdOnMainThread)
+                        {
+                            await this.joinableTaskFactory.SwitchToMainThreadAsync(alwaysYield: true);
+                        }
+                        else
+                        {
+                            await TaskScheduler.Default.SwitchTo(alwaysYield: true);
+                        }
+
+                        await this.handler(value).ConfigureAwaitRunInline();
+                    });
+                this.outstandingJoinableTasks.Add(joinableTask);
+            }
+            else
+            {
+#pragma warning disable CA2008 // Do not create tasks without passing a TaskScheduler
+                var reported = this.taskFactory.StartNew(() => this.handler(value)).Unwrap();
+#pragma warning restore CA2008 // Do not create tasks without passing a TaskScheduler
+                lock (this.syncObject)
+                {
+                    this.outstandingTasks.Add(reported);
+                }
+
+                reported.ContinueWith(
+                    t =>
+                    {
+                        lock (this.syncObject)
+                        {
+                            this.outstandingTasks.Remove(t);
+                        }
+                    },
+                    CancellationToken.None,
+                    TaskContinuationOptions.NotOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
+            }
         }
 
         /// <summary>
         /// Returns a task that completes when all reported progress has executed.
         /// </summary>
         /// <returns>A task that completes when all progress is complete.</returns>
-        public Task WaitAsync()
+        public Task WaitAsync() => this.WaitAsync(CancellationToken.None);
+
+        /// <summary>
+        /// Returns a task that completes when all reported progress has executed.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>A task that completes when all progress is complete.</returns>
+        public Task WaitAsync(CancellationToken cancellationToken)
         {
-            lock (this.syncObject)
+            if (this.outstandingJoinableTasks != null)
             {
-                return Task.WhenAll(this.outstandingTasks);
+                return this.outstandingJoinableTasks.JoinTillEmptyAsync(cancellationToken);
             }
+            else
+            {
+                lock (this.syncObject)
+                {
+                    return Task.WhenAll(this.outstandingTasks).WithCancellation(cancellationToken);
+                }
+            }
+        }
+
+        private static Func<T, Task> WrapSyncHandler(Action<T> handler)
+        {
+            Requires.NotNull(handler, nameof(handler));
+            return value =>
+            {
+                handler(value);
+                return TplExtensions.CompletedTask;
+            };
         }
     }
 }


### PR DESCRIPTION
Our `ProgressWithCompletion<T>` class's entire value of .NET's own `Progress<T>` class is in our `WaitAsync()` method. But since this method allows the caller to await for work executed previously, and since that work might require the main thread, it should be following the 3rd threading rule by using JTF.RunAsync. It wasn't. And as a result deadlocks could happen if that `await progress.WaitAsync()` call were made inside a JTF.Run delegate.

This change adds a JTF option to the class. Similar to our `AsyncLazy<T>` type, it works with or without. But now that a "with" option exists, our threading analyzers will automatically kick in and suggest all existing users switch to providing a JTF instance if they have one by way of a build warning.

I don't think many people use this type as-is, but use of it will increase in the future and this prepares for it.

Closes #490