### PR TITLE
Obsolete APIs that are redundant with modern .NET versions

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Tests/AsyncReaderWriterLockTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/AsyncReaderWriterLockTests.cs
@@ -2917,7 +2917,7 @@
             {
                 callbackInvoked++;
                 Assert.True(asyncLock.IsWriteLockHeld);
-                return TplExtensions.CompletedTask;
+                return Task.CompletedTask;
             };
             using (await asyncLock.WriteLockAsync())
             {

--- a/src/Microsoft.VisualStudio.Threading.Tests/JoinableTaskAndAsyncReaderWriterLockTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/JoinableTaskAndAsyncReaderWriterLockTests.cs
@@ -145,7 +145,7 @@
         {
             using (await this.asyncLock.ReadLockAsync())
             {
-                this.asyncPump.Run(() => TplExtensions.CompletedTask);
+                this.asyncPump.Run(() => Task.CompletedTask);
             }
         }
 
@@ -164,7 +164,7 @@
                 {
                     try
                     {
-                        this.asyncPump.Run(() => TplExtensions.CompletedTask);
+                        this.asyncPump.Run(() => Task.CompletedTask);
                         Assert.False(true, "Expected InvalidOperationException not thrown.");
                     }
                     catch (InvalidOperationException)
@@ -191,7 +191,7 @@
                 {
                     try
                     {
-                        this.asyncPump.Run(() => TplExtensions.CompletedTask);
+                        this.asyncPump.Run(() => Task.CompletedTask);
                         Assert.True(false, "Expected InvalidOperationException not thrown.");
                     }
                     catch (InvalidOperationException)

--- a/src/Microsoft.VisualStudio.Threading.Tests/JoinableTaskCollectionTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/JoinableTaskCollectionTests.cs
@@ -194,7 +194,7 @@
                 releaser.Dispose();
                 releaser.Dispose();
 
-                return TplExtensions.CompletedTask;
+                return Task.CompletedTask;
             });
         }
     }

--- a/src/Microsoft.VisualStudio.Threading.Tests/JoinableTaskContextTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/JoinableTaskContextTests.cs
@@ -40,7 +40,7 @@
                 await Task.Run(delegate
                 {
                     Assert.True(this.Context.IsWithinJoinableTask);
-                    return TplExtensions.CompletedTask;
+                    return Task.CompletedTask;
                 });
             });
         }
@@ -413,7 +413,7 @@
                                        where node.Attribute(XName.Get("Category"))?.Value == "Collection"
                                        select node.Attribute(XName.Get("Label"))?.Value;
                 Assert.Contains(collectionLabels, label => label == jtcName);
-                return TplExtensions.CompletedTask;
+                return Task.CompletedTask;
             });
         }
 

--- a/src/Microsoft.VisualStudio.Threading.Tests/JoinableTaskTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/JoinableTaskTests.cs
@@ -146,7 +146,7 @@
                     await this.asyncPump.SwitchToMainThreadAsync();
                 });
 
-                return TplExtensions.CompletedTask;
+                return Task.CompletedTask;
             });
             outerTaskCompleted.Set();
 
@@ -203,7 +203,7 @@
                                     this.testFrame.Continue = false;
                                 }
                             });
-                        return TplExtensions.CompletedTask;
+                        return Task.CompletedTask;
                     });
                 mainThreadRequestPended.Set();
             });
@@ -413,7 +413,7 @@
                 });
                 cts.Cancel();
                 testResultSource.Task.Wait(this.TimeoutToken);
-                return TplExtensions.CompletedTask;
+                return Task.CompletedTask;
             });
         }
 
@@ -468,7 +468,7 @@
                 asyncLocal.Value = null;
                 cts.Cancel();
                 testResultSource.Task.Wait(this.TimeoutToken);
-                return TplExtensions.CompletedTask;
+                return Task.CompletedTask;
             });
         }
 
@@ -1757,7 +1757,7 @@
                     await this.asyncPump.SwitchToMainThreadAsync();
                 });
 
-                return TplExtensions.CompletedTask;
+                return Task.CompletedTask;
             });
 
             this.asyncPump.Run(async delegate
@@ -2056,7 +2056,7 @@
                 Assert.True(executed2);
             });
 
-                return TplExtensions.CompletedTask;
+                return Task.CompletedTask;
             });
 
             // From the Main thread.
@@ -2176,7 +2176,7 @@
                     Assert.True(false, $"Posted message threw an exception: {ex}");
                 }
 
-                return TplExtensions.CompletedTask;
+                return Task.CompletedTask;
             });
         }
 
@@ -2201,10 +2201,10 @@
                         }
                     });
 
