### PR TITLE
Fix a typo in the JTF dependency computation code.

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskDependencyGraph.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskDependencyGraph.cs
@@ -760,7 +760,7 @@ namespace Microsoft.VisualStudio.Threading
                 {
                     if (reachableNodes.Add(taskOrCollection))
                     {
-                        if (remainNodes.Remove(taskOrCollection) && reachableNodes.Count == 0)
+                        if (remainNodes.Remove(taskOrCollection) && remainNodes.Count == 0)
                         {
                             // no remain task left, quit the loop earlier
                             return;

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskDependencyGraph.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskDependencyGraph.cs
@@ -772,6 +772,10 @@ namespace Microsoft.VisualStudio.Threading
                             foreach (KeyValuePair<IJoinableTaskDependent, int> item in dependencies)
                             {
                                 ComputeSelfAndDescendentOrJoinedJobsAndRemainTasks(item.Key, reachableNodes, remainNodes);
+                                if (remainNodes.Count == 0)
+                                {
+                                    return;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
This PR is to fix a typo in the code, which prevent code to take a short-cut when it finds necessary nodes. It makes a performance problem in VS worse.

