### PR TITLE
Add NonConcurrentSynchronizationContext

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Tests/NonConcurrentSynchronizationContextTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Tests/NonConcurrentSynchronizationContextTests.cs
@@ -1,0 +1,273 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
+using Microsoft.VisualStudio.Threading.Tests;
+using Xunit;
+using Xunit.Abstractions;
+
+public class NonConcurrentSynchronizationContextTests : TestBase
+{
+    private readonly NonConcurrentSynchronizationContext nonSticky = new NonConcurrentSynchronizationContext(sticky: false);
+
+    public NonConcurrentSynchronizationContextTests(ITestOutputHelper logger)
+        : base(logger)
+    {
+    }
+
+    [Fact]
+    public void CreateCopy()
+    {
+        var copy = this.nonSticky.CreateCopy();
+        Assert.NotSame(this.nonSticky, copy);
+        ConfirmNonConcurrentPost(this.nonSticky, copy);
+    }
+
+    [Fact]
+    public void Post_NonConcurrentExecution()
+    {
+        ConfirmNonConcurrentPost(this.nonSticky, this.nonSticky);
+    }
+
+    [Fact]
+    public void Send_NonConcurrentExecution()
+    {
+        ConfirmNonConcurrentSend(this.nonSticky);
+    }
+
+    [Fact]
+    public void UnhandledException_WithNoHandler()
+    {
+        // Verifies that no crash occurs when an exception is thrown without an event handler attached.
+        this.nonSticky.Post(s => throw new InvalidOperationException(), null);
+    }
+
+    [Fact]
+    public async Task UnhandledException_WithHandler()
+    {
+        var eventArgs = new TaskCompletionSource<(object?, Exception)>();
+        this.nonSticky.UnhandledException += (s, e) => eventArgs.SetResult((s, e));
+        this.nonSticky.Post(s => throw new InvalidOperationException(), null);
+        var (sender, ex) = await eventArgs.Task.WithCancellation(this.TimeoutToken);
+        Assert.Same(this.nonSticky, sender);
+        Assert.IsType<InvalidOperationException>(ex);
+    }
+
+    [Fact]
+    public async Task NonSticky_HasNoCurrentSyncContext()
+    {
+        Assert.Null(await GetCurrentSyncContextDuringPost(this.nonSticky));
+    }
+
+    [Fact]
+    public async Task Sticky_SetsCurrentSyncContext()
+    {
+        var sticky = new NonConcurrentSynchronizationContext(sticky: true);
+        Assert.Same(sticky, await GetCurrentSyncContextDuringPost(sticky));
+    }
+
+    [Fact]
+    public async Task InlinedSendReappliesSyncContextWhenSticky()
+    {
+        var sticky = new NonConcurrentSynchronizationContext(sticky: true);
+        var tcs = new TaskCompletionSource<object?>();
+        sticky.Post(_ =>
+        {
+            try
+            {
+                SynchronizationContext.SetSynchronizationContext(new SynchronizationContext());
+                sticky.Send(_ =>
+                {
+                    Assert.Same(sticky, SynchronizationContext.Current);
+                }, null);
+                Assert.IsType<SynchronizationContext>(SynchronizationContext.Current);
+                tcs.TrySetResult(null);
+            }
+            catch (Exception ex)
+            {
+                tcs.TrySetException(ex);
+            }
+        }, null);
+        await tcs.Task.WithCancellation(this.TimeoutToken);
+    }
+
+    [Fact]
+    public async Task InlinedSendIgnoresSyncContextWhenNotSticky()
+    {
+        var tcs = new TaskCompletionSource<object?>();
+        this.nonSticky.Post(_ =>
+        {
+            try
+            {
+                SynchronizationContext.SetSynchronizationContext(new SynchronizationContext());
+                this.nonSticky.Send(_ =>
+                {
+                    Assert.IsType<SynchronizationContext>(SynchronizationContext.Current);
+                }, null);
+                Assert.IsType<SynchronizationContext>(SynchronizationContext.Current);
+                tcs.TrySetResult(null);
+            }
+            catch (Exception ex)
+            {
+                tcs.TrySetException(ex);
+            }
+        }, null);
+        await tcs.Task.WithCancellation(this.TimeoutToken);
+    }
+
+    [Fact]
+    public async Task SyncContextIsNotInherited()
+    {
+        // Set a SyncContext when creating the context, and ensure the current context is never used.
+        SynchronizationContext.SetSynchronizationContext(new ThrowingSyncContext());
+        var nonConcurrentContext = new NonConcurrentSynchronizationContext(sticky: false);
+
+        // Also confirm the current context doesn't impact the Post method.
+        Assert.Null(await GetCurrentSyncContextDuringPost(nonConcurrentContext).ConfigureAwait(false));
+    }
+
+    [Fact]
+    public void Send_RethrowsExceptionFromDelegate()
+    {
+        bool handlerInvoked = false;
+        this.nonSticky.UnhandledException += (s, e) => handlerInvoked = true;
+
+        Assert.Throws<InvalidOperationException>(() => this.nonSticky.Send(_ => throw new InvalidOperationException(), null));
+        Assert.False(handlerInvoked);
+    }
+
+    [Fact]
+    public void Send_RethrowsExceptionFromDelegate_WhenInlined()
+    {
+        bool handlerInvoked = false;
+        this.nonSticky.UnhandledException += (s, e) => handlerInvoked = true;
+
+        this.nonSticky.Send(_ => Assert.Throws<InvalidOperationException>(() => this.nonSticky.Send(_ => throw new InvalidOperationException(), null)), null);
+        Assert.False(handlerInvoked);
+    }
+
+    [Fact]
+    public void SendWithinSendDoesNotDeadlock()
+    {
+        Task.Run(delegate
+        {
+            bool reachedInnerDelegate = false;
+            this.nonSticky.Send(_ =>
+            {
+                this.nonSticky.Send(_ =>
+                {
+                    reachedInnerDelegate = true;
+                }, null);
+            }, null);
+
+            Assert.True(reachedInnerDelegate);
+        }).WithCancellation(this.TimeoutToken).GetAwaiter().GetResult();
+    }
+
+    [Fact]
+    public async Task SendWithinPostDoesNotDeadlock()
+    {
+        var reachedInnerDelegate = new TaskCompletionSource<bool>();
+        this.nonSticky.Post(_ =>
+        {
+            this.nonSticky.Send(_ =>
+            {
+                reachedInnerDelegate.SetResult(true);
+            }, null);
+        }, null);
+
+        Assert.True(await reachedInnerDelegate.Task.WithCancellation(this.TimeoutToken));
+    }
+
+    [Fact]
+    public void CannotFoolSendBySettingSyncContext()
+    {
+        using var releaseFirst = new ManualResetEventSlim();
+        this.nonSticky.Post(s =>
+        {
+            releaseFirst.Wait(UnexpectedTimeout);
+        }, null);
+        using var secondEntered = new ManualResetEventSlim();
+        Task sendTask = Task.Run(delegate
+        {
+            SynchronizationContext.SetSynchronizationContext(this.nonSticky);
+            this.nonSticky.Send(s =>
+            {
+                secondEntered.Set();
+            }, null);
+        });
+        Assert.False(secondEntered.Wait(ExpectedTimeout));
+
+        // Now that we've proven the second one hasn't started, allow the first to finish and confirm the second one could then execute.
+        releaseFirst.Set();
+        Assert.True(secondEntered.Wait(UnexpectedTimeout));
+        sendTask.Wait(UnexpectedTimeout);
+    }
+
+    private static Task<SynchronizationContext?> GetCurrentSyncContextDuringPost(SynchronizationContext synchronizationContext)
+    {
+        var observed = new TaskCompletionSource<SynchronizationContext?>();
+        synchronizationContext.Post(
+            s =>
+            {
+                observed.SetResult(SynchronizationContext.Current);
+            },
+            null);
+        return observed.Task;
+    }
+
+    private static void ConfirmNonConcurrentSend(SynchronizationContext ctxt)
+    {
+        using var releaseFirst = new ManualResetEventSlim();
+        ctxt.Post(s =>
+        {
+            releaseFirst.Wait(UnexpectedTimeout);
+        }, null);
+        using var secondEntered = new ManualResetEventSlim();
+        Task sendTask = Task.Run(delegate
+        {
+            ctxt.Send(s =>
+            {
+                secondEntered.Set();
+            }, null);
+        });
+        Assert.False(secondEntered.Wait(ExpectedTimeout));
+
+        // Now that we've proven the second one hasn't started, allow the first to finish and confirm the second one could then execute.
+        releaseFirst.Set();
+        Assert.True(secondEntered.Wait(UnexpectedTimeout));
+        sendTask.Wait(UnexpectedTimeout);
+    }
+
+    private static void ConfirmNonConcurrentPost(SynchronizationContext a, SynchronizationContext b)
+    {
+        // Verify that the two instances share a common non-concurrent queue
+        // by scheduling something on each one, and confirming that the second can't start
+        // before the second one completes.
+        using var releaseFirst = new ManualResetEventSlim();
+        a.Post(s =>
+        {
+            releaseFirst.Wait(UnexpectedTimeout);
+        }, null);
+        using var secondEntered = new ManualResetEventSlim();
+        b.Post(s =>
+        {
+            secondEntered.Set();
+        }, null);
+        Assert.False(secondEntered.Wait(ExpectedTimeout));
+
+        // Now that we've proven the second one hasn't started, allow the first to finish and confirm the second one could then execute.
+        releaseFirst.Set();
+        Assert.True(secondEntered.Wait(UnexpectedTimeout));
+    }
+
+    private class ThrowingSyncContext : SynchronizationContext
+    {
+        public override void Post(SendOrPostCallback d, object? state) => throw new NotSupportedException();
+
+        public override void Send(SendOrPostCallback d, object? state) => throw new NotSupportedException();
+    }
+}