-                    return TplExtensions.CompletedTask;
+                    return Task.CompletedTask;
                 });
 
-                return TplExtensions.CompletedTask;
+                return Task.CompletedTask;
             });
 
             mainThreadUnblocked.Set();
@@ -2253,7 +2253,7 @@
                     }
                 });
 
-                return TplExtensions.CompletedTask;
+                return Task.CompletedTask;
             });
 
             uiBoundWork = Task.Run(
@@ -2445,7 +2445,7 @@
                 this.asyncPump.Run(delegate
                 {
                     syncContext = SynchronizationContext.Current;
-                    return TplExtensions.CompletedTask;
+                    return Task.CompletedTask;
                 });
                 syncContext!.Post(
                     delegate
@@ -2526,7 +2526,7 @@
                         await loPriFactory.SwitchToMainThreadAsync().GetAwaiter().YieldAndNotify(loPriSwitchPosted);
                     });
                 });
-                return TplExtensions.CompletedTask;
+                return Task.CompletedTask;
             });
             outerFinished.Set();
             loPriSwitchPosted.WaitAsync().Wait();
@@ -2569,7 +2569,7 @@
                 {
                     await outerFinished;
                 });
-                return TplExtensions.CompletedTask;
+                return Task.CompletedTask;
             });
             outerFinished.Set();
 
@@ -2741,7 +2741,7 @@
                         }
                     }
                 });
-                return TplExtensions.CompletedTask;
+                return Task.CompletedTask;
             });
 
             this.asyncPump.Run(delegate
@@ -2765,7 +2765,7 @@
                         }
                     }
                 });
-                return TplExtensions.CompletedTask;
+                return Task.CompletedTask;
             });
 
             this.PushFrame();
@@ -2799,7 +2799,7 @@
                                 null);
                             posted = true;
                         });
-                        return TplExtensions.CompletedTask;
+                        return Task.CompletedTask;
                     });
                 }).WaitWithoutInlining(throwOriginalException: true);
 
@@ -3054,7 +3054,7 @@
                 {
                     this.asyncPump.Run(delegate
                     {
-                        return TplExtensions.CompletedTask;
+                        return Task.CompletedTask;
                     });
                 }, maxBytesAllocated: 819);
             }
@@ -3198,7 +3198,7 @@
                     // of the iterations, showing that doing real work exercerbates the problem.
                     ////for (int j = 0; j < 5000; j++) { }
 
-                    await this.asyncPump.RunAsync(() => TplExtensions.CompletedTask);
+                    await this.asyncPump.RunAsync(() => Task.CompletedTask);
                 }
             });
 
@@ -3329,7 +3329,7 @@
                 {
                     jtStarted.Set();
                     unawaitedWork = otherAsyncMethod();
-                    return TplExtensions.CompletedTask;
+                    return Task.CompletedTask;
                 });
             });
             this.context.Factory.Run(async delegate
@@ -3358,7 +3358,7 @@
                 this.asyncPump.Run(delegate
                 {
                     otherAsyncMethod().Forget();
-                    return TplExtensions.CompletedTask;
+                    return Task.CompletedTask;
                 });
             });
             bkgrndThread.WaitWithoutInlining(throwOriginalException: true);
@@ -3378,7 +3378,7 @@
                 this.asyncPump.Run(delegate
                 {
                     otherAsyncMethod().Forget();
-                    return TplExtensions.CompletedTask;
+                    return Task.CompletedTask;
                 });
             });
             this.context.Factory.Run(async delegate
@@ -3609,7 +3609,7 @@
 
                     // Synchronously block *BEFORE* yielding.
                     unblockJoinableTask.Wait();
-                    return TplExtensions.CompletedTask;
+                    return Task.CompletedTask;
                 });
 
                 await assertingTask; // observe failures.
@@ -3803,7 +3803,7 @@
             var job = this.asyncPump.RunAsync(() =>
             {
                 sc = SynchronizationContext.Current; // simulate someone who has captured the sync context.
-                return TplExtensions.CompletedTask;
+                return Task.CompletedTask;
             });
 
             job.Join(); // it never yielded, so this isn't strictly necessary.

--- a/src/Microsoft.VisualStudio.Threading.Tests/ProgressWithCompletionTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/ProgressWithCompletionTests.cs
@@ -27,7 +27,7 @@
         public void Ctor_NullJtf()
         {
             var progress = new ProgressWithCompletion<GenericParameterHelper>(v => { }, joinableTaskFactory: null);
-            progress = new ProgressWithCompletion<GenericParameterHelper>(v => TplExtensions.CompletedTask, joinableTaskFactory: null);
+            progress = new ProgressWithCompletion<GenericParameterHelper>(v => Task.CompletedTask, joinableTaskFactory: null);
         }
 
         [Fact]
