### PR TITLE
An inconsistence whether dependencies of completed tasks should be included leads corrupted data structure

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
@@ -940,6 +940,9 @@ namespace Microsoft.VisualStudio.Threading
                             }
                             else if (tryAgainAfter is object)
                             {
+                                // prevent referencing tasks which may be GCed during the waiting cycle.
+                                visited?.Clear();
+
                                 ThreadingEventSource.Instance.WaitSynchronouslyStart();
                                 this.owner.WaitSynchronously(tryAgainAfter);
                                 ThreadingEventSource.Instance.WaitSynchronouslyStop();
@@ -1070,7 +1073,7 @@ namespace Microsoft.VisualStudio.Threading
 
                 if (work is null)
                 {
-                    if (joinableTask?.IsFullyCompleted != true)
+                    if (joinableTask?.IsCompleteRequested != true)
                     {
                         foreach (IJoinableTaskDependent? item in JoinableTaskDependencyGraph.GetDirectDependentNodes(currentNode))
                         {

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskDependencyGraph.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskDependencyGraph.cs
@@ -502,7 +502,11 @@ namespace Microsoft.VisualStudio.Threading
                     lock (syncTask.Factory.Context.SyncContextLock)
                     {
                         // Remove itself from the tracking list, after the task is completed.
-                        RemoveDependingSynchronousTask(syncTask, syncTask, force: true);
+                        var syncTaskItem = (IJoinableTaskDependent)syncTask;
+                        if (syncTaskItem.GetJoinableTaskDependentData().dependingSynchronousTaskTracking is object)
+                        {
+                            RemoveDependingSynchronousTask(syncTask, syncTask, force: true);
+                        }
 
                         if (syncTask.PotentialUnreachableDependents is object && syncTask.PotentialUnreachableDependents.Count > 0)
                         {
@@ -849,11 +853,7 @@ namespace Microsoft.VisualStudio.Threading
                 Requires.NotNull(syncTask, nameof(syncTask));
                 Assumes.True(Monitor.IsEntered(taskOrCollection.JoinableTaskContext.SyncContextLock));
 
-                var syncTaskItem = (IJoinableTaskDependent)syncTask;
-                if (syncTaskItem.GetJoinableTaskDependentData().dependingSynchronousTaskTracking is object)
-                {
-                    RemoveDependingSynchronousTaskFrom(new IJoinableTaskDependent[] { taskOrCollection }, syncTask, force);
-                }
+                RemoveDependingSynchronousTaskFrom(new IJoinableTaskDependent[] { taskOrCollection }, syncTask, force);
             }
 
             /// <summary>

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskDependencyGraph.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskDependencyGraph.cs
@@ -453,7 +453,7 @@ namespace Microsoft.VisualStudio.Threading
 
                 if (taskOrCollection is JoinableTask thisJoinableTask)
                 {
-                    if (thisJoinableTask.IsFullyCompleted || !joinables.Add(thisJoinableTask))
+                    if (thisJoinableTask.IsFullyCompleted || !joinables.Add(thisJoinableTask) || thisJoinableTask.IsCompleteRequested)
                     {
                         return;
                     }
@@ -532,6 +532,11 @@ namespace Microsoft.VisualStudio.Threading
                         if (remainNodes.Remove(taskOrCollection) && remainNodes.Count == 0)
                         {
                             // no remain task left, quit the loop earlier
+                            return;
+                        }
+
+                        if ((taskOrCollection as JoinableTask)?.IsCompleteRequested == true)
+                        {
                             return;
                         }
 

--- a/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskTests.cs
@@ -4164,7 +4164,6 @@ public class JoinableTaskTests : JoinableTaskTestBase
         await Task.Yield();
     }
 
-    [MethodImpl(MethodImplOptions.NoInlining)] // We need locals to surely be popped off the stack for a reliable test
     private async Task<JoinableTask> SpinOffMainThreadTaskForJoinableTaskDependenciesHandledAfterTaskCompletion(
         JoinableTaskFactory joinableTaskFactory,
         JoinableTaskCollection joinableTaskCollection,


### PR DESCRIPTION
In the JTF implementation, we don't include dependencies of a completed task in the ref-count tracking part, but includes them when scanning the dependencies directly. That inconsistency can lead dependency tracking data structure to be corrupted, and leads into IsMainThreadBlocked to return true for completed main thread tasks.

A new unit test was added to repro this problem, and also include changes to fix them. This change will stop dependency scanning on completed task node.

 It doesn't look like any existing unit test actually depending on this behavior.
