### PR TITLE
Check the status of waitTask before assuming a lock was acquired

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/AsyncSemaphore.cs
+++ b/src/Microsoft.VisualStudio.Threading/AsyncSemaphore.cs
@@ -149,7 +149,7 @@ namespace Microsoft.VisualStudio.Threading
         {
             Requires.NotNull(waitTask, nameof(waitTask));
 
-            return waitTask.IsCompleted
+            return waitTask.Status == TaskStatus.RanToCompletion
                 ? this.uncontestedReleaser // uncontested lock
                 : waitTask.ContinueWith(
                     (waiter, state) =>


### PR DESCRIPTION
Fixes a failure in AsyncSemaphore where cancellation during the call EnterAsync can lead to an incorrectly-claimed semaphore. When the Releaser later releases the semaphore, the semaphore transitions to a state where more than one thread may be allowed to use the semaphore.

Thread 1:
* Cancellation is triggered during the SemaphoreSlim.WaitAsync, which completes synchronously even though the semaphore was not acquired

Thread 2:
* Successfully acquires the semaphore

Thread 1:
* Throws an exception for cancellationToken.ThrowIfCancellationRequested()
* Releases the semaphore when exiting the using block

Thread 3:
* Successfully acquires the semaphore, even though Thread 2 has not released it

Fixes #521