@@ -41,7 +41,7 @@
         [Fact]
         public void NoWorkFuncOfTask()
         {
-            var callback = new Func<GenericParameterHelper, Task>(p => { return TplExtensions.CompletedTask; });
+            var callback = new Func<GenericParameterHelper, Task>(p => { return Task.CompletedTask; });
             var progress = new ProgressWithCompletion<GenericParameterHelper>(callback);
             Assert.True(progress.WaitAsync().IsCompleted);
         }

--- a/src/Microsoft.VisualStudio.Threading.Tests/ReentrantSemaphoreJTFTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/ReentrantSemaphoreJTFTests.cs
@@ -53,7 +53,7 @@ public class ReentrantSemaphoreJTFTests : ReentrantSemaphoreTestBase
                     {
                         secondEntryComplete = true;
                         Assert.True(firstOperationReachedMainThread);
-                        return TplExtensions.CompletedTask;
+                        return Task.CompletedTask;
                     },
                     this.TimeoutToken);
             });
@@ -175,7 +175,7 @@ public class ReentrantSemaphoreJTFTests : ReentrantSemaphoreTestBase
             () =>
             {
                 acquired = true;
-                return TplExtensions.CompletedTask;
+                return Task.CompletedTask;
             },
             cancellationToken)
             .ConfigureAwait(false);

--- a/src/Microsoft.VisualStudio.Threading.Tests/ReentrantSemaphoreNonJTFTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/ReentrantSemaphoreNonJTFTests.cs
@@ -22,8 +22,8 @@ public class ReentrantSemaphoreNonJTFTests : ReentrantSemaphoreTestBase
         this.semaphore = this.CreateSemaphore(mode);
         this.ExecuteOnDispatcher(delegate
         {
-            this.semaphore.ExecuteAsync(() => TplExtensions.CompletedTask).Wait(this.TimeoutToken);
-            return TplExtensions.CompletedTask;
+            this.semaphore.ExecuteAsync(() => Task.CompletedTask).Wait(this.TimeoutToken);
+            return Task.CompletedTask;
         });
     }
 }

--- a/src/Microsoft.VisualStudio.Threading.Tests/ReentrantSemaphoreTestBase.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/ReentrantSemaphoreTestBase.cs
@@ -87,7 +87,7 @@ public abstract class ReentrantSemaphoreTestBase : TestBase, IDisposable
                 {
                     Assert.Equal(originalThreadId, Environment.CurrentManagedThreadId);
                     executed = true;
-                    return TplExtensions.CompletedTask;
+                    return Task.CompletedTask;
                 }, this.TimeoutToken);
             Assert.True(executed);
         });
@@ -110,7 +110,7 @@ public abstract class ReentrantSemaphoreTestBase : TestBase, IDisposable
                 {
                     Assert.Equal(originalThreadId, Environment.CurrentManagedThreadId);
                     executed = true;
-                    return TplExtensions.CompletedTask;
+                    return Task.CompletedTask;
                 }, this.TimeoutToken);
 
             releaseHolder.Set();
@@ -212,7 +212,7 @@ public abstract class ReentrantSemaphoreTestBase : TestBase, IDisposable
                 delegate
                 {
                     secondEntered.Set();
-                    return TplExtensions.CompletedTask;
+                    return Task.CompletedTask;
                 },
                 this.TimeoutToken);
 
@@ -274,7 +274,7 @@ public abstract class ReentrantSemaphoreTestBase : TestBase, IDisposable
                 {
                     await this.semaphore.ExecuteAsync(delegate
                     {
-                        return TplExtensions.CompletedTask;
+                        return Task.CompletedTask;
                     }, this.TimeoutToken);
                 }, this.TimeoutToken);
             }, this.TimeoutToken);
@@ -292,7 +292,7 @@ public abstract class ReentrantSemaphoreTestBase : TestBase, IDisposable
             await this.semaphore.ExecuteAsync(delegate
             {
                 innerOperation = EnterAndUseSemaphoreAsync(releaser1);
-                return TplExtensions.CompletedTask;
+                return Task.CompletedTask;
             });
             releaser1.Set();
             await innerOperation!;
