### PR TITLE
Remove VSTHRD003 warnings for readonly tasks defined in another assembly

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD003UseJtfRunAsyncAnalyzerTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD003UseJtfRunAsyncAnalyzerTests.cs
@@ -1144,7 +1144,8 @@ public static class Boom {
   {
     return SpecialTasks.True;
   }
-}",
+}
+",
                     },
                 },
                 SolutionTransforms =

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.Designer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.Designer.cs
@@ -10,7 +10,6 @@
 
 namespace Microsoft.VisualStudio.Threading.Analyzers {
     using System;
-    using System.Reflection;
     
     
     /// <summary>
@@ -20,7 +19,7 @@ namespace Microsoft.VisualStudio.Threading.Analyzers {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {
@@ -40,7 +39,7 @@ namespace Microsoft.VisualStudio.Threading.Analyzers {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.VisualStudio.Threading.Analyzers.Strings", typeof(Strings).GetTypeInfo().Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.VisualStudio.Threading.Analyzers.Strings", typeof(Strings).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -126,7 +125,7 @@ namespace Microsoft.VisualStudio.Threading.Analyzers {
         
         /// <summary>
         ///   Looks up a localized string similar to Avoid awaiting or returning a Task representing work that was not started within your context as that can lead to deadlocks.
-        ///Start the work within this context, or use JoinableTaskFactory.RunAsync and await the returned JoinableTask instead..
+        ///Start the work within this context, or use JoinableTaskFactory.RunAsync to start the task and await the returned JoinableTask instead..
         /// </summary>
         internal static string VSTHRD003_MessageFormat {
             get {

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.resx
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.resx
@@ -167,7 +167,7 @@
   </data>
   <data name="VSTHRD003_MessageFormat" xml:space="preserve">
     <value>Avoid awaiting or returning a Task representing work that was not started within your context as that can lead to deadlocks.
-Start the work within this context, or use JoinableTaskFactory.RunAsync and await the returned JoinableTask instead.</value>
+Start the work within this context, or use JoinableTaskFactory.RunAsync to start the task and await the returned JoinableTask instead.</value>
   </data>
   <data name="VSTHRD003_Title" xml:space="preserve">
     <value>Avoid awaiting foreign Tasks</value>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD003UseJtfRunAsyncAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD003UseJtfRunAsyncAnalyzer.cs
@@ -9,6 +9,7 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
     using System;
     using System.Collections.Generic;
     using System.Collections.Immutable;
+    using System.Diagnostics;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
@@ -155,6 +156,12 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
 
                         // If we can find the source code for the field, we can check whether it has a field initializer
                         // that stores the result of a Task.FromResult invocation.
+                        if (!fieldSymbol.DeclaringSyntaxReferences.Any())
+                        {
+                            // No syntax for it at all. So outside the compilation. It *probably* is a precompleted cached task, so don't create a diagnostic.
+                            return null;
+                        }
+
                         foreach (var syntaxReference in fieldSymbol.DeclaringSyntaxReferences)
                         {
                             if (syntaxReference.GetSyntax(cancellationToken) is VariableDeclaratorSyntax declarationSyntax &&

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.cs.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.cs.xlf
@@ -40,8 +40,8 @@
       </trans-unit>
       <trans-unit id="VSTHRD003_MessageFormat" translate="yes" xml:space="preserve">
         <source>Avoid awaiting or returning a Task representing work that was not started within your context as that can lead to deadlocks.
-Start the work within this context, or use JoinableTaskFactory.RunAsync and await the returned JoinableTask instead.</source>
-        <target state="translated">Vyhněte se čekání na úlohu (nebo vracení úlohy) představující práci, která nebyla zahájena ve vašem kontextu, protože to může vést k zablokování.
+Start the work within this context, or use JoinableTaskFactory.RunAsync to start the task and await the returned JoinableTask instead.</source>
+        <target state="needs-review-translation">Vyhněte se čekání na úlohu (nebo vracení úlohy) představující práci, která nebyla zahájena ve vašem kontextu, protože to může vést k zablokování.
 Zahajte danou práci v tomto kontextu, nebo místo toho použijte JoinableTaskFactory.RunAsync a očekávejte vrácený JoinableTask.</target>
         <note from="MultilingualUpdate" annotates="source" priority="2" />
       </trans-unit>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.de.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.de.xlf
@@ -40,8 +40,8 @@
       </trans-unit>
       <trans-unit id="VSTHRD003_MessageFormat" translate="yes" xml:space="preserve">
         <source>Avoid awaiting or returning a Task representing work that was not started within your context as that can lead to deadlocks.
-Start the work within this context, or use JoinableTaskFactory.RunAsync and await the returned JoinableTask instead.</source>
-        <target state="translated">Vermeiden Sie das Warten auf eine Arbeitsaufgabe, die nicht in Ihrem Kontext gestartet wurde, da dies zu Deadlocks führen kann.
+Start the work within this context, or use JoinableTaskFactory.RunAsync to start the task and await the returned JoinableTask instead.</source>
+        <target state="needs-review-translation">Vermeiden Sie das Warten auf eine Arbeitsaufgabe, die nicht in Ihrem Kontext gestartet wurde, da dies zu Deadlocks führen kann.
 Starten Sie das Arbeitselement in Ihrem Kontext, oder verwenden Sie JoinableTaskFactory.RunAsync, und warten Sie stattdessen auf das zurückgegebene JoinableTask-Objekt.</target>
         <note from="MultilingualUpdate" annotates="source" priority="2" />
       </trans-unit>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.es.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.es.xlf
@@ -40,8 +40,8 @@
       </trans-unit>
       <trans-unit id="VSTHRD003_MessageFormat" translate="yes" xml:space="preserve">
         <source>Avoid awaiting or returning a Task representing work that was not started within your context as that can lead to deadlocks.
-Start the work within this context, or use JoinableTaskFactory.RunAsync and await the returned JoinableTask instead.</source>
-        <target state="translated">Evite la espera o devolución de una tarea representativa de un trabajo no iniciado en su contexto, lo cual puede causar bloqueos.
+Start the work within this context, or use JoinableTaskFactory.RunAsync to start the task and await the returned JoinableTask instead.</source>
+        <target state="needs-review-translation">Evite la espera o devolución de una tarea representativa de un trabajo no iniciado en su contexto, lo cual puede causar bloqueos.
 Inicie el trabajo en este contexto o use JoinableTaskFactory.RunAsync y espere el objeto JoinableTask que se devuelve.</target>
         <note from="MultilingualUpdate" annotates="source" priority="2" />
       </trans-unit>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.fr.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.fr.xlf
@@ -40,8 +40,8 @@
       </trans-unit>
       <trans-unit id="VSTHRD003_MessageFormat" translate="yes" xml:space="preserve">
         <source>Avoid awaiting or returning a Task representing work that was not started within your context as that can lead to deadlocks.
-Start the work within this context, or use JoinableTaskFactory.RunAsync and await the returned JoinableTask instead.</source>
-        <target state="translated">Évitez d'attendre ou de retourner une tâche représentant un travail non démarré dans votre contexte, car cela peut provoquer des interblocages.
+Start the work within this context, or use JoinableTaskFactory.RunAsync to start the task and await the returned JoinableTask instead.</source>
+        <target state="needs-review-translation">Évitez d'attendre ou de retourner une tâche représentant un travail non démarré dans votre contexte, car cela peut provoquer des interblocages.
 Démarrez le travail dans ce contexte, ou utilisez JoinableTaskFactory.RunAsync, et attendez plutôt le JoinableTask retourné.</target>
         <note from="MultilingualUpdate" annotates="source" priority="2" />
       </trans-unit>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.it.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.it.xlf
@@ -40,8 +40,8 @@
       </trans-unit>
       <trans-unit id="VSTHRD003_MessageFormat" translate="yes" xml:space="preserve">
         <source>Avoid awaiting or returning a Task representing work that was not started within your context as that can lead to deadlocks.
-Start the work within this context, or use JoinableTaskFactory.RunAsync and await the returned JoinableTask instead.</source>
-        <target state="translated">Evitare di attendere o restituire un oggetto Task che rappresenta un'operazione non avviata nel contesto perché potrebbe causare deadlock.
+Start the work within this context, or use JoinableTaskFactory.RunAsync to start the task and await the returned JoinableTask instead.</source>
+        <target state="needs-review-translation">Evitare di attendere o restituire un oggetto Task che rappresenta un'operazione non avviata nel contesto perché potrebbe causare deadlock.
 Avviare l'operazione in questo contesto oppure usare JoinableTaskFactory.RunAsync e attendere l'oggetto restituito JoinableTask.</target>
         <note from="MultilingualUpdate" annotates="source" priority="2" />
       </trans-unit>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.ja.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.ja.xlf
@@ -40,8 +40,8 @@
       </trans-unit>
       <trans-unit id="VSTHRD003_MessageFormat" translate="yes" xml:space="preserve">
         <source>Avoid awaiting or returning a Task representing work that was not started within your context as that can lead to deadlocks.
-Start the work within this context, or use JoinableTaskFactory.RunAsync and await the returned JoinableTask instead.</source>
-        <target state="translated">コンテキスト内で開始されなかった作業を表すタスクを待機したり返したりしないでください。これは、デッドロックを生じさせる可能性があります。
+Start the work within this context, or use JoinableTaskFactory.RunAsync to start the task and await the returned JoinableTask instead.</source>
+        <target state="needs-review-translation">コンテキスト内で開始されなかった作業を表すタスクを待機したり返したりしないでください。これは、デッドロックを生じさせる可能性があります。
 このコンテキスト内で作業を開始するか、代わりに JoinableTaskFactory.RunAsync を使用して返される JoinableTask を待機してください。</target>
         <note from="MultilingualUpdate" annotates="source" priority="2" />
       </trans-unit>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.ko.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.ko.xlf
@@ -40,8 +40,8 @@
       </trans-unit>
       <trans-unit id="VSTHRD003_MessageFormat" translate="yes" xml:space="preserve">
         <source>Avoid awaiting or returning a Task representing work that was not started within your context as that can lead to deadlocks.
-Start the work within this context, or use JoinableTaskFactory.RunAsync and await the returned JoinableTask instead.</source>
-        <target state="translated">교착 상태가 발생할 수 있기 때문에 컨텍스트 내에서 시작되지 않은 작업을 나타내는 작업을 대기하거나 반환하지 않습니다.
+Start the work within this context, or use JoinableTaskFactory.RunAsync to start the task and await the returned JoinableTask instead.</source>
+        <target state="needs-review-translation">교착 상태가 발생할 수 있기 때문에 컨텍스트 내에서 시작되지 않은 작업을 나타내는 작업을 대기하거나 반환하지 않습니다.
 대신 이 컨텍스트 내에서 작업을 시작하거나 JoinableTaskFactory.RunAsync를 사용하고 반환된 JoinableTask를 대기하세요.</target>
         <note from="MultilingualUpdate" annotates="source" priority="2" />
       </trans-unit>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.pl.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.pl.xlf
@@ -40,8 +40,8 @@
       </trans-unit>
       <trans-unit id="VSTHRD003_MessageFormat" translate="yes" xml:space="preserve">
         <source>Avoid awaiting or returning a Task representing work that was not started within your context as that can lead to deadlocks.
-Start the work within this context, or use JoinableTaskFactory.RunAsync and await the returned JoinableTask instead.</source>
-        <target state="translated">Unikaj oczekiwania na obiekt Task lub zwracania obiektu Task reprezentującego pracę, która nie została uruchomiona w danym kontekście, ponieważ może to prowadzić do zakleszczeń.
+Start the work within this context, or use JoinableTaskFactory.RunAsync to start the task and await the returned JoinableTask instead.</source>
+        <target state="needs-review-translation">Unikaj oczekiwania na obiekt Task lub zwracania obiektu Task reprezentującego pracę, która nie została uruchomiona w danym kontekście, ponieważ może to prowadzić do zakleszczeń.
 Uruchom pracę w tym kontekście lub zamiast tego użyj metody JoinableTaskFactory.RunAsync i oczekuj na zwrócony obiekt JoinableTask.</target>
         <note from="MultilingualUpdate" annotates="source" priority="2" />
       </trans-unit>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.pt-BR.xlf
@@ -40,8 +40,8 @@
       </trans-unit>
       <trans-unit id="VSTHRD003_MessageFormat" translate="yes" xml:space="preserve">
         <source>Avoid awaiting or returning a Task representing work that was not started within your context as that can lead to deadlocks.
-Start the work within this context, or use JoinableTaskFactory.RunAsync and await the returned JoinableTask instead.</source>
-        <target state="translated">Evite aguardar ou retornar uma Tarefa que representa o trabalho que não foi iniciado em seu contexto, pois isso pode levar a deadlocks.
+Start the work within this context, or use JoinableTaskFactory.RunAsync to start the task and await the returned JoinableTask instead.</source>
+        <target state="needs-review-translation">Evite aguardar ou retornar uma Tarefa que representa o trabalho que não foi iniciado em seu contexto, pois isso pode levar a deadlocks.
 Inice o trabalho neste contexto ou use JoinableTaskFactory.RunAsync e aguarde o JoinableTask retornado em seu lugar.</target>
         <note from="MultilingualUpdate" annotates="source" priority="2" />
       </trans-unit>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.ru.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.ru.xlf
@@ -40,8 +40,8 @@
       </trans-unit>
       <trans-unit id="VSTHRD003_MessageFormat" translate="yes" xml:space="preserve">
         <source>Avoid awaiting or returning a Task representing work that was not started within your context as that can lead to deadlocks.
-Start the work within this context, or use JoinableTaskFactory.RunAsync and await the returned JoinableTask instead.</source>
-        <target state="translated">Не рекомендуется ожидать или возвращать задачу, представляющую работу, которая не была запущена в вашем контексте, так как это может привести к взаимоблокировке.
+Start the work within this context, or use JoinableTaskFactory.RunAsync to start the task and await the returned JoinableTask instead.</source>
+        <target state="needs-review-translation">Не рекомендуется ожидать или возвращать задачу, представляющую работу, которая не была запущена в вашем контексте, так как это может привести к взаимоблокировке.
 Запустите работу в этом контексте или используйте JoinableTaskFactory.RunAsync и ожидайте возвращаемую задачу JoinableTask.</target>
         <note from="MultilingualUpdate" annotates="source" priority="2" />
       </trans-unit>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.tr.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.tr.xlf
@@ -40,8 +40,8 @@
       </trans-unit>
       <trans-unit id="VSTHRD003_MessageFormat" translate="yes" xml:space="preserve">
         <source>Avoid awaiting or returning a Task representing work that was not started within your context as that can lead to deadlocks.
-Start the work within this context, or use JoinableTaskFactory.RunAsync and await the returned JoinableTask instead.</source>
-        <target state="translated">Kilitlenmelere yol açabileceğinden, bağlamınızda başlatılmamış işi temsil eden bir Görevi beklemekten veya döndürmekten kaçının.
+Start the work within this context, or use JoinableTaskFactory.RunAsync to start the task and await the returned JoinableTask instead.</source>
+        <target state="needs-review-translation">Kilitlenmelere yol açabileceğinden, bağlamınızda başlatılmamış işi temsil eden bir Görevi beklemekten veya döndürmekten kaçının.
 İşi bu bağlamda başlatın veya bunun yerine JoinableTaskFactory.RunAsync kullanın ve döndürülen JoinableTask öğesini bekleyin.</target>
         <note from="MultilingualUpdate" annotates="source" priority="2" />
       </trans-unit>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.zh-Hans.xlf
@@ -40,8 +40,8 @@
       </trans-unit>
       <trans-unit id="VSTHRD003_MessageFormat" translate="yes" xml:space="preserve">
         <source>Avoid awaiting or returning a Task representing work that was not started within your context as that can lead to deadlocks.
-Start the work within this context, or use JoinableTaskFactory.RunAsync and await the returned JoinableTask instead.</source>
-        <target state="translated">避免等待或返回表示在上下文内未启动的工作的任务，因为可能导致死锁。
+Start the work within this context, or use JoinableTaskFactory.RunAsync to start the task and await the returned JoinableTask instead.</source>
+        <target state="needs-review-translation">避免等待或返回表示在上下文内未启动的工作的任务，因为可能导致死锁。
 在此上下文内启动工作，或使用 JoinableTaskFactory.RunAsync 并等待返回的 JoinableTask。</target>
         <note from="MultilingualUpdate" annotates="source" priority="2" />
       </trans-unit>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.zh-Hant.xlf
@@ -40,8 +40,8 @@
       </trans-unit>
       <trans-unit id="VSTHRD003_MessageFormat" translate="yes" xml:space="preserve">
         <source>Avoid awaiting or returning a Task representing work that was not started within your context as that can lead to deadlocks.
-Start the work within this context, or use JoinableTaskFactory.RunAsync and await the returned JoinableTask instead.</source>
-        <target state="translated">避免等待或傳回代表未在您內容中啟動的工作，因為其可能會造成死結。
+Start the work within this context, or use JoinableTaskFactory.RunAsync to start the task and await the returned JoinableTask instead.</source>
+        <target state="needs-review-translation">避免等待或傳回代表未在您內容中啟動的工作，因為其可能會造成死結。
 您可以在此內容中啟動該工作，或使用 JoinableTaskFactory.RunAsync，改為等待傳回 JoinableTask。</target>
         <note from="MultilingualUpdate" annotates="source" priority="2" />
       </trans-unit>


### PR DESCRIPTION
We tried to avoid reporting VSTHRD003 diagnostics for readonly Task fields defined in other projects/assemblies, but failed to do so properly. This fixes that to dramatically reduce false warnings typically associated with precompleted tasks such as `SpecialTasks.TrueTask`.

It also refines the wording in the diagnostic to reduce confusion.