### PR TITLE
Minor: reuse existing WeakReference of the JoinableTask

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
@@ -1014,7 +1014,7 @@ namespace Microsoft.VisualStudio.Threading
 
             if (this.pendingEventSource is null || taskHasPendingMessages == this)
             {
-                this.pendingEventSource = new WeakReference<JoinableTask>(taskHasPendingMessages);
+                this.pendingEventSource = taskHasPendingMessages.WeakSelf;
             }
 
             this.pendingEventCount += newPendingMessagesCount;


### PR DESCRIPTION
Reuse the existing WeakSelf, instead of allocating another weak reference item.