### PR TITLE
Drop VB support

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD112ImplementSystemIAsyncDisposableAnalyzerTests.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD112ImplementSystemIAsyncDisposableAnalyzerTests.cs
@@ -110,6 +110,7 @@ class Test : object, VsThreadingAsyncDisposable, BclAsyncDisposable
             await Verify.VerifyCodeFixAsync(test, fix);
         }
 
+#if IncludeVBSupport
         [Fact]
         public async Task ClassImplementsOnlyVsThreadingType_WithBaseClassToo_VB()
         {
@@ -139,6 +140,7 @@ End Class";
 
             await VBVerify.VerifyCodeFixAsync(test, fix);
         }
+#endif
 
         [Fact]
         public async Task StructImplementsBoth()
@@ -203,6 +205,7 @@ struct Test : VsThreadingAsyncDisposable, BclAsyncDisposable
             await Verify.VerifyCodeFixAsync(test, fix);
         }
 
+#if IncludeVBSupport
         [Fact]
         public async Task StructImplementsOnlyVsThreadingType_VB()
         {
@@ -230,6 +233,7 @@ End Structure";
 
             await VBVerify.VerifyCodeFixAsync(test, fix);
         }
+#endif
 
         [Fact]
         public async Task InterfaceImplementsBoth()
@@ -285,6 +289,7 @@ interface Test : VsThreadingAsyncDisposable, BclAsyncDisposable
             await Verify.VerifyCodeFixAsync(test, fix);
         }
 
+#if IncludeVBSupport
         [Fact]
         public async Task InterfaceImplementsOnlyVsThreadingType_VB()
         {
@@ -300,5 +305,6 @@ End Interface";
 
             await VBVerify.VerifyCodeFixAsync(test, fix);
         }
+#endif
     }
 }

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Microsoft.VisualStudio.Threading.Analyzers.csproj
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Microsoft.VisualStudio.Threading.Analyzers.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.8.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="2.8.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="2.8.2" Condition=" '$(IncludeVBSupport)' == 'true' " />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0" PrivateAssets="all" />
     <PackageReference Include="MicroBuild.VisualStudio" Version="$(MicroBuildVersion)" />
     <PackageReference Include="Nullable" Version="1.2.1">

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Utils.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Utils.cs
@@ -157,6 +157,7 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
                         }
                     }
                 }
+#if IncludeVBSupport
                 else if (syntaxNode is CodeAnalysis.VisualBasic.Syntax.InterfaceStatementSyntax { Parent: CodeAnalysis.VisualBasic.Syntax.InterfaceBlockSyntax vbInterface })
                 {
                     if (compilation.GetSemanticModel(vbInterface.SyntaxTree) is { } semanticModel)
@@ -208,6 +209,7 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
                         }
                     }
                 }
+#endif
             }
 
             return symbol.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax(cancellationToken)?.GetLocation();


### PR DESCRIPTION
When enabling this, we should also change the path of the analyzer assemblies in the package to allow Roslyn to recognize and load the dll for VB language projects as well.

This is necessary because of https://github.com/dotnet/roslyn/issues/43963