### PR TITLE
When a JTF is removed from a collection, it should ignore refCount.

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
@@ -995,7 +995,7 @@ namespace Microsoft.VisualStudio.Threading
 
                 foreach (IJoinableTaskDependent? collection in this.dependencyParents)
                 {
-                    JoinableTaskDependencyGraph.RemoveDependency(collection, this);
+                    JoinableTaskDependencyGraph.RemoveDependency(collection, this, forceCleanup: true);
                 }
 
                 if (this.mainThreadJobSyncContext is object)

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskDependencyGraph.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskDependencyGraph.cs
@@ -71,10 +71,11 @@ namespace Microsoft.VisualStudio.Threading
         /// </summary>
         /// <param name="taskItem">The current joinableTask or collection.</param>
         /// <param name="child">The <see cref="IJoinableTaskDependent"/> to join as a child.</param>
-        internal static void RemoveDependency(IJoinableTaskDependent taskItem, IJoinableTaskDependent child)
+        /// <param name="forceCleanup">Ignore refCount, it is being used when the child task is completed.</param>
+        internal static void RemoveDependency(IJoinableTaskDependent taskItem, IJoinableTaskDependent child, bool forceCleanup = false)
         {
             Requires.NotNull(taskItem, nameof(taskItem));
-            JoinableTaskDependentData.RemoveDependency(taskItem, child);
+            JoinableTaskDependentData.RemoveDependency(taskItem, child, forceCleanup);
         }
 
         /// <summary>
@@ -400,7 +401,8 @@ namespace Microsoft.VisualStudio.Threading
             /// </summary>
             /// <param name="parentTaskOrCollection">The current joinableTask or collection contains to remove a dependency.</param>
             /// <param name="joinChild">The <see cref="IJoinableTaskDependent"/> to join as a child.</param>
-            internal static void RemoveDependency(IJoinableTaskDependent parentTaskOrCollection, IJoinableTaskDependent joinChild)
+            /// <param name="forceCleanup">Ignore refCount, it is being used when the child task is completed.</param>
+            internal static void RemoveDependency(IJoinableTaskDependent parentTaskOrCollection, IJoinableTaskDependent joinChild, bool forceCleanup)
             {
                 Requires.NotNull(parentTaskOrCollection, nameof(parentTaskOrCollection));
                 Requires.NotNull(joinChild, nameof(joinChild));
@@ -412,7 +414,7 @@ namespace Microsoft.VisualStudio.Threading
                     {
                         if (data.childDependentNodes is object && data.childDependentNodes.TryGetValue(joinChild, out int refCount))
                         {
-                            if (refCount == 1)
+                            if (refCount == 1 || forceCleanup)
                             {
                                 joinChild.OnRemovedFromDependency(parentTaskOrCollection);
 


### PR DESCRIPTION
It is called when a task is completed and all pending queue finished. Otherwise, the collection may reference a task which can be GCed.

This is an old bug, when a JTF is completed, but it has spin off work, which can run add join to JTF collections. Because the JTF is completed, the key point to clean it up from the graph is the time the code clean up all its incoming dependencies (which will clean up the outgoing one). However, because of this bug in the code, when a JTF collection has extra ref-count, it will stay in the graph, which can be a part of a circular reference. However, that completed JTF can be GCed later and disappears from the graph, and leaves stale refCount in the graph.

Before the last optimization, the recomputing can often happen which can fix the problem. In the new optimized code, when the task is GCed, it can run into a condition that the code decides the JTF collection is not a part of loop dependency (when it has no out-going dependency), and will keep the invalid sync task dependency after the task is finished long time ago. That leads IsMainThreadBlocked to return wrong value, and causes product issues.

I am trying to create a unit test for that, but it is tricky to get the task to GC on the right spot due to some internal JTF structures. I take a further look on that, but want to bring the fix, which blocks insertions.