### PR TITLE
JoinTillEmptyAsync hangs for ref-counted JTF collection

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
@@ -995,7 +995,7 @@ namespace Microsoft.VisualStudio.Threading
 
                 foreach (IJoinableTaskDependent? collection in this.dependencyParents)
                 {
-                    JoinableTaskDependencyGraph.RemoveDependency(collection, this);
+                    JoinableTaskDependencyGraph.RemoveDependency(collection, this, forceCleanup: true);
                 }
 
                 if (this.mainThreadJobSyncContext is object)

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskDependencyGraph.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskDependencyGraph.cs
@@ -71,10 +71,11 @@ namespace Microsoft.VisualStudio.Threading
         /// </summary>
         /// <param name="taskItem">The current joinableTask or collection.</param>
         /// <param name="child">The <see cref="IJoinableTaskDependent"/> to join as a child.</param>
-        internal static void RemoveDependency(IJoinableTaskDependent taskItem, IJoinableTaskDependent child)
+        /// <param name="forceCleanup">Ignore refCount, it is being used when the child task is completed.</param>
+        internal static void RemoveDependency(IJoinableTaskDependent taskItem, IJoinableTaskDependent child, bool forceCleanup = false)
         {
             Requires.NotNull(taskItem, nameof(taskItem));
-            JoinableTaskDependentData.RemoveDependency(taskItem, child);
+            JoinableTaskDependentData.RemoveDependency(taskItem, child, forceCleanup);
         }
 
         /// <summary>
@@ -400,7 +401,8 @@ namespace Microsoft.VisualStudio.Threading
             /// </summary>
             /// <param name="parentTaskOrCollection">The current joinableTask or collection contains to remove a dependency.</param>
             /// <param name="joinChild">The <see cref="IJoinableTaskDependent"/> to join as a child.</param>
-            internal static void RemoveDependency(IJoinableTaskDependent parentTaskOrCollection, IJoinableTaskDependent joinChild)
+            /// <param name="forceCleanup">Ignore refCount, it is being used when the child task is completed.</param>
+            internal static void RemoveDependency(IJoinableTaskDependent parentTaskOrCollection, IJoinableTaskDependent joinChild, bool forceCleanup)
             {
                 Requires.NotNull(parentTaskOrCollection, nameof(parentTaskOrCollection));
                 Requires.NotNull(joinChild, nameof(joinChild));
@@ -412,7 +414,7 @@ namespace Microsoft.VisualStudio.Threading
                     {
                         if (data.childDependentNodes is object && data.childDependentNodes.TryGetValue(joinChild, out int refCount))
                         {
-                            if (refCount == 1)
+                            if (refCount == 1 || forceCleanup)
                             {
                                 joinChild.OnRemovedFromDependency(parentTaskOrCollection);
 

--- a/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskCollectionTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskCollectionTests.cs
@@ -196,4 +196,21 @@ public class JoinableTaskCollectionTests : JoinableTaskTestBase
             return Task.CompletedTask;
         });
     }
+
+    [Fact]
+    public void JoinTillEmptyWorksWithRefCounting()
+    {
+        var finishTaskEvent = new AsyncManualResetEvent();
+        JoinableTask? task = this.JoinableFactory.RunAsync(async delegate { await finishTaskEvent.WaitAsync().ConfigureAwait(false); });
+
+        var collection = new JoinableTaskCollection(this.context, refCountAddedJobs: true);
+
+        collection.Add(task);
+        collection.Add(task);
+
+        finishTaskEvent.Set();
+
+        Task? waiter = collection!.JoinTillEmptyAsync();
+        Assert.True(waiter.Wait(UnexpectedTimeout));
+    }
 }

--- a/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskCollectionTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskCollectionTests.cs
@@ -201,7 +201,7 @@ public class JoinableTaskCollectionTests : JoinableTaskTestBase
     public void JoinTillEmptyWorksWithRefCounting()
     {
         var finishTaskEvent = new AsyncManualResetEvent();
-        JoinableTask? task = this.JoinableFactory.RunAsync(async delegate { await finishTaskEvent.WaitAsync().ConfigureAwait(false); });
+        JoinableTask task = this.JoinableFactory.RunAsync(async delegate { await finishTaskEvent.WaitAsync().ConfigureAwait(false); });
 
         var collection = new JoinableTaskCollection(this.context, refCountAddedJobs: true);
 
@@ -210,7 +210,7 @@ public class JoinableTaskCollectionTests : JoinableTaskTestBase
 
         finishTaskEvent.Set();
 
-        Task? waiter = collection!.JoinTillEmptyAsync();
+        Task waiter = collection.JoinTillEmptyAsync();
         Assert.True(waiter.Wait(UnexpectedTimeout));
     }
 }


### PR DESCRIPTION
When a JTF task is fully completed, it removes itself from the dependency graph. However, the current logic only reduces ref-count by 1 on the parent side, and may leave it in the graph. (Which is a weak-reference table, so it will be GCed eventually.)

It looks like the code will maintain sync-blocking task chain of a completed task empty, so I could not find a way that this flaw logic actually leads into any corruption, but I still think it is worth to fix. It would be a problem if we move away from the weak-reference dependencies table in the future.