### PR TITLE
Add VSTHRD112 and VSTHRD113 to help folks migrate to System.IAsyncDisposable

### DIFF
--- a/doc/analyzers/VSTHRD112.md
+++ b/doc/analyzers/VSTHRD112.md
@@ -1,0 +1,66 @@
+# VSTHRD112 Implement `System.IAsyncDisposable`
+
+The `Microsoft.VisualStudio.Threading.IAsyncDisposable` interface is obsolete now that the
+`System.IAsyncDisposable` interface has been defined for .NET Standard 2.0 and .NET Framework 4.6.1
+by the [`Microsoft.Bcl.AsyncInterfaces` NuGet package](https://www.nuget.org/packages/Microsoft.Bcl.AsyncInterfaces).
+
+New classes looking to support async disposable should use `System.IAsyncDisposable` instead of `Microsoft.VisualStudio.Threading.IAsyncDisposable`.
+Existing classes that already implement `Microsoft.VisualStudio.Threading.IAsyncDisposable` should *also* implement `System.IAsyncDisposable` so the async disposal option will be recognized by code that only checks for presence of the new interface.
+
+## Examples of patterns that are flagged by this analyzer
+
+This class only implements `Microsoft.VisualStudio.Threading.IAsyncDisposable` and will produce the VSTHRD112 diagnostic:
+
+```cs
+using Microsoft.VisualStudio.Threading;
+
+class SomeClass : IAsyncDisposable
+{
+    public Task DisposeAsync()
+    {
+    }
+}
+```
+
+## Solution
+
+Implement `System.IAsyncDisposable` in addition to (or instead of) `Microsoft.VisualStudio.Threading.IAsyncDisposable`.
+Add a package reference to `Microsoft.Bcl.AsyncInterfaces` if the compiler cannot find `System.IAsyncDisposable`.
+
+In this example, only `System.IAsyncDisposable` is supported, which is acceptable:
+
+```cs
+using System;
+
+class SomeClass : IAsyncDisposable
+{
+    public ValueTask DisposeAsync()
+    {
+    }
+}
+```
+
+In this next example, both interfaces are supported:
+
+```cs
+class SomeClass : System.IAsyncDisposable, Microsoft.VisualStudio.Threading.IAsyncDisposable
+{
+    Task Microsoft.VisualStudio.Threading.IAsyncDisposable.DisposeAsync()
+    {
+        // Simply forward the call to the other DisposeAsync overload.
+        System.IAsyncDisposable self = this;
+        return self.Dispose().AsTask();
+    }
+
+    ValueTask System.IAsyncDisposable.DisposeAsync()
+    {
+        // Interesting dispose logic here.
+    }
+}
+```
+
+In the above example both `DisposeAsync` methods are explicit interface implementations.
+Promoting one of the methods to be `public` is typically advised.
+If one of these methods was already public and the class itself is public or protected, keep the same method public to avoid an API binary breaking change.
+
+An automated code fix may be offered for VSTHRD112 diagnostics.

--- a/doc/analyzers/VSTHRD113.md
+++ b/doc/analyzers/VSTHRD113.md
@@ -1,0 +1,37 @@
+# VSTHRD113 Check for `System.IAsyncDisposable`
+
+The `Microsoft.VisualStudio.Threading.IAsyncDisposable` interface is obsolete now that the
+`System.IAsyncDisposable` interface has been defined for .NET Standard 2.0 and .NET Framework 4.6.1
+by the [`Microsoft.Bcl.AsyncInterfaces` NuGet package](https://www.nuget.org/packages/Microsoft.Bcl.AsyncInterfaces).
+
+Existing code that tests for the `Microsoft.VisualStudio.Threading.IAsyncDisposable` interface on some object should also check for `System.IAsyncDisposable` and behave similarly in either case.
+New code should consider only supporting the new `System.IAsyncDisposable` interface.
+
+## Examples of patterns that are flagged by this analyzer
+
+The following code only checks for the obsolete interface and is flagged by this diagnostic:
+
+```cs
+using Microsoft.VisualStudio.Threading;
+
+if (obj is IAsyncDisposable asyncDisposable)
+{
+    await asyncDisposable.DisposeAsync();
+}
+```
+
+## Solution
+
+Fix this by adding a code branch for the new interface that behaves similarly
+within the same containing code block:
+
+```cs
+if (obj is Microsoft.VisualStudio.Threading.IAsyncDisposable vsThreadingAsyncDisposable)
+{
+    await vsThreadingAsyncDisposable.DisposeAsync();
+}
+else if (obj is System.IAsyncDisposable bclAsyncDisposable)
+{
+    await bclAsyncDisposable.DisposeAsync();
+}
+```

--- a/doc/analyzers/index.md
+++ b/doc/analyzers/index.md
@@ -24,6 +24,8 @@ ID | Title | Severity | Supports | Default diagnostic severity
 [VSTHRD109](VSTHRD109.md) | Switch instead of assert in async methods | Advisory | [1st rule](../threading_rules.md#Rule1) | Error
 [VSTHRD110](VSTHRD110.md) | Observe result of async calls | Advisory | | Warning
 [VSTHRD111](VSTHRD111.md) | Use `.ConfigureAwait(bool)` | Advisory | | Hidden
+[VSTHRD112](VSTHRD112.md) | Implement `System.IAsyncDisposable` | Advisory | | Info
+[VSTHRD113](VSTHRD113.md) | Check for `System.IAsyncDisposable` | Advisory | | Info
 [VSTHRD200](VSTHRD200.md) | Use `Async` naming convention | Guideline | [VSTHRD103](VSTHRD103.md) | Warning
 
 ## Severity descriptions

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -31,7 +31,7 @@
   <ItemGroup Condition=" '$(MSBuildProjectExtension)' != '.vcxproj' ">
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" PrivateAssets="All" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.0.25" PrivateAssets="all" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.66" PrivateAssets="all" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.164" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.5.0" PrivateAssets="all" />
   </ItemGroup>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/SyntaxGeneratorExtensions.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/SyntaxGeneratorExtensions.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+
+namespace Microsoft.VisualStudio.Threading.Analyzers
+{
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.Editing;
+
+    internal static class SyntaxGeneratorExtensions
+    {
+        internal static SyntaxNode? TryGetContainingDeclaration(this SyntaxGenerator generator, SyntaxNode? node, DeclarationKind? kind = null)
+        {
+            if (node is null)
+            {
+                return null;
+            }
+
+            var declarationKind = generator.GetDeclarationKind(node);
+            while ((kind.HasValue && declarationKind != kind) || (!kind.HasValue && declarationKind == DeclarationKind.None))
+            {
+                node = generator.GetDeclaration(node.Parent);
+                if (node is null)
+                {
+                    return null;
+                }
+
+                declarationKind = generator.GetDeclarationKind(node);
+            }
+
+            return node;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/VSTHRD112ImplementSystemIAsyncDisposableCodeFix.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/VSTHRD112ImplementSystemIAsyncDisposableCodeFix.cs
@@ -1,0 +1,87 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+
+namespace Microsoft.VisualStudio.Threading.Analyzers
+{
+    using System.Collections.Immutable;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CodeActions;
+    using Microsoft.CodeAnalysis.CodeFixes;
+    using Microsoft.CodeAnalysis.Editing;
+
+    [ExportCodeFixProvider(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+    public class VSTHRD112ImplementSystemIAsyncDisposableCodeFix : CodeFixProvider
+    {
+        private static readonly ImmutableArray<string> ReusableFixableDiagnosticIds = ImmutableArray.Create(
+            VSTHRD112ImplementSystemIAsyncDisposableAnalyzer.Id);
+
+        public override ImmutableArray<string> FixableDiagnosticIds => ReusableFixableDiagnosticIds;
+
+        /// <inheritdoc />
+        public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            foreach (var diagnostic in context.Diagnostics)
+            {
+                var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken);
+                var compilation = await context.Document.Project.GetCompilationAsync(context.CancellationToken);
+                if (compilation is null)
+                {
+                    continue;
+                }
+
+                INamedTypeSymbol? bclAsyncDisposableType = compilation.GetTypeByMetadataName(Types.BclAsyncDisposable.FullName);
+                if (bclAsyncDisposableType is null)
+                {
+                    continue;
+                }
+
+                var syntaxRoot = await context.Document.GetSyntaxRootAsync(context.CancellationToken);
+                var generator = SyntaxGenerator.GetGenerator(context.Document);
+                var originalTypeDeclaration = generator.TryGetContainingDeclaration(syntaxRoot.FindNode(diagnostic.Location.SourceSpan));
+                if (originalTypeDeclaration is null)
+                {
+                    continue;
+                }
+
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        Strings.VSTHRD112_CodeFix_Title,
+                        ct =>
+                        {
+                            // Declare that the type implements the System.IAsyncDisposable interface.
+                            var newBaseType = generator.TypeExpression(bclAsyncDisposableType);
+                            var typeDeclaration = generator.AddInterfaceType(originalTypeDeclaration, newBaseType);
+
+                            // Implement the interface, if we're on a non-interface type.
+                            if (semanticModel.GetDeclaredSymbol(originalTypeDeclaration, ct) is ITypeSymbol changedSymbol && changedSymbol.TypeKind != TypeKind.Interface)
+                            {
+                                var disposeAsyncMethod = (IMethodSymbol)bclAsyncDisposableType.GetMembers().Single();
+                                typeDeclaration = generator.AddMembers(
+                                    typeDeclaration,
+                                    generator.AsPrivateInterfaceImplementation(
+                                        generator.MethodDeclaration(
+                                            disposeAsyncMethod.Name,
+                                            returnType: generator.TypeExpression(disposeAsyncMethod.ReturnType),
+                                            accessibility: Accessibility.Public,
+                                            statements: new SyntaxNode[]
+                                            {
+                                                generator.ReturnStatement(
+                                                    generator.ObjectCreationExpression(
+                                                        disposeAsyncMethod.ReturnType,
+                                                        generator.InvocationExpression(
+                                                            generator.MemberAccessExpression(generator.ThisExpression(), "DisposeAsync")))),
+                                            }),
+                                        generator.TypeExpression(bclAsyncDisposableType)));
+                            }
+
+                            return Task.FromResult(context.Document.WithSyntaxRoot(syntaxRoot.ReplaceNode(originalTypeDeclaration, typeDeclaration)));
+                        },
+                        "AddBaseType"),
+                    diagnostic);
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/Helpers/ReferencesHelper.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/Helpers/ReferencesHelper.cs
@@ -12,5 +12,13 @@ namespace Microsoft.VisualStudio.Threading.Analyzers.Tests
                 new PackageIdentity("System.Collections.Immutable", "1.3.1"),
                 new PackageIdentity("System.Threading.Tasks.Extensions", "4.5.3"),
                 new PackageIdentity("Microsoft.Bcl.AsyncInterfaces", "1.1.0")));
+
+        internal static readonly ImmutableArray<string> VSSDKPackageReferences = ImmutableArray.Create(new string[] {
+                "Microsoft.VisualStudio.Shell.Interop.dll",
+                "Microsoft.VisualStudio.Shell.Interop.11.0.dll",
+                "Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime.dll",
+                "Microsoft.VisualStudio.Shell.Immutable.14.0.dll",
+                "Microsoft.VisualStudio.Shell.14.0.dll",
+            });
     }
 }

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/Helpers/VisualBasicCodeFixVerifierCodeFixVerifier`2+Test.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/Helpers/VisualBasicCodeFixVerifierCodeFixVerifier`2+Test.cs
@@ -7,19 +7,17 @@ namespace Microsoft.VisualStudio.Threading.Analyzers.Tests
     using System.IO;
     using System.Linq;
     using System.Reflection;
-    using System.Runtime.CompilerServices;
-    using System.Threading.Tasks;
     using System.Windows.Threading;
     using Microsoft.CodeAnalysis;
-    using Microsoft.CodeAnalysis.CSharp;
-    using Microsoft.CodeAnalysis.CSharp.Testing;
     using Microsoft.CodeAnalysis.Testing.Verifiers;
     using Microsoft.CodeAnalysis.Text;
+    using Microsoft.CodeAnalysis.VisualBasic;
+    using Microsoft.CodeAnalysis.VisualBasic.Testing;
     using IOleServiceProvider = Microsoft.VisualStudio.OLE.Interop.IServiceProvider;
 
-    public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
+    public static partial class VisualBasicCodeFixVerifier<TAnalyzer, TCodeFix>
     {
-        public class Test : CSharpCodeFixTest<TAnalyzer, TCodeFix, XUnitVerifier>
+        public class Test : VisualBasicCodeFixTest<TAnalyzer, TCodeFix, XUnitVerifier>
         {
             public Test()
             {
@@ -27,8 +25,8 @@ namespace Microsoft.VisualStudio.Threading.Analyzers.Tests
 
                 this.SolutionTransforms.Add((solution, projectId) =>
                 {
-                    var parseOptions = (CSharpParseOptions)solution.GetProject(projectId).ParseOptions;
-                    solution = solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(LanguageVersion.CSharp7_1));
+                    var parseOptions = (VisualBasicParseOptions)solution.GetProject(projectId).ParseOptions;
+                    solution = solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(LanguageVersion.VisualBasic15_5));
 
                     if (this.HasEntryPoint)
                     {

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/Helpers/VisualBasicCodeFixVerifierCodeFixVerifier`2.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/Helpers/VisualBasicCodeFixVerifierCodeFixVerifier`2.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.Threading.Analyzers.Tests
+{
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CodeFixes;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using Microsoft.CodeAnalysis.Testing;
+    using Microsoft.CodeAnalysis.Testing.Verifiers;
+    using Microsoft.CodeAnalysis.VisualBasic.Testing;
+
+    public static partial class VisualBasicCodeFixVerifier<TAnalyzer, TCodeFix>
+        where TAnalyzer : DiagnosticAnalyzer, new()
+        where TCodeFix : CodeFixProvider, new()
+    {
+        public static DiagnosticResult Diagnostic()
+            => VisualBasicCodeFixVerifier<TAnalyzer, TCodeFix, XUnitVerifier>.Diagnostic();
+
+        public static DiagnosticResult Diagnostic(string diagnosticId)
+            => VisualBasicCodeFixVerifier<TAnalyzer, TCodeFix, XUnitVerifier>.Diagnostic(diagnosticId);
+
+        public static DiagnosticResult Diagnostic(DiagnosticDescriptor descriptor)
+            => new DiagnosticResult(descriptor);
+
+        public static Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
+        {
+            var test = new Test { TestCode = source };
+            test.ExpectedDiagnostics.AddRange(expected);
+            return test.RunAsync();
+        }
+
+        public static Task VerifyCodeFixAsync(string source, string fixedSource)
+            => VerifyCodeFixAsync(source, DiagnosticResult.EmptyDiagnosticResults, fixedSource);
+
+        public static Task VerifyCodeFixAsync(string source, DiagnosticResult expected, string fixedSource)
+            => VerifyCodeFixAsync(source, new[] { expected }, fixedSource);
+
+        public static Task VerifyCodeFixAsync(string source, DiagnosticResult[] expected, string fixedSource)
+        {
+            var test = new Test
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+            };
+
+            test.ExpectedDiagnostics.AddRange(expected);
+            return test.RunAsync();
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD112ImplementSystemIAsyncDisposableAnalyzerTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD112ImplementSystemIAsyncDisposableAnalyzerTests.cs
@@ -1,0 +1,304 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+
+namespace Microsoft.VisualStudio.Threading.Analyzers.Tests
+{
+    using System.Threading.Tasks;
+    using Xunit;
+    using VBVerify = VisualBasicCodeFixVerifier<VSTHRD112ImplementSystemIAsyncDisposableAnalyzer, VSTHRD112ImplementSystemIAsyncDisposableCodeFix>;
+    using Verify = CSharpCodeFixVerifier<VSTHRD112ImplementSystemIAsyncDisposableAnalyzer, VSTHRD112ImplementSystemIAsyncDisposableCodeFix>;
+
+    public class VSTHRD112ImplementSystemIAsyncDisposableAnalyzerTests
+    {
+        private const string Preamble = @"
+using System.Threading.Tasks;
+using BclAsyncDisposable = System.IAsyncDisposable;
+using VsThreadingAsyncDisposable = Microsoft.VisualStudio.Threading.IAsyncDisposable;
+";
+
+        private const string VBPreamble = @"
+Imports System.Threading.Tasks
+Imports BclAsyncDisposable = System.IAsyncDisposable
+Imports VsThreadingAsyncDisposable = Microsoft.VisualStudio.Threading.IAsyncDisposable
+";
+
+        [Fact]
+        public async Task ClassImplementsBoth()
+        {
+            var test = Preamble + @"
+class Test : BclAsyncDisposable, VsThreadingAsyncDisposable
+{
+    Task Microsoft.VisualStudio.Threading.IAsyncDisposable.DisposeAsync()
+    {
+        // Simply forward the call to the other DisposeAsync overload.
+        System.IAsyncDisposable self = this;
+        return self.DisposeAsync().AsTask();
+    }
+
+    ValueTask System.IAsyncDisposable.DisposeAsync() => default;
+}";
+
+            await Verify.VerifyAnalyzerAsync(test);
+        }
+
+        [Fact]
+        public async Task ClassImplementsOnlyBclType()
+        {
+            var test = Preamble + @"
+class Test : BclAsyncDisposable
+{
+    ValueTask System.IAsyncDisposable.DisposeAsync() => default;
+}";
+
+            await Verify.VerifyAnalyzerAsync(test);
+        }
+
+        [Fact]
+        public async Task ClassImplementsOnlyVsThreadingType()
+        {
+            var test = Preamble + @"
+class Test : [|VsThreadingAsyncDisposable|]
+{
+    public async Task DisposeAsync()
+    {
+        await Task.Yield();
+    }
+}";
+
+            var fix = Preamble + @"
+class Test : VsThreadingAsyncDisposable, BclAsyncDisposable
+{
+    public async Task DisposeAsync()
+    {
+        await Task.Yield();
+    }
+
+    ValueTask BclAsyncDisposable.DisposeAsync()
+    {
+        return new ValueTask(DisposeAsync());
+    }
+}";
+
+            await Verify.VerifyCodeFixAsync(test, fix);
+        }
+
+        [Fact]
+        public async Task ClassImplementsOnlyVsThreadingType_WithBaseClassToo()
+        {
+            var test = Preamble + @"
+class Test : object, [|VsThreadingAsyncDisposable|]
+{
+    public async Task DisposeAsync()
+    {
+        await Task.Yield();
+    }
+}";
+
+            var fix = Preamble + @"
+class Test : object, VsThreadingAsyncDisposable, BclAsyncDisposable
+{
+    public async Task DisposeAsync()
+    {
+        await Task.Yield();
+    }
+
+    ValueTask BclAsyncDisposable.DisposeAsync()
+    {
+        return new ValueTask(DisposeAsync());
+    }
+}";
+
+            await Verify.VerifyCodeFixAsync(test, fix);
+        }
+
+        [Fact]
+        public async Task ClassImplementsOnlyVsThreadingType_WithBaseClassToo_VB()
+        {
+            var test = VBPreamble + @"
+Class Test
+    Inherits Object
+    Implements [|VsThreadingAsyncDisposable|]
+
+    Public Async Function DisposeAsync() As Task Implements VsThreadingAsyncDisposable.DisposeAsync
+        Await Task.Yield
+    End Function
+End Class";
+
+            var fix = VBPreamble + @"
+Class Test
+    Inherits Object
+    Implements VsThreadingAsyncDisposable, BclAsyncDisposable
+
+    Public Async Function DisposeAsync() As Task Implements VsThreadingAsyncDisposable.DisposeAsync
+        Await Task.Yield
+    End Function
+
+    Private Function IAsyncDisposable_DisposeAsync() As ValueTask Implements BclAsyncDisposable.DisposeAsync
+        Return New ValueTask(DisposeAsync())
+    End Function
+End Class";
+
+            await VBVerify.VerifyCodeFixAsync(test, fix);
+        }
+
+        [Fact]
+        public async Task StructImplementsBoth()
+        {
+            var test = Preamble + @"
+struct Test : BclAsyncDisposable, VsThreadingAsyncDisposable
+{
+    public Task DisposeAsync()
+    {
+        // Simply forward the call to the other DisposeAsync overload.
+        System.IAsyncDisposable self = this;
+        return self.DisposeAsync().AsTask();
+    }
+
+    ValueTask BclAsyncDisposable.DisposeAsync()
+    {
+        return new ValueTask(DisposeAsync());
+    }
+}";
+
+            await Verify.VerifyAnalyzerAsync(test);
+        }
+
+        [Fact]
+        public async Task StructImplementsOnlyBclType()
+        {
+            var test = Preamble + @"
+struct Test : BclAsyncDisposable
+{
+    ValueTask System.IAsyncDisposable.DisposeAsync() => default;
+}";
+
+            await Verify.VerifyAnalyzerAsync(test);
+        }
+
+        [Fact]
+        public async Task StructImplementsOnlyVsThreadingType()
+        {
+            var test = Preamble + @"
+struct Test : [|VsThreadingAsyncDisposable|]
+{
+    public async Task DisposeAsync()
+    {
+        await Task.Yield();
+    }
+}";
+
+            var fix = Preamble + @"
+struct Test : VsThreadingAsyncDisposable, BclAsyncDisposable
+{
+    public async Task DisposeAsync()
+    {
+        await Task.Yield();
+    }
+
+    ValueTask BclAsyncDisposable.DisposeAsync()
+    {
+        return new ValueTask(DisposeAsync());
+    }
+}";
+
+            await Verify.VerifyCodeFixAsync(test, fix);
+        }
+
+        [Fact]
+        public async Task StructImplementsOnlyVsThreadingType_VB()
+        {
+            var test = VBPreamble + @"
+Public Structure Test
+    Implements [|VsThreadingAsyncDisposable|]
+
+    Public Async Function DisposeAsync() As Task Implements VsThreadingAsyncDisposable.DisposeAsync
+        Await Task.Yield
+    End Function
+End Structure";
+
+            var fix = VBPreamble + @"
+Public Structure Test
+    Implements VsThreadingAsyncDisposable, BclAsyncDisposable
+
+    Public Async Function DisposeAsync() As Task Implements VsThreadingAsyncDisposable.DisposeAsync
+        Await Task.Yield
+    End Function
+
+    Private Function IAsyncDisposable_DisposeAsync() As ValueTask Implements BclAsyncDisposable.DisposeAsync
+        Return New ValueTask(DisposeAsync())
+    End Function
+End Structure";
+
+            await VBVerify.VerifyCodeFixAsync(test, fix);
+        }
+
+        [Fact]
+        public async Task InterfaceImplementsBoth()
+        {
+            var test = Preamble + @"
+interface Test : BclAsyncDisposable, VsThreadingAsyncDisposable
+{
+}";
+
+            await Verify.VerifyAnalyzerAsync(test);
+        }
+
+        [Fact]
+        public async Task InterfaceImplementsBoth_AcrossTypeHierarchy()
+        {
+            var test = Preamble + @"
+interface Test1 : BclAsyncDisposable
+{
+}
+
+interface Test2 : Test1, VsThreadingAsyncDisposable
+{
+}
+";
+
+            await Verify.VerifyAnalyzerAsync(test);
+        }
+
+        [Fact]
+        public async Task InterfaceImplementsOnlyBclType()
+        {
+            var test = Preamble + @"
+interface Test : BclAsyncDisposable
+{
+}";
+
+            await Verify.VerifyAnalyzerAsync(test);
+        }
+
+        [Fact]
+        public async Task InterfaceImplementsOnlyVsThreadingType()
+        {
+            var test = Preamble + @"
+interface Test : [|VsThreadingAsyncDisposable|]
+{
+}";
+
+            var fix = Preamble + @"
+interface Test : VsThreadingAsyncDisposable, BclAsyncDisposable
+{
+}";
+
+            await Verify.VerifyCodeFixAsync(test, fix);
+        }
+
+        [Fact]
+        public async Task InterfaceImplementsOnlyVsThreadingType_VB()
+        {
+            var test = VBPreamble + @"
+Interface ITest
+    Inherits [|VsThreadingAsyncDisposable|]
+End Interface";
+
+            var fix = VBPreamble + @"
+Interface ITest
+    Inherits VsThreadingAsyncDisposable, BclAsyncDisposable
+End Interface";
+
+            await VBVerify.VerifyCodeFixAsync(test, fix);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD113CheckForSystemIAsyncDisposableAnalyzerTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD113CheckForSystemIAsyncDisposableAnalyzerTests.cs
@@ -1,0 +1,271 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+
+namespace Microsoft.VisualStudio.Threading.Analyzers.Tests
+{
+    using System.Threading.Tasks;
+    using Xunit;
+    using VBVerify = VisualBasicCodeFixVerifier<VSTHRD113CheckForSystemIAsyncDisposableAnalyzer, Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+    using Verify = CSharpCodeFixVerifier<VSTHRD113CheckForSystemIAsyncDisposableAnalyzer, Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+
+    public class VSTHRD113CheckForSystemIAsyncDisposableAnalyzerTests
+    {
+        private const string Preamble = @"
+using System.Threading.Tasks;
+using BclAsyncDisposable = System.IAsyncDisposable;
+using VsThreadingAsyncDisposable = Microsoft.VisualStudio.Threading.IAsyncDisposable;
+";
+
+        private const string VBPreamble = @"
+Imports System.Threading.Tasks
+Imports BclAsyncDisposable = System.IAsyncDisposable
+Imports VsThreadingAsyncDisposable = Microsoft.VisualStudio.Threading.IAsyncDisposable
+";
+
+        [Fact]
+        public async Task MethodChecksBoth_WithIsCast()
+        {
+            var test = Preamble + @"
+class Test {
+    async Task CheckAndDispose(object o) {
+        if (o is BclAsyncDisposable bcl) {
+            await bcl.DisposeAsync();
+        }
+        else if (o is VsThreadingAsyncDisposable vs) {
+            await vs.DisposeAsync();
+        }
+    }
+}";
+
+            await Verify.VerifyAnalyzerAsync(test);
+        }
+
+        [Fact]
+        public async Task MethodChecksBoth_WithIsCheck()
+        {
+            var test = Preamble + @"
+class Test {
+    async Task CheckAndDispose(object o) {
+        if (o is BclAsyncDisposable) {
+            await ((BclAsyncDisposable)o).DisposeAsync();
+        }
+        else if (o is VsThreadingAsyncDisposable) {
+            await ((VsThreadingAsyncDisposable)o).DisposeAsync();
+        }
+    }
+}";
+
+            await Verify.VerifyAnalyzerAsync(test);
+        }
+
+        [Fact]
+        public async Task MethodChecksVsThreadingOnly_WithIsCheck()
+        {
+            var test = Preamble + @"
+class Test {
+    async Task CheckAndDispose(object o) {
+        if ([|o is VsThreadingAsyncDisposable|]) {
+            await ([|(VsThreadingAsyncDisposable)o|]).DisposeAsync();
+        }
+    }
+}";
+
+            await Verify.VerifyAnalyzerAsync(test);
+        }
+
+        [Fact]
+        public async Task MethodChecksVsThreadingOnly_WithIsCast()
+        {
+            var test = Preamble + @"
+class Test {
+    async Task CheckAndDispose(object o) {
+        if ([|o is VsThreadingAsyncDisposable vs|]) {
+            await vs.DisposeAsync();
+        }
+    }
+}";
+
+            await Verify.VerifyAnalyzerAsync(test);
+        }
+
+        [Fact(Skip = "Too complex to support")]
+        public async Task MethodChecksVsThreadingOnly_WithIsCast_MultiBlock()
+        {
+            var test = Preamble + @"
+class Test {
+    async Task CheckAndDispose(object o, bool flag) {
+        if (flag) {
+            if (o is BclAsyncDisposable bcl) {
+                await bcl.DisposeAsync();
+            }
+            if (o is VsThreadingAsyncDisposable vs) {
+                await vs.DisposeAsync();
+            }
+        } else {
+            if ([|o is VsThreadingAsyncDisposable vs|]) {
+                await vs.DisposeAsync();
+            }
+        }
+    }
+}";
+
+            await Verify.VerifyAnalyzerAsync(test);
+        }
+
+        [Fact]
+        public async Task MethodChecksBclOnly_WithIsCast()
+        {
+            var test = Preamble + @"
+class Test {
+    async Task CheckAndDispose(object o) {
+        if (o is BclAsyncDisposable bcl) {
+            await bcl.DisposeAsync();
+        }
+    }
+}";
+
+            await Verify.VerifyAnalyzerAsync(test);
+        }
+
+        [Fact]
+        public async Task MethodChecksBoth_WithAsCast()
+        {
+            var test = Preamble + @"
+class Test {
+    async Task CheckAndDispose(object o) {
+        await ((o as BclAsyncDisposable)?.DisposeAsync() ?? default);
+        await ((o as VsThreadingAsyncDisposable)?.DisposeAsync() ?? Task.CompletedTask);
+    }
+}";
+
+            await Verify.VerifyAnalyzerAsync(test);
+        }
+
+        [Fact]
+        public async Task MethodChecksVsThreadingOnly_WithAsCast()
+        {
+            var test = Preamble + @"
+class Test {
+    async Task CheckAndDispose(object o) {
+        await (([|o as VsThreadingAsyncDisposable|])?.DisposeAsync() ?? Task.CompletedTask);
+    }
+}";
+
+            await Verify.VerifyAnalyzerAsync(test);
+        }
+
+        [Fact]
+        public async Task MethodChecksBoth_WithTryCast_VB()
+        {
+            var test = VBPreamble + @"
+Class Test
+    Async Function CheckAndDispose(o) As Task
+        Dim bcl = TryCast(o, BclAsyncDisposable)
+        If (bcl IsNot Nothing) Then
+            Await bcl.DisposeAsync
+        End If
+        Dim vs = TryCast(o, VsThreadingAsyncDisposable)
+        If (vs IsNot Nothing) Then
+            Await vs.DisposeAsync
+        End If
+    End Function
+End Class";
+
+            await VBVerify.VerifyAnalyzerAsync(test);
+        }
+
+        [Fact]
+        public async Task MethodChecksVsThreadingOnly_WithTypeOf_VB()
+        {
+            var test = VBPreamble + @"
+Class Test
+    Async Function CheckAndDispose(o) As Task
+        If ([|TypeOf o Is VsThreadingAsyncDisposable|]) Then
+        End If
+    End Function
+End Class";
+
+            await VBVerify.VerifyAnalyzerAsync(test);
+        }
+
+        [Fact]
+        public async Task MethodChecksVsThreadingOnly_WithTryCast_VB()
+        {
+            var test = VBPreamble + @"
+Class Test
+    Async Function CheckAndDispose(o) As Task
+        Dim vs = [|TryCast(o, VsThreadingAsyncDisposable)|]
+        If (vs IsNot Nothing) Then
+            Await vs.DisposeAsync
+        End If
+    End Function
+End Class";
+
+            await VBVerify.VerifyAnalyzerAsync(test);
+        }
+
+        [Fact]
+        public async Task MethodChecksVsThreadingOnly_WithCType_VB()
+        {
+            var test = VBPreamble + @"
+Class Test
+    Async Function CheckAndDispose(o) As Task
+        Dim vs = [|CType(o, VsThreadingAsyncDisposable)|]
+        Await vs.DisposeAsync
+    End Function
+End Class";
+
+            await VBVerify.VerifyAnalyzerAsync(test);
+        }
+
+        [Fact]
+        public async Task MethodChecksBoth_WithCType_VB()
+        {
+            var test = VBPreamble + @"
+Class Test
+    Async Function CheckAndDispose(o) As Task
+        If (TypeOf o Is VsThreadingAsyncDisposable) Then
+            Dim vs = CType(o, VsThreadingAsyncDisposable)
+            Await vs.DisposeAsync
+        ElseIf (TypeOf o Is BclAsyncDisposable) Then
+            Dim bcl = CType(o, BclAsyncDisposable)
+            Await bcl.DisposeAsync
+        End If
+    End Function
+End Class";
+
+            await VBVerify.VerifyAnalyzerAsync(test);
+        }
+
+        [Fact]
+        public async Task MethodChecksBoth_WithDirectCast_VB()
+        {
+            var test = VBPreamble + @"
+Class Test
+    Async Function CheckAndDispose(o) As Task
+        If (TypeOf o Is VsThreadingAsyncDisposable) Then
+            Dim vs = DirectCast(o, VsThreadingAsyncDisposable)
+            Await vs.DisposeAsync
+        ElseIf (TypeOf o Is BclAsyncDisposable) Then
+            Dim bcl = DirectCast(o, BclAsyncDisposable)
+            Await bcl.DisposeAsync
+        End If
+    End Function
+End Class";
+
+            await VBVerify.VerifyAnalyzerAsync(test);
+        }
+
+        [Fact]
+        public async Task MethodChecksBclOnly_WithAsCast()
+        {
+            var test = Preamble + @"
+class Test {
+    async Task CheckAndDispose(object o) {
+        await ((o as BclAsyncDisposable)?.DisposeAsync() ?? default);
+    }
+}";
+
+            await Verify.VerifyAnalyzerAsync(test);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Microsoft.VisualStudio.Threading.Analyzers.csproj
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Microsoft.VisualStudio.Threading.Analyzers.csproj
@@ -30,6 +30,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.8.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="2.8.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.6" PrivateAssets="all" />
     <PackageReference Include="MicroBuild.VisualStudio" Version="$(MicroBuildVersion)" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.3" />

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.Designer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.Designer.cs
@@ -70,6 +70,15 @@ namespace Microsoft.VisualStudio.Threading.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The System.IAsyncDisposable interface is defined in the Microsoft.Bcl.AsyncInterfaces NuGet package..
+        /// </summary>
+        internal static string SystemIAsyncDisposablePackageNote {
+            get {
+                return ResourceManager.GetString("SystemIAsyncDisposablePackageNote", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Use await instead.
         /// </summary>
         internal static string UseAwaitInstead {
@@ -492,6 +501,51 @@ namespace Microsoft.VisualStudio.Threading.Analyzers {
         internal static string VSTHRD111_Title {
             get {
                 return ResourceManager.GetString("VSTHRD111_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Add implementation of System.IAsyncDisposable..
+        /// </summary>
+        internal static string VSTHRD112_CodeFix_Title {
+            get {
+                return ResourceManager.GetString("VSTHRD112_CodeFix_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Implement the System.IAsyncDisposable interface when implementing the obsolete Microsoft.VisualStudio.Threading.IAsyncDisposable interface..
+        /// </summary>
+        internal static string VSTHRD112_MessageFormat {
+            get {
+                return ResourceManager.GetString("VSTHRD112_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Implement System.IAsyncDisposable.
+        /// </summary>
+        internal static string VSTHRD112_Title {
+            get {
+                return ResourceManager.GetString("VSTHRD112_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Add a check for System.IAsyncDisposable in the same code block that checks for Microsoft.VisualStudio.Threading.IAsyncDisposable that behaves similarly..
+        /// </summary>
+        internal static string VSTHRD113_MessageFormat {
+            get {
+                return ResourceManager.GetString("VSTHRD113_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Check for System.IAsyncDisposable.
+        /// </summary>
+        internal static string VSTHRD113_Title {
+            get {
+                return ResourceManager.GetString("VSTHRD113_Title", resourceCulture);
             }
         }
         

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.resx
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Strings.resx
@@ -309,4 +309,22 @@ Use AsyncLazy&lt;T&gt; instead.</value>
     <value>Call ThrowIfCancellationRequested()</value>
     <comment>"ThrowIfCancellationRequested" is a method name and should not be translated.</comment>
   </data>
+  <data name="VSTHRD112_CodeFix_Title" xml:space="preserve">
+    <value>Add implementation of System.IAsyncDisposable.</value>
+  </data>
+  <data name="VSTHRD112_MessageFormat" xml:space="preserve">
+    <value>Implement the System.IAsyncDisposable interface when implementing the obsolete Microsoft.VisualStudio.Threading.IAsyncDisposable interface.</value>
+  </data>
+  <data name="VSTHRD112_Title" xml:space="preserve">
+    <value>Implement System.IAsyncDisposable</value>
+  </data>
+  <data name="VSTHRD113_MessageFormat" xml:space="preserve">
+    <value>Add a check for System.IAsyncDisposable in the same code block that checks for Microsoft.VisualStudio.Threading.IAsyncDisposable that behaves similarly.</value>
+  </data>
+  <data name="VSTHRD113_Title" xml:space="preserve">
+    <value>Check for System.IAsyncDisposable</value>
+  </data>
+  <data name="SystemIAsyncDisposablePackageNote" xml:space="preserve">
+    <value>The System.IAsyncDisposable interface is defined in the Microsoft.Bcl.AsyncInterfaces NuGet package.</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Types.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Types.cs
@@ -14,6 +14,18 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
     /// </summary>
     internal static class Types
     {
+        internal static class BclAsyncDisposable
+        {
+            internal const string FullName = "System.IAsyncDisposable";
+
+            internal const string PackageId = "Microsoft.Bcl.AsyncInterfaces";
+        }
+
+        internal static class IAsyncDisposable
+        {
+            internal const string FullName = "Microsoft.VisualStudio.Threading.IAsyncDisposable";
+        }
+
         internal static class AwaitExtensions
         {
             /// <summary>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD112ImplementSystemIAsyncDisposableAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD112ImplementSystemIAsyncDisposableAnalyzer.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+
+namespace Microsoft.VisualStudio.Threading.Analyzers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Linq;
+    using System.Text;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.Diagnostics;
+
+    /// <summary>
+    /// Verifies that types that implement vs-threading's IAsyncDisposable interface also implement System.IAsyncDisposable.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+    public class VSTHRD112ImplementSystemIAsyncDisposableAnalyzer : DiagnosticAnalyzer
+    {
+        public const string Id = "VSTHRD112";
+
+        internal static readonly DiagnosticDescriptor Descriptor = new DiagnosticDescriptor(
+            id: Id,
+            title: new LocalizableResourceString(nameof(Strings.VSTHRD112_Title), Strings.ResourceManager, typeof(Strings)),
+            messageFormat: new LocalizableResourceString(nameof(Strings.VSTHRD112_MessageFormat), Strings.ResourceManager, typeof(Strings)),
+            description: new LocalizableResourceString(nameof(Strings.SystemIAsyncDisposablePackageNote), Strings.ResourceManager, typeof(Strings)),
+            helpLinkUri: Utils.GetHelpLink(Id),
+            category: "Usage",
+            defaultSeverity: DiagnosticSeverity.Info,
+            isEnabledByDefault: true);
+
+        /// <inheritdoc />
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptor);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze);
+
+            context.RegisterCompilationStartAction(startCompilation =>
+            {
+                INamedTypeSymbol? vsThreadingAsyncDisposableType = startCompilation.Compilation.GetTypeByMetadataName(Types.IAsyncDisposable.FullName);
+                INamedTypeSymbol? bclAsyncDisposableType = startCompilation.Compilation.GetTypeByMetadataName(Types.BclAsyncDisposable.FullName);
+                if (vsThreadingAsyncDisposableType is object)
+                {
+                    startCompilation.RegisterSymbolAction(Utils.DebuggableWrapper(c => this.AnalyzeType(c, vsThreadingAsyncDisposableType, bclAsyncDisposableType)), SymbolKind.NamedType);
+                }
+            });
+        }
+
+        private void AnalyzeType(SymbolAnalysisContext context, INamedTypeSymbol vsThreadingAsyncDisposableType, INamedTypeSymbol bclAsyncDisposableType)
+        {
+            var symbol = (INamedTypeSymbol)context.Symbol;
+            if (symbol.Interfaces.Contains(vsThreadingAsyncDisposableType))
+            {
+                if (bclAsyncDisposableType is null || !symbol.AllInterfaces.Contains(bclAsyncDisposableType))
+                {
+                    context.ReportDiagnostic(
+                        Diagnostic.Create(
+                            Descriptor,
+                            Utils.GetLocationOfBaseTypeName(symbol, vsThreadingAsyncDisposableType, context.Compilation, context.CancellationToken)));
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD113CheckForSystemIAsyncDisposableAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD113CheckForSystemIAsyncDisposableAnalyzer.cs
@@ -1,0 +1,104 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+
+namespace Microsoft.VisualStudio.Threading.Analyzers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Linq;
+    using System.Reflection.Emit;
+    using System.Text;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using Microsoft.CodeAnalysis.Operations;
+
+    /// <summary>
+    /// Verifies that code that performs type checks for vs-threading's IAsyncDisposable interface also check for System.IAsyncDisposable.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+    public class VSTHRD113CheckForSystemIAsyncDisposableAnalyzer : DiagnosticAnalyzer
+    {
+        public const string Id = "VSTHRD113";
+
+        internal static readonly DiagnosticDescriptor Descriptor = new DiagnosticDescriptor(
+            id: Id,
+            title: new LocalizableResourceString(nameof(Strings.VSTHRD113_Title), Strings.ResourceManager, typeof(Strings)),
+            messageFormat: new LocalizableResourceString(nameof(Strings.VSTHRD113_MessageFormat), Strings.ResourceManager, typeof(Strings)),
+            description: new LocalizableResourceString(nameof(Strings.SystemIAsyncDisposablePackageNote), Strings.ResourceManager, typeof(Strings)),
+            helpLinkUri: Utils.GetHelpLink(Id),
+            category: "Usage",
+            defaultSeverity: DiagnosticSeverity.Info,
+            isEnabledByDefault: true);
+
+        /// <inheritdoc />
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptor);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze);
+
+            context.RegisterCompilationStartAction(startCompilation =>
+            {
+                INamedTypeSymbol? vsThreadingAsyncDisposableType = startCompilation.Compilation.GetTypeByMetadataName(Types.IAsyncDisposable.FullName);
+                INamedTypeSymbol? bclAsyncDisposableType = startCompilation.Compilation.GetTypeByMetadataName(Types.BclAsyncDisposable.FullName);
+                if (vsThreadingAsyncDisposableType is object)
+                {
+                    startCompilation.RegisterOperationAction(Utils.DebuggableWrapper(c => this.AnalyzeTypeCheck(c, vsThreadingAsyncDisposableType, bclAsyncDisposableType)), OperationKind.IsType);
+                    startCompilation.RegisterOperationAction(Utils.DebuggableWrapper(c => this.AnalyzeTypeCheck(c, vsThreadingAsyncDisposableType, bclAsyncDisposableType)), OperationKind.IsPattern);
+                    startCompilation.RegisterOperationAction(Utils.DebuggableWrapper(c => this.AnalyzeTypeCheck(c, vsThreadingAsyncDisposableType, bclAsyncDisposableType)), OperationKind.Conversion);
+                }
+            });
+        }
+
+        private void AnalyzeTypeCheck(OperationAnalysisContext context, INamedTypeSymbol vsThreadingAsyncDisposableType, INamedTypeSymbol bclAsyncDisposableType)
+        {
+            switch (context.Operation)
+            {
+                case IIsTypeOperation { TypeOperand: { } operand }:
+                    ConsiderTypeCheck(context, operand, vsThreadingAsyncDisposableType, bclAsyncDisposableType);
+                    break;
+                case IIsPatternOperation { Pattern: IDeclarationPatternOperation { DeclaredSymbol: ILocalSymbol { Type: { } operand } } }:
+                    ConsiderTypeCheck(context, operand, vsThreadingAsyncDisposableType, bclAsyncDisposableType);
+                    break;
+                case IConversionOperation { Type: { } operand }:
+                    ConsiderTypeCheck(context, operand, vsThreadingAsyncDisposableType, bclAsyncDisposableType);
+                    break;
+            }
+
+            static void ConsiderTypeCheck(OperationAnalysisContext context, ITypeSymbol operand, INamedTypeSymbol vsThreadingAsyncDisposableType, INamedTypeSymbol bclAsyncDisposableType)
+            {
+                if (Equals(vsThreadingAsyncDisposableType, operand))
+                {
+                    // If the System.IAsyncDisposable type is defined, search for a check for that type and skip the diagnostic if we find one.
+                    if (bclAsyncDisposableType is object)
+                    {
+                        IOperation methodBlock = Utils.FindFinalAncestor(context.Operation);
+                        if (methodBlock.Descendants().Any(op => IsTypeCheck(op, bclAsyncDisposableType)))
+                        {
+                            // We found a matching check for the BCL type. No diagnostic to report.
+                            return;
+                        }
+                    }
+
+                    context.ReportDiagnostic(Diagnostic.Create(Descriptor, context.Operation.Syntax.GetLocation()));
+                }
+            }
+
+            static bool IsTypeCheck(IOperation operation, INamedTypeSymbol typeChecked)
+            {
+                switch (operation)
+                {
+                    case IIsTypeOperation { TypeOperand: { } operand }:
+                        return Equals(typeChecked, operand);
+                    case IDeclarationPatternOperation { DeclaredSymbol: ILocalSymbol { Type: { } operand } }:
+                        return Equals(typeChecked, operand);
+                    case IConversionOperation { Type: { } operand }:
+                        return Equals(typeChecked, operand);
+                    default:
+                        return false;
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.cs.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.cs.xlf
@@ -8,6 +8,11 @@
         <note from="MultilingualBuild" annotates="source" priority="2">"await" is a C# keyword and should not be translated.
 {0} is a method name.</note>
       </trans-unit>
+      <trans-unit id="SystemIAsyncDisposablePackageNote">
+        <source>The System.IAsyncDisposable interface is defined in the Microsoft.Bcl.AsyncInterfaces NuGet package.</source>
+        <target state="new">The System.IAsyncDisposable interface is defined in the Microsoft.Bcl.AsyncInterfaces NuGet package.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseAwaitInstead" translate="yes" xml:space="preserve">
         <source>Use await instead</source>
         <target state="translated">Použijte raději await.</target>
@@ -248,6 +253,31 @@ Použijte místo toho AsyncLazy&lt;T&gt;.</target>
         <source>Use ConfigureAwait(bool)</source>
         <target state="translated">Používat ConfigureAwait(bool)</target>
         <note from="MultilingualBuild" annotates="source" priority="2">"ConfigureAwait(bool)" is a reference and should NOT be translated.</note>
+      </trans-unit>
+      <trans-unit id="VSTHRD112_CodeFix_Title">
+        <source>Add implementation of System.IAsyncDisposable.</source>
+        <target state="new">Add implementation of System.IAsyncDisposable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD112_MessageFormat">
+        <source>Implement the System.IAsyncDisposable interface when implementing the obsolete Microsoft.VisualStudio.Threading.IAsyncDisposable interface.</source>
+        <target state="new">Implement the System.IAsyncDisposable interface when implementing the obsolete Microsoft.VisualStudio.Threading.IAsyncDisposable interface.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD112_Title">
+        <source>Implement System.IAsyncDisposable</source>
+        <target state="new">Implement System.IAsyncDisposable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD113_MessageFormat">
+        <source>Add a check for System.IAsyncDisposable in the same code block that checks for Microsoft.VisualStudio.Threading.IAsyncDisposable that behaves similarly.</source>
+        <target state="new">Add a check for System.IAsyncDisposable in the same code block that checks for Microsoft.VisualStudio.Threading.IAsyncDisposable that behaves similarly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD113_Title">
+        <source>Check for System.IAsyncDisposable</source>
+        <target state="new">Check for System.IAsyncDisposable</target>
+        <note />
       </trans-unit>
       <trans-unit id="VSTHRD200_AddAsync_MessageFormat" translate="yes" xml:space="preserve">
         <source>Use "Async" suffix in names of methods that return an awaitable type.</source>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.de.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.de.xlf
@@ -8,6 +8,11 @@
         <note from="MultilingualBuild" annotates="source" priority="2">"await" is a C# keyword and should not be translated.
 {0} is a method name.</note>
       </trans-unit>
+      <trans-unit id="SystemIAsyncDisposablePackageNote">
+        <source>The System.IAsyncDisposable interface is defined in the Microsoft.Bcl.AsyncInterfaces NuGet package.</source>
+        <target state="new">The System.IAsyncDisposable interface is defined in the Microsoft.Bcl.AsyncInterfaces NuGet package.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseAwaitInstead" translate="yes" xml:space="preserve">
         <source>Use await instead</source>
         <target state="translated">Stattdessen "await" verwenden</target>
@@ -248,6 +253,31 @@ Verwenden Sie stattdessen "AsyncLazy&lt;T&gt;".</target>
         <source>Use ConfigureAwait(bool)</source>
         <target state="translated">ConfigureAwait(bool) verwenden</target>
         <note from="MultilingualBuild" annotates="source" priority="2">"ConfigureAwait(bool)" is a reference and should NOT be translated.</note>
+      </trans-unit>
+      <trans-unit id="VSTHRD112_CodeFix_Title">
+        <source>Add implementation of System.IAsyncDisposable.</source>
+        <target state="new">Add implementation of System.IAsyncDisposable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD112_MessageFormat">
+        <source>Implement the System.IAsyncDisposable interface when implementing the obsolete Microsoft.VisualStudio.Threading.IAsyncDisposable interface.</source>
+        <target state="new">Implement the System.IAsyncDisposable interface when implementing the obsolete Microsoft.VisualStudio.Threading.IAsyncDisposable interface.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD112_Title">
+        <source>Implement System.IAsyncDisposable</source>
+        <target state="new">Implement System.IAsyncDisposable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD113_MessageFormat">
+        <source>Add a check for System.IAsyncDisposable in the same code block that checks for Microsoft.VisualStudio.Threading.IAsyncDisposable that behaves similarly.</source>
+        <target state="new">Add a check for System.IAsyncDisposable in the same code block that checks for Microsoft.VisualStudio.Threading.IAsyncDisposable that behaves similarly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD113_Title">
+        <source>Check for System.IAsyncDisposable</source>
+        <target state="new">Check for System.IAsyncDisposable</target>
+        <note />
       </trans-unit>
       <trans-unit id="VSTHRD200_AddAsync_MessageFormat" translate="yes" xml:space="preserve">
         <source>Use "Async" suffix in names of methods that return an awaitable type.</source>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.es.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.es.xlf
@@ -8,6 +8,11 @@
         <note from="MultilingualBuild" annotates="source" priority="2">"await" is a C# keyword and should not be translated.
 {0} is a method name.</note>
       </trans-unit>
+      <trans-unit id="SystemIAsyncDisposablePackageNote">
+        <source>The System.IAsyncDisposable interface is defined in the Microsoft.Bcl.AsyncInterfaces NuGet package.</source>
+        <target state="new">The System.IAsyncDisposable interface is defined in the Microsoft.Bcl.AsyncInterfaces NuGet package.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseAwaitInstead" translate="yes" xml:space="preserve">
         <source>Use await instead</source>
         <target state="translated">Use await en su lugar</target>
@@ -248,6 +253,31 @@ Use AsyncLazy&lt;T&gt; en su lugar.</target>
         <source>Use ConfigureAwait(bool)</source>
         <target state="translated">Usar ConfigureAwait(bool)</target>
         <note from="MultilingualBuild" annotates="source" priority="2">"ConfigureAwait(bool)" is a reference and should NOT be translated.</note>
+      </trans-unit>
+      <trans-unit id="VSTHRD112_CodeFix_Title">
+        <source>Add implementation of System.IAsyncDisposable.</source>
+        <target state="new">Add implementation of System.IAsyncDisposable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD112_MessageFormat">
+        <source>Implement the System.IAsyncDisposable interface when implementing the obsolete Microsoft.VisualStudio.Threading.IAsyncDisposable interface.</source>
+        <target state="new">Implement the System.IAsyncDisposable interface when implementing the obsolete Microsoft.VisualStudio.Threading.IAsyncDisposable interface.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD112_Title">
+        <source>Implement System.IAsyncDisposable</source>
+        <target state="new">Implement System.IAsyncDisposable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD113_MessageFormat">
+        <source>Add a check for System.IAsyncDisposable in the same code block that checks for Microsoft.VisualStudio.Threading.IAsyncDisposable that behaves similarly.</source>
+        <target state="new">Add a check for System.IAsyncDisposable in the same code block that checks for Microsoft.VisualStudio.Threading.IAsyncDisposable that behaves similarly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD113_Title">
+        <source>Check for System.IAsyncDisposable</source>
+        <target state="new">Check for System.IAsyncDisposable</target>
+        <note />
       </trans-unit>
       <trans-unit id="VSTHRD200_AddAsync_MessageFormat" translate="yes" xml:space="preserve">
         <source>Use "Async" suffix in names of methods that return an awaitable type.</source>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.fr.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.fr.xlf
@@ -8,6 +8,11 @@
         <note from="MultilingualBuild" annotates="source" priority="2">"await" is a C# keyword and should not be translated.
 {0} is a method name.</note>
       </trans-unit>
+      <trans-unit id="SystemIAsyncDisposablePackageNote">
+        <source>The System.IAsyncDisposable interface is defined in the Microsoft.Bcl.AsyncInterfaces NuGet package.</source>
+        <target state="new">The System.IAsyncDisposable interface is defined in the Microsoft.Bcl.AsyncInterfaces NuGet package.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseAwaitInstead" translate="yes" xml:space="preserve">
         <source>Use await instead</source>
         <target state="translated">Utiliser await à la place</target>
@@ -248,6 +253,31 @@ Utilisez AsyncLazy&lt;T&gt; à la place.</target>
         <source>Use ConfigureAwait(bool)</source>
         <target state="translated">Utiliser ConfigureAwait(bool)</target>
         <note from="MultilingualBuild" annotates="source" priority="2">"ConfigureAwait(bool)" is a reference and should NOT be translated.</note>
+      </trans-unit>
+      <trans-unit id="VSTHRD112_CodeFix_Title">
+        <source>Add implementation of System.IAsyncDisposable.</source>
+        <target state="new">Add implementation of System.IAsyncDisposable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD112_MessageFormat">
+        <source>Implement the System.IAsyncDisposable interface when implementing the obsolete Microsoft.VisualStudio.Threading.IAsyncDisposable interface.</source>
+        <target state="new">Implement the System.IAsyncDisposable interface when implementing the obsolete Microsoft.VisualStudio.Threading.IAsyncDisposable interface.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD112_Title">
+        <source>Implement System.IAsyncDisposable</source>
+        <target state="new">Implement System.IAsyncDisposable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD113_MessageFormat">
+        <source>Add a check for System.IAsyncDisposable in the same code block that checks for Microsoft.VisualStudio.Threading.IAsyncDisposable that behaves similarly.</source>
+        <target state="new">Add a check for System.IAsyncDisposable in the same code block that checks for Microsoft.VisualStudio.Threading.IAsyncDisposable that behaves similarly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD113_Title">
+        <source>Check for System.IAsyncDisposable</source>
+        <target state="new">Check for System.IAsyncDisposable</target>
+        <note />
       </trans-unit>
       <trans-unit id="VSTHRD200_AddAsync_MessageFormat" translate="yes" xml:space="preserve">
         <source>Use "Async" suffix in names of methods that return an awaitable type.</source>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.it.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.it.xlf
@@ -8,6 +8,11 @@
         <note from="MultilingualBuild" annotates="source" priority="2">"await" is a C# keyword and should not be translated.
 {0} is a method name.</note>
       </trans-unit>
+      <trans-unit id="SystemIAsyncDisposablePackageNote">
+        <source>The System.IAsyncDisposable interface is defined in the Microsoft.Bcl.AsyncInterfaces NuGet package.</source>
+        <target state="new">The System.IAsyncDisposable interface is defined in the Microsoft.Bcl.AsyncInterfaces NuGet package.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseAwaitInstead" translate="yes" xml:space="preserve">
         <source>Use await instead</source>
         <target state="translated">In alternativa, usare await</target>
@@ -248,6 +253,31 @@ In alternativa, usare AsyncLazy&lt;T&gt;.</target>
         <source>Use ConfigureAwait(bool)</source>
         <target state="translated">Usa ConfigureAwait(bool)</target>
         <note from="MultilingualBuild" annotates="source" priority="2">"ConfigureAwait(bool)" is a reference and should NOT be translated.</note>
+      </trans-unit>
+      <trans-unit id="VSTHRD112_CodeFix_Title">
+        <source>Add implementation of System.IAsyncDisposable.</source>
+        <target state="new">Add implementation of System.IAsyncDisposable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD112_MessageFormat">
+        <source>Implement the System.IAsyncDisposable interface when implementing the obsolete Microsoft.VisualStudio.Threading.IAsyncDisposable interface.</source>
+        <target state="new">Implement the System.IAsyncDisposable interface when implementing the obsolete Microsoft.VisualStudio.Threading.IAsyncDisposable interface.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD112_Title">
+        <source>Implement System.IAsyncDisposable</source>
+        <target state="new">Implement System.IAsyncDisposable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD113_MessageFormat">
+        <source>Add a check for System.IAsyncDisposable in the same code block that checks for Microsoft.VisualStudio.Threading.IAsyncDisposable that behaves similarly.</source>
+        <target state="new">Add a check for System.IAsyncDisposable in the same code block that checks for Microsoft.VisualStudio.Threading.IAsyncDisposable that behaves similarly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD113_Title">
+        <source>Check for System.IAsyncDisposable</source>
+        <target state="new">Check for System.IAsyncDisposable</target>
+        <note />
       </trans-unit>
       <trans-unit id="VSTHRD200_AddAsync_MessageFormat" translate="yes" xml:space="preserve">
         <source>Use "Async" suffix in names of methods that return an awaitable type.</source>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.ja.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.ja.xlf
@@ -8,6 +8,11 @@
         <note from="MultilingualBuild" annotates="source" priority="2">"await" is a C# keyword and should not be translated.
 {0} is a method name.</note>
       </trans-unit>
+      <trans-unit id="SystemIAsyncDisposablePackageNote">
+        <source>The System.IAsyncDisposable interface is defined in the Microsoft.Bcl.AsyncInterfaces NuGet package.</source>
+        <target state="new">The System.IAsyncDisposable interface is defined in the Microsoft.Bcl.AsyncInterfaces NuGet package.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseAwaitInstead" translate="yes" xml:space="preserve">
         <source>Use await instead</source>
         <target state="translated">代わりに Await を使用する</target>
@@ -248,6 +253,31 @@ Use AsyncLazy&lt;T&gt; instead.</source>
         <source>Use ConfigureAwait(bool)</source>
         <target state="translated">ConfigureAwait(bool) を使用する</target>
         <note from="MultilingualBuild" annotates="source" priority="2">"ConfigureAwait(bool)" is a reference and should NOT be translated.</note>
+      </trans-unit>
+      <trans-unit id="VSTHRD112_CodeFix_Title">
+        <source>Add implementation of System.IAsyncDisposable.</source>
+        <target state="new">Add implementation of System.IAsyncDisposable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD112_MessageFormat">
+        <source>Implement the System.IAsyncDisposable interface when implementing the obsolete Microsoft.VisualStudio.Threading.IAsyncDisposable interface.</source>
+        <target state="new">Implement the System.IAsyncDisposable interface when implementing the obsolete Microsoft.VisualStudio.Threading.IAsyncDisposable interface.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD112_Title">
+        <source>Implement System.IAsyncDisposable</source>
+        <target state="new">Implement System.IAsyncDisposable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD113_MessageFormat">
+        <source>Add a check for System.IAsyncDisposable in the same code block that checks for Microsoft.VisualStudio.Threading.IAsyncDisposable that behaves similarly.</source>
+        <target state="new">Add a check for System.IAsyncDisposable in the same code block that checks for Microsoft.VisualStudio.Threading.IAsyncDisposable that behaves similarly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD113_Title">
+        <source>Check for System.IAsyncDisposable</source>
+        <target state="new">Check for System.IAsyncDisposable</target>
+        <note />
       </trans-unit>
       <trans-unit id="VSTHRD200_AddAsync_MessageFormat" translate="yes" xml:space="preserve">
         <source>Use "Async" suffix in names of methods that return an awaitable type.</source>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.ko.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.ko.xlf
@@ -8,6 +8,11 @@
         <note from="MultilingualBuild" annotates="source" priority="2">"await" is a C# keyword and should not be translated.
 {0} is a method name.</note>
       </trans-unit>
+      <trans-unit id="SystemIAsyncDisposablePackageNote">
+        <source>The System.IAsyncDisposable interface is defined in the Microsoft.Bcl.AsyncInterfaces NuGet package.</source>
+        <target state="new">The System.IAsyncDisposable interface is defined in the Microsoft.Bcl.AsyncInterfaces NuGet package.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseAwaitInstead" translate="yes" xml:space="preserve">
         <source>Use await instead</source>
         <target state="translated">대신 await를 사용합니다.</target>
@@ -248,6 +253,31 @@ Use AsyncLazy&lt;T&gt; instead.</source>
         <source>Use ConfigureAwait(bool)</source>
         <target state="translated">ConfigureAwait(bool)를 사용합니다.</target>
         <note from="MultilingualBuild" annotates="source" priority="2">"ConfigureAwait(bool)" is a reference and should NOT be translated.</note>
+      </trans-unit>
+      <trans-unit id="VSTHRD112_CodeFix_Title">
+        <source>Add implementation of System.IAsyncDisposable.</source>
+        <target state="new">Add implementation of System.IAsyncDisposable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD112_MessageFormat">
+        <source>Implement the System.IAsyncDisposable interface when implementing the obsolete Microsoft.VisualStudio.Threading.IAsyncDisposable interface.</source>
+        <target state="new">Implement the System.IAsyncDisposable interface when implementing the obsolete Microsoft.VisualStudio.Threading.IAsyncDisposable interface.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD112_Title">
+        <source>Implement System.IAsyncDisposable</source>
+        <target state="new">Implement System.IAsyncDisposable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD113_MessageFormat">
+        <source>Add a check for System.IAsyncDisposable in the same code block that checks for Microsoft.VisualStudio.Threading.IAsyncDisposable that behaves similarly.</source>
+        <target state="new">Add a check for System.IAsyncDisposable in the same code block that checks for Microsoft.VisualStudio.Threading.IAsyncDisposable that behaves similarly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD113_Title">
+        <source>Check for System.IAsyncDisposable</source>
+        <target state="new">Check for System.IAsyncDisposable</target>
+        <note />
       </trans-unit>
       <trans-unit id="VSTHRD200_AddAsync_MessageFormat" translate="yes" xml:space="preserve">
         <source>Use "Async" suffix in names of methods that return an awaitable type.</source>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.pl.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.pl.xlf
@@ -8,6 +8,11 @@
         <note from="MultilingualBuild" annotates="source" priority="2">"await" is a C# keyword and should not be translated.
 {0} is a method name.</note>
       </trans-unit>
+      <trans-unit id="SystemIAsyncDisposablePackageNote">
+        <source>The System.IAsyncDisposable interface is defined in the Microsoft.Bcl.AsyncInterfaces NuGet package.</source>
+        <target state="new">The System.IAsyncDisposable interface is defined in the Microsoft.Bcl.AsyncInterfaces NuGet package.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseAwaitInstead" translate="yes" xml:space="preserve">
         <source>Use await instead</source>
         <target state="translated">Zamiast tego używaj oczekiwania</target>
@@ -248,6 +253,31 @@ Zamiast tego użyj elementu AsyncLazy&lt;T&gt;.</target>
         <source>Use ConfigureAwait(bool)</source>
         <target state="translated">Użyj metody ConfigureAwait(bool)</target>
         <note from="MultilingualBuild" annotates="source" priority="2">"ConfigureAwait(bool)" is a reference and should NOT be translated.</note>
+      </trans-unit>
+      <trans-unit id="VSTHRD112_CodeFix_Title">
+        <source>Add implementation of System.IAsyncDisposable.</source>
+        <target state="new">Add implementation of System.IAsyncDisposable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD112_MessageFormat">
+        <source>Implement the System.IAsyncDisposable interface when implementing the obsolete Microsoft.VisualStudio.Threading.IAsyncDisposable interface.</source>
+        <target state="new">Implement the System.IAsyncDisposable interface when implementing the obsolete Microsoft.VisualStudio.Threading.IAsyncDisposable interface.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD112_Title">
+        <source>Implement System.IAsyncDisposable</source>
+        <target state="new">Implement System.IAsyncDisposable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD113_MessageFormat">
+        <source>Add a check for System.IAsyncDisposable in the same code block that checks for Microsoft.VisualStudio.Threading.IAsyncDisposable that behaves similarly.</source>
+        <target state="new">Add a check for System.IAsyncDisposable in the same code block that checks for Microsoft.VisualStudio.Threading.IAsyncDisposable that behaves similarly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD113_Title">
+        <source>Check for System.IAsyncDisposable</source>
+        <target state="new">Check for System.IAsyncDisposable</target>
+        <note />
       </trans-unit>
       <trans-unit id="VSTHRD200_AddAsync_MessageFormat" translate="yes" xml:space="preserve">
         <source>Use "Async" suffix in names of methods that return an awaitable type.</source>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.pt-BR.xlf
@@ -8,6 +8,11 @@
         <note from="MultilingualBuild" annotates="source" priority="2">"await" is a C# keyword and should not be translated.
 {0} is a method name.</note>
       </trans-unit>
+      <trans-unit id="SystemIAsyncDisposablePackageNote">
+        <source>The System.IAsyncDisposable interface is defined in the Microsoft.Bcl.AsyncInterfaces NuGet package.</source>
+        <target state="new">The System.IAsyncDisposable interface is defined in the Microsoft.Bcl.AsyncInterfaces NuGet package.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseAwaitInstead" translate="yes" xml:space="preserve">
         <source>Use await instead</source>
         <target state="translated">Em vez disso, use a espera</target>
@@ -248,6 +253,31 @@ Nesse caso, use AsyncLazy&lt;T&gt;.</target>
         <source>Use ConfigureAwait(bool)</source>
         <target state="translated">Use ConfigureAwait(bool)</target>
         <note from="MultilingualBuild" annotates="source" priority="2">"ConfigureAwait(bool)" is a reference and should NOT be translated.</note>
+      </trans-unit>
+      <trans-unit id="VSTHRD112_CodeFix_Title">
+        <source>Add implementation of System.IAsyncDisposable.</source>
+        <target state="new">Add implementation of System.IAsyncDisposable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD112_MessageFormat">
+        <source>Implement the System.IAsyncDisposable interface when implementing the obsolete Microsoft.VisualStudio.Threading.IAsyncDisposable interface.</source>
+        <target state="new">Implement the System.IAsyncDisposable interface when implementing the obsolete Microsoft.VisualStudio.Threading.IAsyncDisposable interface.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD112_Title">
+        <source>Implement System.IAsyncDisposable</source>
+        <target state="new">Implement System.IAsyncDisposable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD113_MessageFormat">
+        <source>Add a check for System.IAsyncDisposable in the same code block that checks for Microsoft.VisualStudio.Threading.IAsyncDisposable that behaves similarly.</source>
+        <target state="new">Add a check for System.IAsyncDisposable in the same code block that checks for Microsoft.VisualStudio.Threading.IAsyncDisposable that behaves similarly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD113_Title">
+        <source>Check for System.IAsyncDisposable</source>
+        <target state="new">Check for System.IAsyncDisposable</target>
+        <note />
       </trans-unit>
       <trans-unit id="VSTHRD200_AddAsync_MessageFormat" translate="yes" xml:space="preserve">
         <source>Use "Async" suffix in names of methods that return an awaitable type.</source>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.ru.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.ru.xlf
@@ -8,6 +8,11 @@
         <note from="MultilingualBuild" annotates="source" priority="2">"await" is a C# keyword and should not be translated.
 {0} is a method name.</note>
       </trans-unit>
+      <trans-unit id="SystemIAsyncDisposablePackageNote">
+        <source>The System.IAsyncDisposable interface is defined in the Microsoft.Bcl.AsyncInterfaces NuGet package.</source>
+        <target state="new">The System.IAsyncDisposable interface is defined in the Microsoft.Bcl.AsyncInterfaces NuGet package.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseAwaitInstead" translate="yes" xml:space="preserve">
         <source>Use await instead</source>
         <target state="translated">Вместо этого используйте await.</target>
@@ -248,6 +253,31 @@ Use AsyncLazy&lt;T&gt; instead.</source>
         <source>Use ConfigureAwait(bool)</source>
         <target state="translated">Используйте ConfigureAwait(bool)</target>
         <note from="MultilingualBuild" annotates="source" priority="2">"ConfigureAwait(bool)" is a reference and should NOT be translated.</note>
+      </trans-unit>
+      <trans-unit id="VSTHRD112_CodeFix_Title">
+        <source>Add implementation of System.IAsyncDisposable.</source>
+        <target state="new">Add implementation of System.IAsyncDisposable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD112_MessageFormat">
+        <source>Implement the System.IAsyncDisposable interface when implementing the obsolete Microsoft.VisualStudio.Threading.IAsyncDisposable interface.</source>
+        <target state="new">Implement the System.IAsyncDisposable interface when implementing the obsolete Microsoft.VisualStudio.Threading.IAsyncDisposable interface.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD112_Title">
+        <source>Implement System.IAsyncDisposable</source>
+        <target state="new">Implement System.IAsyncDisposable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD113_MessageFormat">
+        <source>Add a check for System.IAsyncDisposable in the same code block that checks for Microsoft.VisualStudio.Threading.IAsyncDisposable that behaves similarly.</source>
+        <target state="new">Add a check for System.IAsyncDisposable in the same code block that checks for Microsoft.VisualStudio.Threading.IAsyncDisposable that behaves similarly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD113_Title">
+        <source>Check for System.IAsyncDisposable</source>
+        <target state="new">Check for System.IAsyncDisposable</target>
+        <note />
       </trans-unit>
       <trans-unit id="VSTHRD200_AddAsync_MessageFormat" translate="yes" xml:space="preserve">
         <source>Use "Async" suffix in names of methods that return an awaitable type.</source>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.tr.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.tr.xlf
@@ -8,6 +8,11 @@
         <note from="MultilingualBuild" annotates="source" priority="2">"await" is a C# keyword and should not be translated.
 {0} is a method name.</note>
       </trans-unit>
+      <trans-unit id="SystemIAsyncDisposablePackageNote">
+        <source>The System.IAsyncDisposable interface is defined in the Microsoft.Bcl.AsyncInterfaces NuGet package.</source>
+        <target state="new">The System.IAsyncDisposable interface is defined in the Microsoft.Bcl.AsyncInterfaces NuGet package.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseAwaitInstead" translate="yes" xml:space="preserve">
         <source>Use await instead</source>
         <target state="translated">Bunun yerine await kullanın</target>
@@ -248,6 +253,31 @@ Bunun yerine AsyncLazy&lt;T&gt; kullanın.</target>
         <source>Use ConfigureAwait(bool)</source>
         <target state="translated">ConfigureAwait(bool) kullanın</target>
         <note from="MultilingualBuild" annotates="source" priority="2">"ConfigureAwait(bool)" is a reference and should NOT be translated.</note>
+      </trans-unit>
+      <trans-unit id="VSTHRD112_CodeFix_Title">
+        <source>Add implementation of System.IAsyncDisposable.</source>
+        <target state="new">Add implementation of System.IAsyncDisposable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD112_MessageFormat">
+        <source>Implement the System.IAsyncDisposable interface when implementing the obsolete Microsoft.VisualStudio.Threading.IAsyncDisposable interface.</source>
+        <target state="new">Implement the System.IAsyncDisposable interface when implementing the obsolete Microsoft.VisualStudio.Threading.IAsyncDisposable interface.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD112_Title">
+        <source>Implement System.IAsyncDisposable</source>
+        <target state="new">Implement System.IAsyncDisposable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD113_MessageFormat">
+        <source>Add a check for System.IAsyncDisposable in the same code block that checks for Microsoft.VisualStudio.Threading.IAsyncDisposable that behaves similarly.</source>
+        <target state="new">Add a check for System.IAsyncDisposable in the same code block that checks for Microsoft.VisualStudio.Threading.IAsyncDisposable that behaves similarly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD113_Title">
+        <source>Check for System.IAsyncDisposable</source>
+        <target state="new">Check for System.IAsyncDisposable</target>
+        <note />
       </trans-unit>
       <trans-unit id="VSTHRD200_AddAsync_MessageFormat" translate="yes" xml:space="preserve">
         <source>Use "Async" suffix in names of methods that return an awaitable type.</source>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.zh-Hans.xlf
@@ -8,6 +8,11 @@
         <note from="MultilingualBuild" annotates="source" priority="2">"await" is a C# keyword and should not be translated.
 {0} is a method name.</note>
       </trans-unit>
+      <trans-unit id="SystemIAsyncDisposablePackageNote">
+        <source>The System.IAsyncDisposable interface is defined in the Microsoft.Bcl.AsyncInterfaces NuGet package.</source>
+        <target state="new">The System.IAsyncDisposable interface is defined in the Microsoft.Bcl.AsyncInterfaces NuGet package.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseAwaitInstead" translate="yes" xml:space="preserve">
         <source>Use await instead</source>
         <target state="translated">改用 await</target>
@@ -248,6 +253,31 @@ Use AsyncLazy&lt;T&gt; instead.</source>
         <source>Use ConfigureAwait(bool)</source>
         <target state="translated">使用 ConfigureAwait(bool)</target>
         <note from="MultilingualBuild" annotates="source" priority="2">"ConfigureAwait(bool)" is a reference and should NOT be translated.</note>
+      </trans-unit>
+      <trans-unit id="VSTHRD112_CodeFix_Title">
+        <source>Add implementation of System.IAsyncDisposable.</source>
+        <target state="new">Add implementation of System.IAsyncDisposable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD112_MessageFormat">
+        <source>Implement the System.IAsyncDisposable interface when implementing the obsolete Microsoft.VisualStudio.Threading.IAsyncDisposable interface.</source>
+        <target state="new">Implement the System.IAsyncDisposable interface when implementing the obsolete Microsoft.VisualStudio.Threading.IAsyncDisposable interface.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD112_Title">
+        <source>Implement System.IAsyncDisposable</source>
+        <target state="new">Implement System.IAsyncDisposable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD113_MessageFormat">
+        <source>Add a check for System.IAsyncDisposable in the same code block that checks for Microsoft.VisualStudio.Threading.IAsyncDisposable that behaves similarly.</source>
+        <target state="new">Add a check for System.IAsyncDisposable in the same code block that checks for Microsoft.VisualStudio.Threading.IAsyncDisposable that behaves similarly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD113_Title">
+        <source>Check for System.IAsyncDisposable</source>
+        <target state="new">Check for System.IAsyncDisposable</target>
+        <note />
       </trans-unit>
       <trans-unit id="VSTHRD200_AddAsync_MessageFormat" translate="yes" xml:space="preserve">
         <source>Use "Async" suffix in names of methods that return an awaitable type.</source>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/xlf/Strings.zh-Hant.xlf
@@ -8,6 +8,11 @@
         <note from="MultilingualBuild" annotates="source" priority="2">"await" is a C# keyword and should not be translated.
 {0} is a method name.</note>
       </trans-unit>
+      <trans-unit id="SystemIAsyncDisposablePackageNote">
+        <source>The System.IAsyncDisposable interface is defined in the Microsoft.Bcl.AsyncInterfaces NuGet package.</source>
+        <target state="new">The System.IAsyncDisposable interface is defined in the Microsoft.Bcl.AsyncInterfaces NuGet package.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseAwaitInstead" translate="yes" xml:space="preserve">
         <source>Use await instead</source>
         <target state="translated">改用 await</target>
@@ -248,6 +253,31 @@ Use AsyncLazy&lt;T&gt; instead.</source>
         <source>Use ConfigureAwait(bool)</source>
         <target state="translated">使用 ConfigureAwait(bool)</target>
         <note from="MultilingualBuild" annotates="source" priority="2">"ConfigureAwait(bool)" is a reference and should NOT be translated.</note>
+      </trans-unit>
+      <trans-unit id="VSTHRD112_CodeFix_Title">
+        <source>Add implementation of System.IAsyncDisposable.</source>
+        <target state="new">Add implementation of System.IAsyncDisposable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD112_MessageFormat">
+        <source>Implement the System.IAsyncDisposable interface when implementing the obsolete Microsoft.VisualStudio.Threading.IAsyncDisposable interface.</source>
+        <target state="new">Implement the System.IAsyncDisposable interface when implementing the obsolete Microsoft.VisualStudio.Threading.IAsyncDisposable interface.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD112_Title">
+        <source>Implement System.IAsyncDisposable</source>
+        <target state="new">Implement System.IAsyncDisposable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD113_MessageFormat">
+        <source>Add a check for System.IAsyncDisposable in the same code block that checks for Microsoft.VisualStudio.Threading.IAsyncDisposable that behaves similarly.</source>
+        <target state="new">Add a check for System.IAsyncDisposable in the same code block that checks for Microsoft.VisualStudio.Threading.IAsyncDisposable that behaves similarly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VSTHRD113_Title">
+        <source>Check for System.IAsyncDisposable</source>
+        <target state="new">Check for System.IAsyncDisposable</target>
+        <note />
       </trans-unit>
       <trans-unit id="VSTHRD200_AddAsync_MessageFormat" translate="yes" xml:space="preserve">
         <source>Use "Async" suffix in names of methods that return an awaitable type.</source>


### PR DESCRIPTION
These analyzers and the code fix are almost entirely language independent, so they can operate both on C# and VB code.

Closes #583