### PR TITLE
VSTHRD110: trigger on ConfigureAwait, recognize ValueTask

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD110ObserveResultOfAsyncCallsAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD110ObserveResultOfAsyncCallsAnalyzer.cs
@@ -49,8 +49,7 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
                 if (invocation.Parent?.GetType().Equals(typeof(ExpressionStatementSyntax)) ?? false)
                 {
                     var methodSymbol = context.SemanticModel.GetSymbolInfo(context.Node).Symbol as IMethodSymbol;
-                    ITypeSymbol? returnedSymbol = methodSymbol?.ReturnType;
-                    if (returnedSymbol != null && (IsStockAwaitable(returnedSymbol) || this.IsAwaitableType(returnedSymbol, context.Compilation, context.CancellationToken)))
+                    if (this.IsAwaitableType(methodSymbol?.ReturnType, context.Compilation, context.CancellationToken))
                     {
                         if (!CSharpUtils.GetContainingFunction(invocation).IsAsync)
                         {
@@ -60,24 +59,6 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
                     }
                 }
             }
-
-            private static bool IsStockAwaitable(ITypeSymbol symbol) =>
-                symbol.Name switch
-                {
-                    Types.Task.TypeName
-                        when symbol.BelongsToNamespace(Types.Task.Namespace) => true,
-
-                    Types.ConfiguredTaskAwaitable.TypeName
-                        when symbol.BelongsToNamespace(Types.ConfiguredTaskAwaitable.Namespace) => true,
-
-                    Types.ValueTask.TypeName
-                        when symbol.BelongsToNamespace(Types.ValueTask.Namespace) => true,
-
-                    Types.ConfiguredValueTaskAwaitable.TypeName
-                        when symbol.BelongsToNamespace(Types.ConfiguredValueTaskAwaitable.Namespace) => true,
-
-                    _ => false,
-                };
         }
     }
 }

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD110ObserveResultOfAsyncCallsAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD110ObserveResultOfAsyncCallsAnalyzer.cs
@@ -40,29 +40,29 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
             context.RegisterSyntaxNodeAction(Utils.DebuggableWrapper(this.AnalyzeInvocation), SyntaxKind.InvocationExpression);
         }
 
-        private static bool IsAwaitable(ITypeSymbol returnedSymbol) =>
-            returnedSymbol.Name switch
+        private static bool IsStockAwaitable(ITypeSymbol symbol) =>
+            symbol.Name switch
             {
                 Types.Task.TypeName
-                    when returnedSymbol.BelongsToNamespace(Types.Task.Namespace) => true,
+                    when symbol.BelongsToNamespace(Types.Task.Namespace) => true,
 
                 Types.ConfiguredTaskAwaitable.TypeName
-                    when returnedSymbol.BelongsToNamespace(Types.ConfiguredTaskAwaitable.Namespace) => true,
+                    when symbol.BelongsToNamespace(Types.ConfiguredTaskAwaitable.Namespace) => true,
 
                 Types.ValueTask.TypeName
-                    when returnedSymbol.BelongsToNamespace(Types.ValueTask.Namespace) => true,
+                    when symbol.BelongsToNamespace(Types.ValueTask.Namespace) => true,
 
                 Types.ConfiguredValueTaskAwaitable.TypeName
-                    when returnedSymbol.BelongsToNamespace(Types.ConfiguredValueTaskAwaitable.Namespace) => true,
+                    when symbol.BelongsToNamespace(Types.ConfiguredValueTaskAwaitable.Namespace) => true,
 
                 _ => false,
             };
 