--- a/src/Microsoft.VisualStudio.Threading/NonConcurrentSynchronizationContext.cs
+++ b/src/Microsoft.VisualStudio.Threading/NonConcurrentSynchronizationContext.cs
@@ -1,0 +1,177 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+
+namespace Microsoft.VisualStudio.Threading
+{
+    using System;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// A <see cref="SynchronizationContext"/> that executes messages in the order they are received.
+    /// </summary>
+    /// <remarks>
+    /// Delegates will be invoked in the order they are received on the threadpool.
+    /// No two delegates will ever be executed concurrently, but <see cref="Send(SendOrPostCallback, object?)"/> may permit
+    /// a delegate to execute inline on another.
+    /// Note that if the delegate invokes an async method, the delegate formally ends
+    /// when the async method yields for the first time or returns, whichever comes first.
+    /// Once that delegate returns the next delegate can be executed.
+    /// </remarks>
+    public sealed class NonConcurrentSynchronizationContext : SynchronizationContext
+    {
+        /// <summary>
+        /// The queue of work to execute, if this is the original instance.
+        /// </summary>
+        private readonly AsyncQueue<(SendOrPostCallback, object?)>? queue;
+
+        /// <summary>
+        /// A value indicating whether to set this instance as <see cref="SynchronizationContext.Current" /> when invoking delegates.
+        /// </summary>
+        private readonly bool sticky;
+
+        /// <summary>
+        /// The original instance (on which <see cref="CreateCopy"/> was called).
+        /// </summary>
+        private readonly NonConcurrentSynchronizationContext? copyOf;
+
+        /// <summary>
+        /// Set to the <see cref="Environment.CurrentManagedThreadId"/> when a delegate is currently executing.
+        /// </summary>
+        private int? activeManagedThreadId;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NonConcurrentSynchronizationContext"/> class.
+        /// </summary>
+        /// <param name="sticky">
+        /// A value indicating whether to set this instance as <see cref="SynchronizationContext.Current" /> when invoking delegates.
+        /// This has the effect that async methods that are invoked on this <see cref="SynchronizationContext" />
+        /// will execute their continuations on this <see cref="SynchronizationContext" /> as well unless they use <see cref="Task.ConfigureAwait(bool)" /> with <c>false</c> as the argument.
+        /// </param>
+        public NonConcurrentSynchronizationContext(bool sticky)
+        {
+            this.queue = new AsyncQueue<(SendOrPostCallback, object?)>();
+            this.sticky = sticky;
+
+            // Start the queue processor. It will handle all exceptions.
+            this.ProcessQueueAsync().Forget();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NonConcurrentSynchronizationContext"/> class
+        /// that is a copy of an existing instance.
+        /// </summary>
+        /// <param name="copyFrom">The instance to copy from.</param>
+        private NonConcurrentSynchronizationContext(NonConcurrentSynchronizationContext copyFrom)
+        {
+            // We do *not* kick off processing of the queue, since the original copy has done that and we don't want two logical threads processing the queue.
+            this.sticky = copyFrom.sticky;
+            this.copyOf = copyFrom;
+        }
+
+        /// <summary>
+        /// Occurs when posted work throws an unhandled exception.
+        /// </summary>
+        /// <remarks>
+        /// Any exception thrown from this handler will crash the process.
+        /// </remarks>
+        public event EventHandler<Exception>? UnhandledException;
+
+        /// <inheritdoc />
+        public override void Post(SendOrPostCallback d, object? state)
+        {
+            Requires.NotNull(d, nameof(d));
+
+            if (this.copyOf is object)
+            {
+                this.copyOf.Post(d, state);
+                return;
+            }
+
+            this.queue!.Enqueue((d, state));
+        }
+
+        /// <inheritdoc />
+        public override void Send(SendOrPostCallback d, object? state)
+        {
+            Requires.NotNull(d, nameof(d));
+
+            if (this.copyOf is object)
+            {
+                this.copyOf.Send(d, state);
+                return;
+            }
+
+            // Allow inlining if we're on the already-assigned thread.
+            if (this.activeManagedThreadId is int activeThread && Environment.CurrentManagedThreadId == activeThread)
+            {
+                using (this.sticky ? this.Apply(checkForChangesOnRevert: false) : default)
+                {
+                    d(state);
+                }
+
+                return;
+            }
+
+            var tcs = new TaskCompletionSource<object?>();
+            this.Post(
+                s2 =>
+                {
+                    var (cb, s, m) = (Tuple<SendOrPostCallback, object, TaskCompletionSource<object?>>)s2!;
+                    try
+                    {
+                        cb(s);
+                        m.SetResult(null);
+                    }
+                    catch (Exception ex)
+                    {
+                        m.SetException(ex);
+                    }
+                },
+                Tuple.Create(d, state, tcs));
+            tcs.Task.GetAwaiter().GetResult();
+        }
+
+        /// <inheritdoc />
+        public override SynchronizationContext CreateCopy() => new NonConcurrentSynchronizationContext(this);
+
+        /// <summary>
+        /// Executes queued work on the threadpool, one at a time.
+        /// </summary>
+        /// <returns>A task that always completes successfully.</returns>
+        [SuppressMessage("Microsoft.Globalization", "CA1303:Do not pass literals as localized parameters", MessageId = "System.Environment.FailFast(System.String,System.Exception)")]
+        private async Task ProcessQueueAsync()
+        {
+            try
+            {
+                while (true)
+                {
+                    var work = await this.queue!.DequeueAsync().ConfigureAwait(false);
+                    this.activeManagedThreadId = Environment.CurrentManagedThreadId;
+                    try
+                    {
+                        using (this.sticky ? this.Apply(checkForChangesOnRevert: false) : default)
+                        {
+                            work.Item1(work.Item2);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        this.UnhandledException?.Invoke(this, ex);
+                    }
+                    finally
+                    {
+                        this.activeManagedThreadId = null;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                // A failure to schedule work is fatal because it can lead to hangs that are
+                // very hard to diagnose to a failure in the scheduler, and even harder to identify
+                // the root cause of the failure in the scheduler.
+                Environment.FailFast("Failure in scheduler.", ex);
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Threading/net472/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/net472/PublicAPI.Unshipped.txt
@@ -1,4 +1,10 @@
 Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Releaser.DisposeAsync() -> System.Threading.Tasks.ValueTask
 Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ResourceReleaser.DisposeAsync() -> System.Threading.Tasks.ValueTask
+Microsoft.VisualStudio.Threading.NonConcurrentSynchronizationContext
+Microsoft.VisualStudio.Threading.NonConcurrentSynchronizationContext.NonConcurrentSynchronizationContext(bool sticky) -> void
+Microsoft.VisualStudio.Threading.NonConcurrentSynchronizationContext.UnhandledException -> System.EventHandler<System.Exception>
+override Microsoft.VisualStudio.Threading.NonConcurrentSynchronizationContext.CreateCopy() -> System.Threading.SynchronizationContext
+override Microsoft.VisualStudio.Threading.NonConcurrentSynchronizationContext.Post(System.Threading.SendOrPostCallback d, object state) -> void
+override Microsoft.VisualStudio.Threading.NonConcurrentSynchronizationContext.Send(System.Threading.SendOrPostCallback d, object state) -> void
 static Microsoft.VisualStudio.Threading.TplExtensions.Forget(this System.Threading.Tasks.ValueTask task) -> void
 static Microsoft.VisualStudio.Threading.TplExtensions.Forget<T>(this System.Threading.Tasks.ValueTask<T> task) -> void

--- a/src/Microsoft.VisualStudio.Threading/netcoreapp3.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/netcoreapp3.0/PublicAPI.Unshipped.txt
@@ -1,4 +1,10 @@
 Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Releaser.DisposeAsync() -> System.Threading.Tasks.ValueTask
 Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ResourceReleaser.DisposeAsync() -> System.Threading.Tasks.ValueTask
+Microsoft.VisualStudio.Threading.NonConcurrentSynchronizationContext
+Microsoft.VisualStudio.Threading.NonConcurrentSynchronizationContext.NonConcurrentSynchronizationContext(bool sticky) -> void
+Microsoft.VisualStudio.Threading.NonConcurrentSynchronizationContext.UnhandledException -> System.EventHandler<System.Exception>
+override Microsoft.VisualStudio.Threading.NonConcurrentSynchronizationContext.CreateCopy() -> System.Threading.SynchronizationContext
+override Microsoft.VisualStudio.Threading.NonConcurrentSynchronizationContext.Post(System.Threading.SendOrPostCallback d, object state) -> void
+override Microsoft.VisualStudio.Threading.NonConcurrentSynchronizationContext.Send(System.Threading.SendOrPostCallback d, object state) -> void
 static Microsoft.VisualStudio.Threading.TplExtensions.Forget(this System.Threading.Tasks.ValueTask task) -> void
 static Microsoft.VisualStudio.Threading.TplExtensions.Forget<T>(this System.Threading.Tasks.ValueTask<T> task) -> void

--- a/src/Microsoft.VisualStudio.Threading/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,4 +1,10 @@
 Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Releaser.DisposeAsync() -> System.Threading.Tasks.ValueTask
 Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ResourceReleaser.DisposeAsync() -> System.Threading.Tasks.ValueTask
+Microsoft.VisualStudio.Threading.NonConcurrentSynchronizationContext
+Microsoft.VisualStudio.Threading.NonConcurrentSynchronizationContext.NonConcurrentSynchronizationContext(bool sticky) -> void
+Microsoft.VisualStudio.Threading.NonConcurrentSynchronizationContext.UnhandledException -> System.EventHandler<System.Exception>
+override Microsoft.VisualStudio.Threading.NonConcurrentSynchronizationContext.CreateCopy() -> System.Threading.SynchronizationContext
+override Microsoft.VisualStudio.Threading.NonConcurrentSynchronizationContext.Post(System.Threading.SendOrPostCallback d, object state) -> void
+override Microsoft.VisualStudio.Threading.NonConcurrentSynchronizationContext.Send(System.Threading.SendOrPostCallback d, object state) -> void
 static Microsoft.VisualStudio.Threading.TplExtensions.Forget(this System.Threading.Tasks.ValueTask task) -> void
 static Microsoft.VisualStudio.Threading.TplExtensions.Forget<T>(this System.Threading.Tasks.ValueTask<T> task) -> void


### PR DESCRIPTION
This `SynchronizationContext` schedules work on the threadpool in such a way as to ensure that no posted delegate is concurrent with another posted delegate.
It provides a "logically single thread" environment without actually having to create a dedicated thread.