### PR TITLE
Avoid storing ITypeSymbol beyond the scope of a compilation

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Analyzers/DiagnosticAnalyzerState.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/DiagnosticAnalyzerState.cs
@@ -15,19 +15,18 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
     using System.Threading;
     using System.Threading.Tasks;
     using CodeAnalysis;
-    using CodeAnalysis.Diagnostics;
 
     /// <summary>
-    /// A base class for our analyzers that provide per-compilation caching by way of its private fields
+    /// A class for our analyzers that provide per-compilation caching by way of its private fields
     /// to support common utility methods.
     /// </summary>
-    public abstract class DiagnosticAnalyzerBase : DiagnosticAnalyzer
+    internal abstract class DiagnosticAnalyzerState
     {
         private const string GetAwaiterMethodName = nameof(Task.GetAwaiter);
 
         private readonly ConcurrentDictionary<ITypeSymbol, bool> customAwaitableTypes = new ConcurrentDictionary<ITypeSymbol, bool>();
 
-        protected bool IsAwaitableType(ITypeSymbol typeSymbol, Compilation compilation, CancellationToken cancellationToken)
+        internal bool IsAwaitableType(ITypeSymbol typeSymbol, Compilation compilation, CancellationToken cancellationToken)
         {
             if (typeSymbol == null)
             {

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD200UseAsyncNamingConventionAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD200UseAsyncNamingConventionAnalyzer.cs
@@ -6,17 +6,13 @@
 
 namespace Microsoft.VisualStudio.Threading.Analyzers
 {
-    using System;
-    using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
     using CodeAnalysis;
     using CodeAnalysis.Diagnostics;
 
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class VSTHRD200UseAsyncNamingConventionAnalyzer : DiagnosticAnalyzerBase
+    public class VSTHRD200UseAsyncNamingConventionAnalyzer : DiagnosticAnalyzer
     {
         public const string Id = "VSTHRD200";
 
@@ -53,57 +49,60 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
             context.EnableConcurrentExecution();
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze);
 
-            context.RegisterSymbolAction(Utils.DebuggableWrapper(this.AnalyzeNode), SymbolKind.Method);
+            context.RegisterSymbolAction(Utils.DebuggableWrapper(new PerCompilation().AnalyzeNode), SymbolKind.Method);
         }
 
-        private void AnalyzeNode(SymbolAnalysisContext context)
+        private class PerCompilation : DiagnosticAnalyzerState
         {
-            var methodSymbol = (IMethodSymbol)context.Symbol;
-            if (methodSymbol.AssociatedSymbol is IPropertySymbol)
+            internal void AnalyzeNode(SymbolAnalysisContext context)
             {
-                // Skip accessor methods associated with properties.
-                return;
-            }
+                var methodSymbol = (IMethodSymbol)context.Symbol;
+                if (methodSymbol.AssociatedSymbol is IPropertySymbol)
+                {
+                    // Skip accessor methods associated with properties.
+                    return;
+                }
 
-            // Skip entrypoint methods since their name is non-negotiable.
-            if (Utils.IsEntrypointMethod(methodSymbol, context.Compilation, context.CancellationToken))
-            {
-                return;
-            }
-
-            bool hasAsyncFocusedReturnType = Utils.HasAsyncCompatibleReturnType(methodSymbol);
-
-            bool actuallyEndsWithAsync = methodSymbol.Name.EndsWith(MandatoryAsyncSuffix);
-
-            if (hasAsyncFocusedReturnType != actuallyEndsWithAsync)
-            {
-                // Now that we have done the cheap checks to find that this method may deserve a diagnostic,
-                // Do deeper checks to skip over methods that implement API contracts that are controlled elsewhere.
-                if (methodSymbol.FindInterfacesImplemented().Any() || methodSymbol.IsOverride)
+                // Skip entrypoint methods since their name is non-negotiable.
+                if (Utils.IsEntrypointMethod(methodSymbol, context.Compilation, context.CancellationToken))
                 {
                     return;
                 }
 
-                if (hasAsyncFocusedReturnType)
+                bool hasAsyncFocusedReturnType = Utils.HasAsyncCompatibleReturnType(methodSymbol);
+
+                bool actuallyEndsWithAsync = methodSymbol.Name.EndsWith(MandatoryAsyncSuffix);
+
+                if (hasAsyncFocusedReturnType != actuallyEndsWithAsync)
                 {
-                    // We actively encourage folks to use the Async keyword only for clearly async-focused types.
-                    // Not just any awaitable, since some stray extension method shouldn't change the world for everyone.
-                    var properties = ImmutableDictionary<string, string>.Empty
-                        .Add(NewNameKey, methodSymbol.Name + MandatoryAsyncSuffix);
-                    context.ReportDiagnostic(Diagnostic.Create(
-                        AddAsyncDescriptor,
-                        methodSymbol.Locations[0],
-                        properties));
-                }
-                else if (!this.IsAwaitableType(methodSymbol.ReturnType, context.Compilation, context.CancellationToken))
-                {
-                    // Only warn about abusing the Async suffix if the return type is not awaitable.
-                    var properties = ImmutableDictionary<string, string>.Empty
-                        .Add(NewNameKey, methodSymbol.Name.Substring(0, methodSymbol.Name.Length - MandatoryAsyncSuffix.Length));
-                    context.ReportDiagnostic(Diagnostic.Create(
-                        RemoveAsyncDescriptor,
-                        methodSymbol.Locations[0],
-                        properties));
+                    // Now that we have done the cheap checks to find that this method may deserve a diagnostic,
+                    // Do deeper checks to skip over methods that implement API contracts that are controlled elsewhere.
+                    if (methodSymbol.FindInterfacesImplemented().Any() || methodSymbol.IsOverride)
+                    {
+                        return;
+                    }
+
+                    if (hasAsyncFocusedReturnType)
+                    {
+                        // We actively encourage folks to use the Async keyword only for clearly async-focused types.
+                        // Not just any awaitable, since some stray extension method shouldn't change the world for everyone.
+                        var properties = ImmutableDictionary<string, string>.Empty
+                            .Add(NewNameKey, methodSymbol.Name + MandatoryAsyncSuffix);
+                        context.ReportDiagnostic(Diagnostic.Create(
+                            AddAsyncDescriptor,
+                            methodSymbol.Locations[0],
+                            properties));
+                    }
+                    else if (!this.IsAwaitableType(methodSymbol.ReturnType, context.Compilation, context.CancellationToken))
+                    {
+                        // Only warn about abusing the Async suffix if the return type is not awaitable.
+                        var properties = ImmutableDictionary<string, string>.Empty
+                            .Add(NewNameKey, methodSymbol.Name.Substring(0, methodSymbol.Name.Length - MandatoryAsyncSuffix.Length));
+                        context.ReportDiagnostic(Diagnostic.Create(
+                            RemoveAsyncDescriptor,
+                            methodSymbol.Locations[0],
+                            properties));
+                    }
                 }
             }
         }


### PR DESCRIPTION
This avoids a memory leak that comes from analyzers being reused across compilations.

Fixes #508

Reviewer notes: The content of the `AnalyzeNode` method is exactly the same. I just moved (and re-indented) the method into a nested class.