### PR TITLE
Use lock-free fast paths for completed tasks

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskDependencyGraph.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskDependencyGraph.cs
@@ -234,7 +234,7 @@ namespace Microsoft.VisualStudio.Threading
                     lock (parentTaskOrCollection.JoinableTaskContext.SyncContextLock)
                     {
                         var joinableTask = joinChild as JoinableTask;
-                        if (joinableTask?.IsCompleted == true)
+                        if (joinableTask?.IsFullyCompleted == true)
                         {
                             return default(JoinableTaskCollection.JoinRelease);
                         }
@@ -332,7 +332,7 @@ namespace Microsoft.VisualStudio.Threading
 
                 if (taskOrCollection is JoinableTask thisJoinableTask)
                 {
-                    if (thisJoinableTask.IsCompleted || !joinables.Add(thisJoinableTask))
+                    if (thisJoinableTask.IsFullyCompleted || !joinables.Add(thisJoinableTask))
                     {
                         return;
                     }
@@ -563,7 +563,7 @@ namespace Microsoft.VisualStudio.Threading
                 JoinableTask? thisJoinableTask = taskOrCollection as JoinableTask;
                 if (thisJoinableTask is object)
                 {
-                    if (thisJoinableTask.IsCompleted)
+                    if (thisJoinableTask.IsFullyCompleted)
                     {
                         return null;
                     }
@@ -704,7 +704,7 @@ namespace Microsoft.VisualStudio.Threading
                 Requires.NotNull(taskOrCollection, nameof(taskOrCollection));
                 Requires.NotNull(remainNodes, nameof(remainNodes));
                 Requires.NotNull(reachableNodes, nameof(reachableNodes));
-                if ((taskOrCollection as JoinableTask)?.IsCompleted != true)
+                if ((taskOrCollection as JoinableTask)?.IsFullyCompleted != true)
                 {
                     if (reachableNodes.Add(taskOrCollection))
                     {

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
@@ -1011,7 +1011,7 @@ namespace Microsoft.VisualStudio.Threading
                 this.syncContextRevert = this.joinable.ApplicableJobSyncContext.Apply();
 
                 // Join the ambient parent job, so the parent can dequeue this job's work.
-                if (this.previousJoinable is object && !this.previousJoinable.IsCompleted)
+                if (this.previousJoinable is object && !this.previousJoinable.IsFullyCompleted)
                 {
                     JoinableTaskDependencyGraph.AddDependency(this.previousJoinable, joinable);
 

--- a/src/Microsoft.VisualStudio.Threading/JoinableTask`1.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTask`1.cs
@@ -50,12 +50,7 @@ namespace Microsoft.VisualStudio.Threading
         public new Task<T> JoinAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             Task baseJoin = base.JoinAsync(cancellationToken);
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return System.Threading.Tasks.Task.FromCanceled<T>(cancellationToken);
-            }
-
-            if (baseJoin.IsCompleted)
+            if (baseJoin.IsCompleted && !cancellationToken.IsCancellationRequested)
             {
                 Assumes.True(this.Task.IsCompleted);
                 return this.Task;

--- a/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskTests.cs
@@ -3836,7 +3836,7 @@ public class JoinableTaskTests : JoinableTaskTestBase
     }
 
     [Fact]
-    public void IsResultAvailableTrueDoesNotLock()
+    public void IsCompletedTrueDoesNotLock()
     {
         using var context = new JoinableTaskContext();
         var syncContextLock = typeof(JoinableTaskContext).GetProperty("SyncContextLock", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(context);
@@ -3859,8 +3859,7 @@ public class JoinableTaskTests : JoinableTaskTestBase
         Assert.False(Monitor.TryEnter(syncContextLock));
 
         // This should complete without needing the lock
-        var isResultAvailable = typeof(JoinableTask).GetProperty("IsResultAvailable", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(joinableTask);
-        Assert.Equal(true, isResultAvailable);
+        Assert.True(joinableTask.IsCompleted);
 
         // Verify the lock is still held (as opposed to released by timeout)
         Assert.False(Monitor.TryEnter(syncContextLock));


### PR DESCRIPTION
This change adds allocation- and lock-free fast paths for completed `JoinableTask` instances for the following members:

* `IsCompleted`
* `JoinableTask.Join` and `JoinableTask<T>.Join`
* `JoinableTask.JoinAsync` and `JoinableTask<T>.JoinAsync`
* `JoinableTask.GetAwaiter()` and `JoinableTask<T>.GetAwaiter()` (and in turn the `GetResult()` methods of each)