@@ -321,7 +321,7 @@ public abstract class ReentrantSemaphoreTestBase : TestBase, IDisposable
             await this.semaphore.ExecuteAsync(delegate
             {
                 innerOperation = SemaphoreRecycler();
-                return TplExtensions.CompletedTask;
+                return Task.CompletedTask;
             });
             await this.semaphore.ExecuteAsync(async delegate
             {
@@ -337,7 +337,7 @@ public abstract class ReentrantSemaphoreTestBase : TestBase, IDisposable
 
             // Try to enter the semaphore. This should timeout because someone else is holding the semaphore, waiting for us to timeout.
             await this.semaphore.ExecuteAsync(
-                () => TplExtensions.CompletedTask,
+                () => Task.CompletedTask,
                 new CancellationTokenSource(ExpectedTimeout).Token);
         }
     }
@@ -357,7 +357,7 @@ public abstract class ReentrantSemaphoreTestBase : TestBase, IDisposable
             {
                 innerOperation1 = SemaphoreRecycler1();
                 innerOperation2 = SemaphoreRecycler2();
-                return TplExtensions.CompletedTask;
+                return Task.CompletedTask;
             });
 
             releaseInheritor1.Set();
@@ -384,7 +384,7 @@ public abstract class ReentrantSemaphoreTestBase : TestBase, IDisposable
 
             // Try to enter the semaphore. This should timeout because someone else is holding the semaphore, waiting for us to timeout.
             await this.semaphore.ExecuteAsync(
-                () => TplExtensions.CompletedTask,
+                () => Task.CompletedTask,
                 new CancellationTokenSource(ExpectedTimeout).Token);
         }
     }
@@ -406,7 +406,7 @@ public abstract class ReentrantSemaphoreTestBase : TestBase, IDisposable
                     this.TimeoutToken);
             });
 
-            await this.semaphore.ExecuteAsync(() => TplExtensions.CompletedTask, this.TimeoutToken);
+            await this.semaphore.ExecuteAsync(() => Task.CompletedTask, this.TimeoutToken);
         });
     }
 
@@ -417,7 +417,7 @@ public abstract class ReentrantSemaphoreTestBase : TestBase, IDisposable
         this.semaphore = this.CreateSemaphore(mode);
         this.ExecuteOnDispatcher(async delegate
         {
-            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => this.semaphore.ExecuteAsync(() => TplExtensions.CompletedTask, new CancellationToken(true)));
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => this.semaphore.ExecuteAsync(() => Task.CompletedTask, new CancellationToken(true)));
         });
     }
 
@@ -432,7 +432,7 @@ public abstract class ReentrantSemaphoreTestBase : TestBase, IDisposable
             var holder = this.semaphore.ExecuteAsync(() => release.WaitAsync(), this.TimeoutToken);
 
             var cts = CancellationTokenSource.CreateLinkedTokenSource(this.TimeoutToken);
-            var waiter = this.semaphore.ExecuteAsync(() => TplExtensions.CompletedTask, cts.Token);
+            var waiter = this.semaphore.ExecuteAsync(() => Task.CompletedTask, cts.Token);
             Assert.False(waiter.IsCompleted);
             cts.Cancel();
             await Assert.ThrowsAnyAsync<OperationCanceledException>(() => waiter).WithCancellation(this.TimeoutToken);
@@ -451,7 +451,7 @@ public abstract class ReentrantSemaphoreTestBase : TestBase, IDisposable
             await this.semaphore.ExecuteAsync(delegate
             {
                 this.semaphore.Dispose();
-                return TplExtensions.CompletedTask;
+                return Task.CompletedTask;
             });
         });
     }
@@ -467,7 +467,7 @@ public abstract class ReentrantSemaphoreTestBase : TestBase, IDisposable
         {
             await this.semaphore.ExecuteAsync(async delegate
             {
-                await Assert.ThrowsAsync<InvalidOperationException>(() => this.semaphore.ExecuteAsync(() => TplExtensions.CompletedTask));
+                await Assert.ThrowsAsync<InvalidOperationException>(() => this.semaphore.ExecuteAsync(() => Task.CompletedTask));
                 Assert.Equal(0, this.semaphore.CurrentCount);
             });
         });
@@ -486,7 +486,7 @@ public abstract class ReentrantSemaphoreTestBase : TestBase, IDisposable
             await this.semaphore.ExecuteAsync(async delegate
             {
                 Assert.Equal(0, this.semaphore.CurrentCount);
-                innerUser = this.semaphore.ExecuteAsync(() => TplExtensions.CompletedTask);
+                innerUser = this.semaphore.ExecuteAsync(() => Task.CompletedTask);
                 await Assert.ThrowsAsync<TimeoutException>(() => innerUser.WithTimeout(ExpectedTimeout));
             });
 
@@ -529,7 +529,7 @@ public abstract class ReentrantSemaphoreTestBase : TestBase, IDisposable
 
             // Verify that the semaphore is still in a faulted state, and will reject new calls.
             Assert.Throws<InvalidOperationException>(() => this.semaphore.CurrentCount);
