### PR TITLE
Try to reduce performance overhead when we remove a JTF dependency

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
@@ -1143,6 +1143,7 @@ namespace Microsoft.VisualStudio.Threading
                             if (!foundWork && this.PotentialUnreachableDependents != null)
                             {
                                 JoinableTaskDependencyGraph.RemoveUnreachableDependentItems(this, this.PotentialUnreachableDependents, visitedNodes);
+                                this.PotentialUnreachableDependents = null;
                             }
                         }
 

--- a/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
@@ -381,8 +381,8 @@ namespace Microsoft.VisualStudio.Threading
         }
 
         /// <summary>
-        /// Gets or sets potential unreacable dependent nodes.
-        /// This is a special collection only used in sychronized task when there are other tasks which are marked to block it through ref-count code.
+        /// Gets or sets potential unreachable dependent nodes.
+        /// This is a special collection only used in synchronized task when there are other tasks which are marked to block it through ref-count code.
         /// However, it is possible the reference count is retained by loop-dependencies. This collection tracking those items,
         /// so the clean-up logic can run when it becomes necessary.
         /// </summary>
@@ -717,7 +717,7 @@ namespace Microsoft.VisualStudio.Threading
                                         // because dependencies may change, and invalidate this work. However, we try to do this work in the background thread to make it less likely
                                         // doing the expensive work on the UI thread.
                                         if (JoinableTaskDependencyGraph.CleanUpPotentialUnreachableDependentItems(taskToNotify, out HashSet<IJoinableTaskDependent>? reachableNodes) &&
-                                            !reachableNodes!.Contains(this))
+                                            !reachableNodes.Contains(this))
                                         {
                                             continue;
                                         }
@@ -1128,7 +1128,7 @@ namespace Microsoft.VisualStudio.Threading
                             visited.Clear();
                         }
 
-                        var foundWork = TryDequeueSelfOrDependencies(this, onMainThread, visited, out work);
+                        bool foundWork = TryDequeueSelfOrDependencies(this, onMainThread, visited, out work);
 
                         HashSet<IJoinableTaskDependent>? visitedNodes = visited;
                         if (visitedNodes != null && this.PotentialUnreachableDependents != null)

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskDependencyGraph.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskDependencyGraph.cs
@@ -226,7 +226,7 @@ namespace Microsoft.VisualStudio.Threading
         /// <param name="syncTask">A thread blocking sychornizing task.</param>
         /// <param name="allReachableNodes">Returns all reachable nodes in the connected dependency graph, if unreachable dependency is found.</param>
         /// <returns>True if it removes any unreachable items.</returns>
-        internal static bool CleanUpPotentialUnreachableDependentItems(JoinableTask syncTask, [MaybeNullWhen(false)] out HashSet<IJoinableTaskDependent>? allReachableNodes)
+        internal static bool CleanUpPotentialUnreachableDependentItems(JoinableTask syncTask, [NotNullWhen(true)] out HashSet<IJoinableTaskDependent>? allReachableNodes)
         {
             Requires.NotNull(syncTask, nameof(syncTask));
 
@@ -254,11 +254,8 @@ namespace Microsoft.VisualStudio.Threading
                     return true;
                 }
             }
-            else
-            {
-                allReachableNodes = null;
-            }
 
+            allReachableNodes = null;
             return false;
         }
 
@@ -607,7 +604,7 @@ namespace Microsoft.VisualStudio.Threading
                         {
                             // This might remove the current tracking item from the linked list, so we capture next node first.
                             if (!CleanUpPotentialUnreachableDependentItems(existingTaskTracking.SynchronousTask, out HashSet<IJoinableTaskDependent>? allReachableNodes) ||
-                                allReachableNodes!.Contains(taskItem))
+                                allReachableNodes.Contains(taskItem))
                             {
                                 // this task is still a dependenting task
                                 return true;
@@ -877,7 +874,9 @@ namespace Microsoft.VisualStudio.Threading
                 {
                     if (force)
                     {
-                        Assumes.True(reachableNodes!.Count == 0);
+                        Assumes.NotNull(reachableNodes);
+                        Assumes.True(reachableNodes.Count == 0);
+
                         RemoveUnreachableDependentItems(syncTask, remainNodes, reachableNodes);
 
                         syncTask.PotentialUnreachableDependents = null;

--- a/src/Microsoft.VisualStudio.Threading/ThreadingEventSource.cs
+++ b/src/Microsoft.VisualStudio.Threading/ThreadingEventSource.cs
@@ -67,6 +67,11 @@ namespace Microsoft.VisualStudio.Threading
         private const int PostExecutionStopEvent = 16;
 
         /// <summary>
+        /// The event ID for the <see cref="CircularJoinableTaskDependencyDetected(int, int)"/>.
+        /// </summary>
+        private const int CircularJoinableTaskDependencyDetectedEvent = 17;
+
+        /// <summary>
         /// Logs an issued lock.
         /// </summary>
         [Event(ReaderWriterLockIssuedLockCountsEvent, Task = Tasks.LockRequest, Opcode = Opcodes.ReaderWriterLockIssued)]
@@ -151,6 +156,17 @@ namespace Microsoft.VisualStudio.Threading
         public void PostExecutionStop(int requestId)
         {
             this.WriteEvent(PostExecutionStopEvent, requestId);
+        }
+
+        /// <summary>
+        /// Circular JoinableTask dependency detected.
+        /// </summary>
+        /// <param name="initUnreachableCount">Initial count of unreachable nodes.</param>
+        /// <param name="reachableCount">The size of the connected dependency graph.</param>
+        [Event(CircularJoinableTaskDependencyDetectedEvent, Level = EventLevel.Informational)]
+        public void CircularJoinableTaskDependencyDetected(int initUnreachableCount, int reachableCount)
+        {
+            this.WriteEvent(CircularJoinableTaskDependencyDetectedEvent, initUnreachableCount, reachableCount);
         }
 
         /// <summary>


### PR DESCRIPTION
This is still in a draft of the current thought. The idea is to delay scanning the JTF dependency graph to potentially patch the dependency computation for disconnected circular dependency loop to a much later time. That includes:
 1, when we need a correct answer for IsMainThreadBlocked check for current task
 2, when main thread scans the tree to find work: it would remove the optimization for the first request when we know the dependency is up to date, but we also get the information during the scanning, and we take advantage of that to reduce repeated work.
3, when SwitchToMainThread is raised in a background task, this is not an essential point, but we try to do so the computation is more likely to happen in the background thread.

Need more testing, but bring up the PR for preview.