### PR TITLE
Fix AsyncSemaphore bug that lets too many threads enter the semaphore

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/AsyncSemaphore.cs
+++ b/src/Microsoft.VisualStudio.Threading/AsyncSemaphore.cs
@@ -149,7 +149,7 @@ namespace Microsoft.VisualStudio.Threading
         {
             Requires.NotNull(waitTask, nameof(waitTask));
 
-            return waitTask.IsCompleted
+            return waitTask.Status == TaskStatus.RanToCompletion
                 ? this.uncontestedReleaser // uncontested lock
                 : waitTask.ContinueWith(
                     (waiter, state) =>


### PR DESCRIPTION
Fixes #521

The 16.4 merge of #520

CC: @sharwell