-            await Assert.ThrowsAsync<InvalidOperationException>(() => this.semaphore.ExecuteAsync(() => TplExtensions.CompletedTask));
+            await Assert.ThrowsAsync<InvalidOperationException>(() => this.semaphore.ExecuteAsync(() => Task.CompletedTask));
         });
     }
 
@@ -568,14 +568,14 @@ public abstract class ReentrantSemaphoreTestBase : TestBase, IDisposable
                 Assert.Equal(0, this.semaphore.CurrentCount);
                 using (this.semaphore.SuppressRelevance())
                 {
-                    unrelatedUser = this.semaphore.ExecuteAsync(() => TplExtensions.CompletedTask);
+                    unrelatedUser = this.semaphore.ExecuteAsync(() => Task.CompletedTask);
                 }
 
                 await Assert.ThrowsAsync<TimeoutException>(() => unrelatedUser.WithTimeout(ExpectedTimeout));
 
                 if (IsReentrantMode(mode))
                 {
-                    await this.semaphore.ExecuteAsync(() => TplExtensions.CompletedTask, this.TimeoutToken);
+                    await this.semaphore.ExecuteAsync(() => Task.CompletedTask, this.TimeoutToken);
                 }
             });
 
@@ -609,7 +609,7 @@ public abstract class ReentrantSemaphoreTestBase : TestBase, IDisposable
                     () =>
                     {
                         enteredLog.Add(j);
-                        return TplExtensions.CompletedTask;
+                        return Task.CompletedTask;
                     },
                     cts[i].Token);
             }
@@ -673,7 +673,7 @@ public abstract class ReentrantSemaphoreTestBase : TestBase, IDisposable
                     });
 
                 await releaser3.WaitAsync();
-                var pendingSemaphoreTask = semaphore.ExecuteAsync(() => TplExtensions.CompletedTask);
+                var pendingSemaphoreTask = semaphore.ExecuteAsync(() => Task.CompletedTask);
 
                 releaser1.Set();
                 await Assert.ThrowsAsync<InvalidOperationException>(() => outerFaultySemaphoreTask).WithCancellation(this.TimeoutToken);
@@ -681,7 +681,7 @@ public abstract class ReentrantSemaphoreTestBase : TestBase, IDisposable
 
                 releaser1.Set();
                 await Assert.ThrowsAsync<InvalidOperationException>(() => innerFaulterSemaphoreTask).WithCancellation(this.TimeoutToken);
-                await Assert.ThrowsAsync<InvalidOperationException>(() => semaphore.ExecuteAsync(() => TplExtensions.CompletedTask)).WithCancellation(this.TimeoutToken);
+                await Assert.ThrowsAsync<InvalidOperationException>(() => semaphore.ExecuteAsync(() => Task.CompletedTask)).WithCancellation(this.TimeoutToken);
             });
     }
 

--- a/src/Microsoft.VisualStudio.Threading.Tests/TestBase.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/TestBase.cs
@@ -111,7 +111,7 @@
                 () =>
                 {
                     scenario();
-                    return TplExtensions.CompletedTask;
+                    return Task.CompletedTask;
                 },
                 maxBytesAllocated,
                 iterations,
@@ -288,7 +288,7 @@
             this.ExecuteOnDispatcher(delegate
             {
                 action();
-                return TplExtensions.CompletedTask;
+                return Task.CompletedTask;
             });
         }
 

--- a/src/Microsoft.VisualStudio.Threading.Tests/ThreadingToolsTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/ThreadingToolsTests.cs
@@ -255,7 +255,7 @@
             jtc.Factory.Run(delegate
             {
                 WithCancellationSyncBlock(simulateCancellation: true);
-                return TplExtensions.CompletedTask;
+                return Task.CompletedTask;
             });
         }
 
@@ -266,7 +266,7 @@
             jtc.Factory.Run(delegate
             {
                 WithCancellationSyncBlock(simulateCancellation: false);
-                return TplExtensions.CompletedTask;
+                return Task.CompletedTask;
             });
         }
 
@@ -277,7 +277,7 @@
             jtc.Factory.Run(delegate
             {
                 WithCancellationSyncBlockOnNoncancelableToken();
-                return TplExtensions.CompletedTask;
+                return Task.CompletedTask;
             });
         }
 

