### PR TITLE
Avoid C# syntax that's toxic to .NET Native compilers

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Tests/Microsoft.VisualStudio.Threading.Tests.csproj
+++ b/src/Microsoft.VisualStudio.Threading.Tests/Microsoft.VisualStudio.Threading.Tests.csproj
@@ -32,6 +32,7 @@
     <PackageReference Include="coverlet.msbuild" Version="2.6.3" />
     <PackageReference Include="MicroBuild.Nonshipping" Version="$(MicroBuildVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.6.0" />
     <PackageReference Include="Xunit.Combinatorial" Version="1.2.7" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.12" />

--- a/src/Microsoft.VisualStudio.Threading/InternalUtilities.cs
+++ b/src/Microsoft.VisualStudio.Threading/InternalUtilities.cs
@@ -153,14 +153,7 @@ namespace Microsoft.VisualStudio.Threading
         /// so it is only useful for diagnostics and when we don't expect addresses to be changing much any more.
         /// </remarks>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "value", Justification = "We no-op on one platform.")]
-        private static IntPtr GetAddress(object value)
-        {
-            unsafe
-            {
-                TypedReference tr = __makeref(value);
-                return **(IntPtr**)(&tr);
-            }
-        }
+        private static unsafe IntPtr GetAddress(object value) => new IntPtr(Unsafe.AsPointer(ref value));
 
         /// <summary>
         /// A helper method to find the async state machine from the given delegate.


### PR DESCRIPTION
Fixes #557