-        private static bool IsCustomAwaitable(ITypeSymbol returnedSymbol)
+        private static bool IsCustomAwaitable(ITypeSymbol symbol)
         {
             // type has method: public T GetAwaiter()
             IMethodSymbol? getAwaiterMethod = null;
-            ImmutableArray<ISymbol> members = returnedSymbol.GetMembers("GetAwaiter");
+            ImmutableArray<ISymbol> members = symbol.GetMembers("GetAwaiter");
             for (var i = 0; i < members.Length; ++i)
             {
                 ISymbol member = members[i];
@@ -156,7 +156,7 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
             {
                 var methodSymbol = context.SemanticModel.GetSymbolInfo(context.Node).Symbol as IMethodSymbol;
                 ITypeSymbol? returnedSymbol = methodSymbol?.ReturnType;
-                if (returnedSymbol != null && (IsAwaitable(returnedSymbol) || IsCustomAwaitable(returnedSymbol)))
+                if (returnedSymbol != null && (IsStockAwaitable(returnedSymbol) || IsCustomAwaitable(returnedSymbol)))
                 {
                     if (!CSharpUtils.GetContainingFunction(invocation).IsAsync)
                     {

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD110ObserveResultOfAsyncCallsAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD110ObserveResultOfAsyncCallsAnalyzer.cs
@@ -63,6 +63,12 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
                 Types.ConfiguredTaskAwaitable.TypeName
                     when returnedSymbol.BelongsToNamespace(Types.ConfiguredTaskAwaitable.Namespace) => true,
 
+                Types.ValueTask.TypeName
+                    when returnedSymbol.BelongsToNamespace(Types.ValueTask.Namespace) => true,
+
+                Types.ConfiguredValueTaskAwaitable.TypeName
+                    when returnedSymbol.BelongsToNamespace(Types.ConfiguredValueTaskAwaitable.Namespace) => true,
+
                 _ => false,
             };
 

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/DiagnosticAnalyzerState.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/DiagnosticAnalyzerState.cs
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
 
         private readonly ConcurrentDictionary<ITypeSymbol, bool> customAwaitableTypes = new ConcurrentDictionary<ITypeSymbol, bool>();
 
-        internal bool IsAwaitableType(ITypeSymbol typeSymbol, Compilation compilation, CancellationToken cancellationToken)
+        internal bool IsAwaitableType(ITypeSymbol? typeSymbol, Compilation compilation, CancellationToken cancellationToken)
         {
             if (typeSymbol is null)
             {

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Types.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Types.cs
@@ -186,6 +186,15 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
             internal static readonly IReadOnlyList<string> Namespace = Namespaces.SystemThreadingTasks;
         }
 
+        internal static class ConfiguredTaskAwaitable
+        {
+            internal const string TypeName = nameof(System.Runtime.CompilerServices.ConfiguredTaskAwaitable);
+
+            internal const string FullName = "System.Runtime.CompilerServices." + TypeName;
+
+            internal static readonly IReadOnlyList<string> Namespace = Namespaces.SystemRuntimeCompilerServices;
+        }
+
         internal static class ValueTask
         {
             internal const string TypeName = nameof(ValueTask);

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Types.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Types.cs
@@ -204,6 +204,15 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
             internal static readonly IReadOnlyList<string> Namespace = Namespaces.SystemThreadingTasks;
         }
 
+        internal static class ConfiguredValueTaskAwaitable
+        {
+            internal const string TypeName = nameof(System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable);
+
+            internal const string FullName = "System.Runtime.CompilerServices." + TypeName;
+
+            internal static readonly IReadOnlyList<string> Namespace = Namespaces.SystemRuntimeCompilerServices;
+        }
+
         internal static class CoClassAttribute
         {
             internal const string TypeName = nameof(System.Runtime.InteropServices.CoClassAttribute);

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD110ObserveResultOfAsyncCallsAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD110ObserveResultOfAsyncCallsAnalyzerTests.cs
@@ -323,6 +323,46 @@ class NotAwaitable
             await Verify.VerifyAnalyzerAsync(test);
         }
 
+        [Fact]
+        public async Task SyncMethodWithValueTask_ProducesDiagnostic()
+        {
+            var test = @"
+using System.Threading.Tasks;
+
+class Test {
+    void Foo()
+    {
+        BarAsync();
+    }
+
+    ValueTask BarAsync() => default;
+}
+";
+
+            DiagnosticResult expected = this.CreateDiagnostic(7, 9, 8);
+            await Verify.VerifyAnalyzerAsync(test, expected);
+        }
+
+        [Fact]
+        public async Task ConfigureAwaitValueTask_ProducesDiagnostics()
+        {
+            var test = @"
+using System.Threading.Tasks;
+
+class Test {
+    void Foo()
+    {
+        BarAsync().ConfigureAwait(false);
+    }
+
+    ValueTask BarAsync() => default;
+}
+";
+
+            DiagnosticResult expected = this.CreateDiagnostic(7, 20, nameof(Task.ConfigureAwait).Length);
+            await Verify.VerifyAnalyzerAsync(test, expected);
+        }
+
         private DiagnosticResult CreateDiagnostic(int line, int column, int length)
             => Verify.Diagnostic().WithSpan(line, column, line, column + length);
     }

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD110ObserveResultOfAsyncCallsAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD110ObserveResultOfAsyncCallsAnalyzerTests.cs
@@ -214,6 +214,46 @@ class Test {
             await Verify.VerifyAnalyzerAsync(test, expected);
         }
 
+        [Fact]
+        public async Task ConfigureAwait_ProducesDiagnostics()
+        {
+            var test = @"
+using System.Threading.Tasks;
+
+class Test {
+    void Foo()
+    {
+        BarAsync().ConfigureAwait(false);
+    }
+
+    Task BarAsync() => Task.CompletedTask;
+}
+";
+
+            DiagnosticResult expected = this.CreateDiagnostic(7, 20, nameof(Task.ConfigureAwait).Length);
+            await Verify.VerifyAnalyzerAsync(test, expected);
+        }
+
+        [Fact]
+        public async Task ConfigureAwaitGenerics_ProducesDiagnostics()
+        {
+            var test = @"
+using System.Threading.Tasks;
+
+class Test {
+    void Foo()
+    {
+        BarAsync().ConfigureAwait(false);
+    }
+
+    Task<int> BarAsync() => Task.FromResult(0);
+}
+";
+
+            DiagnosticResult expected = this.CreateDiagnostic(7, 20, nameof(Task.ConfigureAwait).Length);
+            await Verify.VerifyAnalyzerAsync(test, expected);
+        }
+
         private DiagnosticResult CreateDiagnostic(int line, int column, int length)
             => Verify.Diagnostic().WithSpan(line, column, line, column + length);
     }

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD110ObserveResultOfAsyncCallsAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD110ObserveResultOfAsyncCallsAnalyzerTests.cs
@@ -254,6 +254,75 @@ class Test {
             await Verify.VerifyAnalyzerAsync(test, expected);
         }
 
+        [Fact]
+        public async Task CustomAwaitable_ProducesDiagnostics()
+        {
+            var test = @"
+using System;
+using System.Runtime.CompilerServices;
+
+class Test {
+    void Foo()
+    {
+        BarAsync();
+    }
+
+    CustomTask BarAsync() => new CustomTask();
+}
+
+class CustomTask
+{
+	public CustomAwaitable GetAwaiter() => new CustomAwaitable();
+}
+
+class CustomAwaitable : INotifyCompletion
+{
+	public bool IsCompleted { get; } = true;
+
+	public void OnCompleted(Action continuation)
+	{
+	}
+
+	public void GetResult()
+	{
+	}
+}
+";
+            DiagnosticResult expected = this.CreateDiagnostic(8, 9, 8);
+            await Verify.VerifyAnalyzerAsync(test, expected);
+        }
+
+        [Fact]
+        public async Task CustomAwaitableLikeType_ProducesNoDiagnostic()
+        {
+            var test = @"
+using System;
+
+class Test {
+    void Foo()
+    {
+        BarAsync();
+    }
+
+    NotTask BarAsync() => new NotTask();
+}
+
+class NotTask
+{
+	public NotAwaitable GetAwaiter() => new NotAwaitable();
+}
+
+class NotAwaitable
+{
+	public bool IsCompleted { get; } = false;
+
+	public int GetResult() => 0;
+}
+";
+
+            await Verify.VerifyAnalyzerAsync(test);
+        }
+
         private DiagnosticResult CreateDiagnostic(int line, int column, int length)
             => Verify.Diagnostic().WithSpan(line, column, line, column + length);
     }


### PR DESCRIPTION
Fixes #774:
Added functionality:
- recognizing `ConfiguredTaskAwaitable` (returned by `ConfigureAwait` on `Task`)
- recognizing custom awaitable implementation

Fixes #775:
Added functionality:
- recognizing `ValueTask`
- recognizing `ConfiguredValueTaskAwaitable` (returned by `ConfigureAwait` on `ValueTask`)

---

I dared to fix both issues in single PR since #775 was basically just about adding tests and `ConfiguredValueTaskAwaitable`.