### PR TITLE
Add InsertPropsValues variable

### DIFF
--- a/azure-pipelines/variables/InsertPropsValues.ps1
+++ b/azure-pipelines/variables/InsertPropsValues.ps1
@@ -1,0 +1,15 @@
+$BinPath = [System.IO.Path]::GetFullPath("$PSScriptRoot\..\..\bin\Packages\$env:BuildConfiguration")
+
+$dirsToSearch = "$BinPath\NuGet\*.nupkg" |? { Test-Path $_ }
+$icv=@()
+if ($dirsToSearch) {
+    Get-ChildItem -Path $dirsToSearch |% {
+        if ($_.Name -match "^(.*)\.(\d+\.\d+\.\d+(?:-.*?)?)(?:\.symbols)?\.nupkg$") {
+            $id = $Matches[1]
+            $version = $Matches[2]
+            $icv += "$id=$version"
+        }
+    }
+}
+
+Write-Output ([string]::join(',',$icv))


### PR DESCRIPTION
This will cause our VS repo packages.props file (or an import) to consume the new version.