### PR TITLE
Update VSTHRD112.md to call `DisposeAsync` on `System.IAsyncDisposable`

### DIFF
--- a/doc/analyzers/VSTHRD112.md
+++ b/doc/analyzers/VSTHRD112.md
@@ -49,7 +49,7 @@ class SomeClass : System.IAsyncDisposable, Microsoft.VisualStudio.Threading.IAsy
     {
         // Simply forward the call to the other DisposeAsync overload.
         System.IAsyncDisposable self = this;
-        return self.Dispose().AsTask();
+        return self.DisposeAsync().AsTask();
     }
 
     ValueTask System.IAsyncDisposable.DisposeAsync()


### PR DESCRIPTION
Shouldn't this call `DisposeAsync` or is there some compiler magic happening?