### PR TITLE
Fix logging of mismatched arguments

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/ThreadingEventSource.cs
+++ b/src/Microsoft.VisualStudio.Threading/ThreadingEventSource.cs
@@ -77,7 +77,7 @@ namespace Microsoft.VisualStudio.Threading
         [Event(ReaderWriterLockIssuedLockCountsEvent, Task = Tasks.LockRequest, Opcode = Opcodes.ReaderWriterLockIssued)]
         public void ReaderWriterLockIssued(int lockId, AsyncReaderWriterLock.LockKind kind, int issuedUpgradeableReadCount, int issuedReadCount)
         {
-            this.WriteEvent(ReaderWriterLockIssuedLockCountsEvent, lockId, (int)kind, issuedUpgradeableReadCount, issuedReadCount);
+            this.WriteEvent(ReaderWriterLockIssuedLockCountsEvent, lockId, kind, issuedUpgradeableReadCount, issuedReadCount);
         }
 
         /// <summary>
@@ -95,7 +95,7 @@ namespace Microsoft.VisualStudio.Threading
         [Event(WaitReaderWriterLockStopEvent, Task = Tasks.LockRequestContention, Opcode = EventOpcode.Stop)]
         public void WaitReaderWriterLockStop(int lockId, AsyncReaderWriterLock.LockKind kind)
         {
-            this.WriteEvent(WaitReaderWriterLockStopEvent, lockId, (int)kind);
+            this.WriteEvent(WaitReaderWriterLockStopEvent, lockId, kind);
         }
 
 #endregion


### PR DESCRIPTION
The call to `WriteEvent` must have the same argument types as the parameters of the method with the `[Event]` attribute. The comparison in mscorlib doesn't coerce between enum/int.

Prior to this change, the debugger displays a bunch of messages in the output window:

> The parameters to the Event method do not match the parameters to the WriteEvent method. This may cause the event to be displayed incorrectly.

This is logged in `System.Diagnostics.Tracing.EventSource.LogEventArgsMismatches`.