--- a/src/Microsoft.VisualStudio.Threading.Tests/TplExtensionsTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/TplExtensionsTests.cs
@@ -19,7 +19,17 @@
         [Fact]
         public void CompletedTask()
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             Assert.True(TplExtensions.CompletedTask.IsCompleted);
+#pragma warning restore CS0618 // Type or member is obsolete
+        }
+
+        [Fact]
+        public void CanceledTask()
+        {
+#pragma warning disable CS0618 // Type or member is obsolete
+            Assert.True(TplExtensions.CanceledTask.IsCanceled);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         [Fact]
@@ -28,7 +38,7 @@
             var evt = new ManualResetEventSlim();
             Action a = () => evt.Set();
             var cts = new CancellationTokenSource();
-            var result = TplExtensions.CompletedTask.AppendAction(a, TaskContinuationOptions.DenyChildAttach, cts.Token);
+            var result = Task.CompletedTask.AppendAction(a, TaskContinuationOptions.DenyChildAttach, cts.Token);
             Assert.NotNull(result);
             Assert.Equal(TaskContinuationOptions.DenyChildAttach, (TaskContinuationOptions)result.CreationOptions);
             Assert.True(evt.Wait(TestTimeout));
@@ -880,7 +890,7 @@
                 Assert.Same(sender, s);
                 Assert.Same(args, a);
                 invoked++;
-                return TplExtensions.CompletedTask;
+                return Task.CompletedTask;
             };
             var task = handler.InvokeAsync(sender, args!);
             Assert.True(task.IsCompleted);
@@ -895,7 +905,7 @@
                 Assert.Same(sender, s);
                 Assert.Same(args, a);
                 invoked++;
-                return TplExtensions.CompletedTask;
+                return Task.CompletedTask;
             };
             var task = handler.InvokeAsync(sender!, args!);
             Assert.True(task.IsCompleted);

--- a/src/Microsoft.VisualStudio.Threading/AsyncAutoResetEvent.cs
+++ b/src/Microsoft.VisualStudio.Threading/AsyncAutoResetEvent.cs
@@ -86,7 +86,7 @@ namespace Microsoft.VisualStudio.Threading
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return ThreadingTools.TaskFromCanceled(cancellationToken);
+                return Task.FromCanceled(cancellationToken);
             }
 
             lock (this.signalAwaiters)
@@ -94,7 +94,7 @@ namespace Microsoft.VisualStudio.Threading
                 if (this.signaled)
                 {
                     this.signaled = false;
-                    return TplExtensions.CompletedTask;
+                    return Task.CompletedTask;
                 }
                 else
                 {

--- a/src/Microsoft.VisualStudio.Threading/AsyncBarrier.cs
+++ b/src/Microsoft.VisualStudio.Threading/AsyncBarrier.cs
@@ -67,7 +67,7 @@ namespace Microsoft.VisualStudio.Threading
                     }
 
                     // And allow this one to continue immediately.
-                    return TplExtensions.CompletedTask;
+                    return Task.CompletedTask;
                 }
                 else
                 {

--- a/src/Microsoft.VisualStudio.Threading/AsyncCountdownEvent.cs
+++ b/src/Microsoft.VisualStudio.Threading/AsyncCountdownEvent.cs
@@ -111,7 +111,7 @@ namespace Microsoft.VisualStudio.Threading
             }
             catch (Exception ex)
             {
-                return ThreadingTools.TaskFromException(ex);
+                return Task.FromException(ex);
             }
         }
     }

--- a/src/Microsoft.VisualStudio.Threading/AsyncQueue.cs
+++ b/src/Microsoft.VisualStudio.Threading/AsyncQueue.cs
@@ -119,7 +119,7 @@ namespace Microsoft.VisualStudio.Threading
                         {
                             if (this.IsCompleted)
                             {
-                                return TplExtensions.CompletedTask;
+                                return Task.CompletedTask;
                             }
                             else
                             {
@@ -271,7 +271,7 @@ namespace Microsoft.VisualStudio.Threading
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return ThreadingTools.TaskFromCanceled<T>(cancellationToken);
+                return Task.FromCanceled<T>(cancellationToken);
             }
 
             T result;

--- a/src/Microsoft.VisualStudio.Threading/AsyncReaderWriterLock.cs
+++ b/src/Microsoft.VisualStudio.Threading/AsyncReaderWriterLock.cs
@@ -603,7 +603,7 @@ namespace Microsoft.VisualStudio.Threading
             }
             else
             {
-                return TplExtensions.CompletedTask;
+                return Task.CompletedTask;
             }
         }
 
@@ -626,7 +626,7 @@ namespace Microsoft.VisualStudio.Threading
                 }
                 else
                 {
-                    return TplExtensions.CompletedTask;
+                    return Task.CompletedTask;
                 }
             }
         }
