### PR TITLE
Add debugger console output to !dumpasync when encountering an exception

### DIFF
--- a/src/SosThreadingTools/Commands.cs
+++ b/src/SosThreadingTools/Commands.cs
@@ -38,7 +38,15 @@ namespace CpsDbg
                 return;
             }
 
-            handler.Execute(context, args);
+            try
+            {
+                handler.Execute(context, args);
+            }
+            catch (Exception ex)
+            {
+                context.Output.WriteLine($"Encountered an unhandled exception running '{command}':");
+                context.Output.WriteLine(ex.ToString());
+            }
         }
     }
 }


### PR DESCRIPTION
When we encounter an exception we should print out the exception details to the debugger console to make diagnosing the failure easier.