### PR TITLE
Add `using await` support to ARWL.Releaser

### DIFF
--- a/src/IsolatedTestHost/App.config
+++ b/src/IsolatedTestHost/App.config
@@ -3,6 +3,12 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
         <assemblyIdentity name="xunit.core" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.4.1.0" newVersion="2.4.1.0" />
       </dependentAssembly>

--- a/src/Microsoft.VisualStudio.Threading.Tests/AsyncReaderWriterLockTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/AsyncReaderWriterLockTests.cs
@@ -611,12 +611,11 @@
         public async Task IsPassiveWriteLockHeldReturnsTrueForIncompatibleSyncContexts()
         {
             var dispatcher = SingleThreadedTestSynchronizationContext.New();
-            using (var releaser = await this.asyncLock.WriteLockAsync())
+            await using (await this.asyncLock.WriteLockAsync())
             {
                 Assert.True(this.asyncLock.IsPassiveWriteLockHeld);
                 SynchronizationContext.SetSynchronizationContext(dispatcher);
                 Assert.True(this.asyncLock.IsPassiveWriteLockHeld);
-                await releaser.ReleaseAsync();
             }
         }
 
@@ -1286,9 +1285,8 @@
                 onExclusiveLockReleasedBegun.Set();
                 await innerLockReleased;
             };
-            using (var releaser = await asyncLock.WriteLockAsync())
+            await using (await asyncLock.WriteLockAsync())
             {
-                await releaser.ReleaseAsync();
             }
         }
 
@@ -3076,9 +3074,8 @@
         public async Task OnBeforeExclusiveLockReleasedAsyncWriteLockReleaseAsync()
         {
             var asyncLock = new LockDerivedWriteLockAroundOnBeforeExclusiveLockReleased();
-            using (var access = await asyncLock.WriteLockAsync())
+            await using (await asyncLock.WriteLockAsync())
             {
-                await access.ReleaseAsync();
             }
         }
 
@@ -3086,9 +3083,8 @@
         public async Task OnBeforeExclusiveLockReleasedAsyncReadLockReleaseAsync()
         {
             var asyncLock = new LockDerivedReadLockAroundOnBeforeExclusiveLockReleased();
-            using (var access = await asyncLock.WriteLockAsync())
+            await using (await asyncLock.WriteLockAsync())
             {
-                await access.ReleaseAsync();
             }
         }
 

--- a/src/Microsoft.VisualStudio.Threading/AsyncReaderWriterResourceLock.cs
+++ b/src/Microsoft.VisualStudio.Threading/AsyncReaderWriterResourceLock.cs
@@ -389,7 +389,7 @@ namespace Microsoft.VisualStudio.Threading
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes")]
         [DebuggerDisplay("{releaser.awaiter.kind}")]
-        public readonly struct ResourceReleaser : IDisposable
+        public readonly struct ResourceReleaser : IDisposable, System.IAsyncDisposable
         {
             /// <summary>
             /// The underlying lock releaser.
@@ -440,8 +440,16 @@ namespace Microsoft.VisualStudio.Threading
             }
 
             /// <summary>
+            /// Releases the lock.
+            /// </summary>
+            public ValueTask DisposeAsync() => this.LockReleaser.DisposeAsync();
+
+            /// <summary>
             /// Asynchronously releases the lock.  Dispose should still be called after this.
             /// </summary>
+            /// <remarks>
+            /// Rather than calling this method explicitly, use the C# 8 "await using" syntax instead.
+            /// </remarks>
             public Task ReleaseAsync()
             {
                 return this.LockReleaser.ReleaseAsync();

--- a/src/Microsoft.VisualStudio.Threading/IAsyncDisposable.cs
+++ b/src/Microsoft.VisualStudio.Threading/IAsyncDisposable.cs
@@ -11,6 +11,9 @@ namespace Microsoft.VisualStudio.Threading
     /// <summary>
     /// Defines an asynchronous method to release allocated resources.
     /// </summary>
+    /// <remarks>
+    /// Consider implementing <see cref="System.IAsyncDisposable"/> instead.
+    /// </remarks>
     public interface IAsyncDisposable
     {
         /// <summary>

--- a/src/Microsoft.VisualStudio.Threading/Microsoft.VisualStudio.Threading.csproj
+++ b/src/Microsoft.VisualStudio.Threading/Microsoft.VisualStudio.Threading.csproj
@@ -40,6 +40,7 @@
   <ItemGroup>
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" Version="2.9.7" PrivateAssets="all" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.3" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Validation" Version="15.5.31" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.6.0" />
     <PackageReference Include="MicroBuild.VisualStudio" Version="$(MicroBuildVersion)" PrivateAssets="all" />

--- a/src/Microsoft.VisualStudio.Threading/net472/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/net472/PublicAPI.Unshipped.txt
@@ -1,2 +1,4 @@
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Releaser.DisposeAsync() -> System.Threading.Tasks.ValueTask
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ResourceReleaser.DisposeAsync() -> System.Threading.Tasks.ValueTask
 static Microsoft.VisualStudio.Threading.TplExtensions.Forget(this System.Threading.Tasks.ValueTask task) -> void
 static Microsoft.VisualStudio.Threading.TplExtensions.Forget<T>(this System.Threading.Tasks.ValueTask<T> task) -> void

--- a/src/Microsoft.VisualStudio.Threading/netcoreapp3.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/netcoreapp3.0/PublicAPI.Unshipped.txt
@@ -1,2 +1,4 @@
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Releaser.DisposeAsync() -> System.Threading.Tasks.ValueTask
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ResourceReleaser.DisposeAsync() -> System.Threading.Tasks.ValueTask
 static Microsoft.VisualStudio.Threading.TplExtensions.Forget(this System.Threading.Tasks.ValueTask task) -> void
 static Microsoft.VisualStudio.Threading.TplExtensions.Forget<T>(this System.Threading.Tasks.ValueTask<T> task) -> void

--- a/src/Microsoft.VisualStudio.Threading/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,2 +1,4 @@
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Releaser.DisposeAsync() -> System.Threading.Tasks.ValueTask
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ResourceReleaser.DisposeAsync() -> System.Threading.Tasks.ValueTask
 static Microsoft.VisualStudio.Threading.TplExtensions.Forget(this System.Threading.Tasks.ValueTask task) -> void
 static Microsoft.VisualStudio.Threading.TplExtensions.Forget<T>(this System.Threading.Tasks.ValueTask<T> task) -> void


### PR DESCRIPTION
Now doing the most efficient thing is as simple as adding `await` in front of the `using` instead of assigning the releaser to a local variable and manually calling `ReleaseAsync` on it prior to exiting the `using` block.

Usage pattern:

```diff
-using (var releaser = await this.asyncLock.WriteLockAsync())
+await using (await this.asyncLock.WriteLockAsync())
 {
-    await releaser.ReleaseAsync();
 }
```

I'm considering adding a VSTHRD analyzer to find the old pattern and even offer a bulk code fix to update them.
The change is usually better than the older pattern since it guarantees the async exit path is taken even in exception cases.