@@ -1152,7 +1152,7 @@ namespace Microsoft.VisualStudio.Threading
         /// </remarks>
         protected virtual Task OnExclusiveLockReleasedAsync()
         {
-            return TplExtensions.CompletedTask;
+            return Task.CompletedTask;
         }
 
         /// <summary>
@@ -1269,7 +1269,7 @@ namespace Microsoft.VisualStudio.Threading
 
             if (!this.IsLockActive(awaiter, considerStaActive: true))
             {
-                return TplExtensions.CompletedTask;
+                return Task.CompletedTask;
             }
 
             Task? reenterConcurrentOutsideCode = null;
@@ -1291,12 +1291,12 @@ namespace Microsoft.VisualStudio.Threading
                 int upgradeableReadLocksAfter = upgradeableReadLocksBefore - (awaiter.Kind == LockKind.UpgradeableRead ? 1 : 0);
                 bool finalExclusiveLockRelease = writeLocksBefore > 0 && writeLocksAfter == 0;
 
-                Task callbackExecution = TplExtensions.CompletedTask;
+                Task callbackExecution = Task.CompletedTask;
                 if (!lockConsumerCanceled)
                 {
                     // Callbacks should be fired synchronously iff the last write lock is being released and read locks are already issued.
                     // This can occur when upgradeable read locks are held and upgraded, and then downgraded back to an upgradeable read.
-                    callbackExecution = this.OnBeforeLockReleasedAsync(finalExclusiveLockRelease, new LockHandle(awaiter)) ?? TplExtensions.CompletedTask;
+                    callbackExecution = this.OnBeforeLockReleasedAsync(finalExclusiveLockRelease, new LockHandle(awaiter)) ?? Task.CompletedTask;
                     synchronousRequired = finalExclusiveLockRelease && upgradeableReadLocksAfter > 0;
                     if (synchronousRequired)
                     {
@@ -1352,12 +1352,12 @@ namespace Microsoft.VisualStudio.Threading
                 }
                 else
                 {
-                    return reenterConcurrentOutsideCode ?? synchronousCallbackExecution ?? TplExtensions.CompletedTask;
+                    return reenterConcurrentOutsideCode ?? synchronousCallbackExecution ?? Task.CompletedTask;
                 }
             }
             else
             {
-                return TplExtensions.CompletedTask;
+                return Task.CompletedTask;
             }
         }
 
@@ -1880,7 +1880,7 @@ namespace Microsoft.VisualStudio.Threading
                     }
                 }
 
-                return TplExtensions.CompletedTask;
+                return Task.CompletedTask;
             }
         }
 

--- a/src/Microsoft.VisualStudio.Threading/AsyncReaderWriterResourceLock.cs
+++ b/src/Microsoft.VisualStudio.Threading/AsyncReaderWriterResourceLock.cs
@@ -634,7 +634,7 @@ namespace Microsoft.VisualStudio.Threading
                     }
                 }
 
-                return TplExtensions.CompletedTask;
+                return Task.CompletedTask;
             }
 
             /// <summary>
@@ -692,7 +692,7 @@ namespace Microsoft.VisualStudio.Threading
                 {
                     this.resourcePreparationTasks.TryGetValue(resource, out ResourcePreparationTaskAndValidity previousState);
                     this.resourcePreparationTasks[resource] = new ResourcePreparationTaskAndValidity(
-                        previousState.PreparationTask ?? TplExtensions.CompletedTask, // preserve the original task if it exists in case it's not finished
+                        previousState.PreparationTask ?? Task.CompletedTask, // preserve the original task if it exists in case it's not finished
                         ResourceState.Unknown);
                 }
             }

--- a/src/Microsoft.VisualStudio.Threading/AsyncSemaphore.cs
+++ b/src/Microsoft.VisualStudio.Threading/AsyncSemaphore.cs
@@ -54,7 +54,7 @@ namespace Microsoft.VisualStudio.Threading
             this.semaphore = new SemaphoreSlim(initialCount);
             this.uncontestedReleaser = Task.FromResult(new Releaser(this));
 
-            this.canceledReleaser = ThreadingTools.TaskFromCanceled<Releaser>(new CancellationToken(canceled: true));
+            this.canceledReleaser = Task.FromCanceled<Releaser>(new CancellationToken(canceled: true));
         }
 
         /// <summary>
@@ -71,7 +71,7 @@ namespace Microsoft.VisualStudio.Threading
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return ThreadingTools.TaskFromCanceled<Releaser>(cancellationToken);
+                return Task.FromCanceled<Releaser>(cancellationToken);
             }
 
             if (this.disposed)

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
@@ -236,7 +236,7 @@ namespace Microsoft.VisualStudio.Threading
                         ambientJob = this.Context.AmbientTask;
                         wrapper = SingleExecuteProtector.Create(ambientJob, callback);
                         ambientJob.Post(SingleExecuteProtector.ExecuteOnce, wrapper, true);
