### PR TITLE
Use Microsoft.Net.Compilers for a specific compiler version

### DIFF
--- a/azure-pipelines/testfx.yml
+++ b/azure-pipelines/testfx.yml
@@ -36,3 +36,11 @@ steps:
   env:
     DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX: 0
     RuntimeFrameworkVersion: 2.2
+
+- task: PublishBuildArtifacts@1
+  inputs:
+    PathtoPublish: $(Build.ArtifactStagingDirectory)/build_logs
+    ArtifactName: build_logs $(Agent.JobName)
+    ArtifactType: Container
+  displayName: Publish build_logs artifacts
+  condition: succeededOrFailed()

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -24,6 +24,7 @@
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.0.25" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.66" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.4.0-beta2-final" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" />


### PR DESCRIPTION
Reduces the complexity of adopting Nullable Reference Types by ensuring the same bugs and bug fixes are present locally and in CI.