-                        return TplExtensions.CompletedTask;
+                        return Task.CompletedTask;
                     },
                     synchronouslyBlocking: false,
                     creationOptions: JoinableTaskCreationOptions.None,
@@ -629,7 +629,7 @@ namespace Microsoft.VisualStudio.Threading
                     RoslynDebug.Assert(this.Context.AmbientTask is object, $"{nameof(this.Context.AmbientTask)} is always set for {nameof(this.RunAsync)} callbacks.");
 
                     this.Context.AmbientTask.Post(callback, state, true);
-                    return TplExtensions.CompletedTask;
+                    return Task.CompletedTask;
                 });
 
                 if (transient.Task.IsFaulted)

--- a/src/Microsoft.VisualStudio.Threading/ProgressWithCompletion.cs
+++ b/src/Microsoft.VisualStudio.Threading/ProgressWithCompletion.cs
@@ -234,7 +234,7 @@ namespace Microsoft.VisualStudio.Threading
             return value =>
             {
                 handler(value);
-                return TplExtensions.CompletedTask;
+                return Task.CompletedTask;
             };
         }
     }

--- a/src/Microsoft.VisualStudio.Threading/ThreadingTools.cs
+++ b/src/Microsoft.VisualStudio.Threading/ThreadingTools.cs
@@ -113,7 +113,7 @@ namespace Microsoft.VisualStudio.Threading
 
             if (cancellationToken.IsCancellationRequested)
             {
-                return TaskFromCanceled<T>(cancellationToken);
+                return Task.FromCanceled<T>(cancellationToken);
             }
 
             return WithCancellationSlow(task, cancellationToken);
@@ -137,7 +137,7 @@ namespace Microsoft.VisualStudio.Threading
 
             if (cancellationToken.IsCancellationRequested)
             {
-                return TaskFromCanceled(cancellationToken);
+                return Task.FromCanceled(cancellationToken);
             }
 
             return WithCancellationSlow(task, continueOnCapturedContext: false, cancellationToken: cancellationToken);
@@ -172,30 +172,10 @@ namespace Microsoft.VisualStudio.Threading
 
             if (cancellationToken.IsCancellationRequested)
             {
-                return TaskFromCanceled(cancellationToken);
+                return Task.FromCanceled(cancellationToken);
             }
 
             return WithCancellationSlow(task, continueOnCapturedContext, cancellationToken);
-        }
-
-        internal static Task TaskFromCanceled(CancellationToken cancellationToken)
-        {
-            return TaskFromCanceled<EmptyStruct>(cancellationToken);
-        }
-
-        internal static Task<T> TaskFromCanceled<T>(CancellationToken cancellationToken)
-        {
-            return Task.FromCanceled<T>(cancellationToken);
-        }
-
-        internal static Task TaskFromException(Exception exception)
-        {
-            return TaskFromException<EmptyStruct>(exception);
-        }
-
-        internal static Task<T> TaskFromException<T>(Exception exception)
-        {
-            return Task.FromException<T>(exception);
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.Threading/TplExtensions.cs
+++ b/src/Microsoft.VisualStudio.Threading/TplExtensions.cs
@@ -23,13 +23,15 @@ namespace Microsoft.VisualStudio.Threading
         /// A singleton completed task.
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
+        [Obsolete("Use Task.CompletedTask instead.")]
         public static readonly Task CompletedTask = Task.FromResult(default(EmptyStruct));
 
         /// <summary>
         /// A task that is already canceled.
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-        public static readonly Task CanceledTask = ThreadingTools.TaskFromCanceled(new CancellationToken(canceled: true));
+        [Obsolete("Use Task.FromCanceled instead.")]
+        public static readonly Task CanceledTask = Task.FromCanceled(new CancellationToken(canceled: true));
 
         /// <summary>
         /// A completed task with a <c>true</c> result.
@@ -884,7 +886,7 @@ namespace Microsoft.VisualStudio.Threading
             /// A task that is already canceled.
             /// </summary>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-            internal static readonly Task<T> CanceledTask = ThreadingTools.TaskFromCanceled<T>(new CancellationToken(canceled: true));
+            internal static readonly Task<T> CanceledTask = Task.FromCanceled<T>(new CancellationToken(canceled: true));
         }
     }
 }


### PR DESCRIPTION
The only public API we're deprecating here is `TplExtensions.CompletedTask`.

Also remove the internal APIs we were using that are redundant.