### PR TITLE
Minor code cleanups & improvements

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
@@ -990,6 +990,11 @@ namespace Microsoft.VisualStudio.Threading
 
         internal void OnQueueCompleted()
         {
+            if ((this.state & JoinableTaskFlags.CompleteFinalized) == JoinableTaskFlags.CompleteFinalized)
+            {
+                return;
+            }
+
             if (this.IsFullyCompleted)
             {
                 // Note this code may execute more than once, as multiple queue completion

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskCollection.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskCollection.cs
@@ -165,9 +165,10 @@ namespace Microsoft.VisualStudio.Threading
                 {
                     lock (this.Context.SyncContextLock)
                     {
-                        // We use interlocked here to mitigate race conditions in lazily initializing this field.
-                        // We *could* take a write lock above, but that would needlessly increase lock contention.
-                        AsyncManualResetEvent? nowait = Interlocked.CompareExchange(ref this.emptyEvent, new AsyncManualResetEvent(JoinableTaskDependencyGraph.HasNoChildDependentNode(this)), null);
+                        if (this.emptyEvent is null)
+                        {
+                            this.emptyEvent = new AsyncManualResetEvent(JoinableTaskDependencyGraph.HasNoChildDependentNode(this));
+                        }
                     }
                 }
             }

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskDependencyGraph.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskDependencyGraph.cs
@@ -665,7 +665,7 @@ namespace Microsoft.VisualStudio.Threading
                         var childrenTasks = new List<IJoinableTaskDependent>(this.childDependentNodes.Keys);
                         while (existingTaskTracking is object)
                         {
-                            RemoveDependingSynchronousTaskFrom(childrenTasks, existingTaskTracking.SynchronousTask, false);
+                            RemoveDependingSynchronousTaskFrom(childrenTasks, existingTaskTracking.SynchronousTask, force: existingTaskTracking.SynchronousTask == thisDependentNode);
 
                             HashSet<IJoinableTaskDependent>? potentialUnreachableDependents = existingTaskTracking.SynchronousTask.PotentialUnreachableDependents;
                             if (potentialUnreachableDependents is object && potentialUnreachableDependents.Count > 0)
@@ -881,7 +881,7 @@ namespace Microsoft.VisualStudio.Threading
 
                 if (force)
                 {
-                    reachableNodes = new HashSet<IJoinableTaskDependent>();
+                    reachableNodes = EmptySet;
                 }
 
                 foreach (IJoinableTaskDependent? task in tasks)
@@ -898,7 +898,7 @@ namespace Microsoft.VisualStudio.Threading
 
                         RemoveUnreachableDependentItems(syncTask, remainNodes, reachableNodes);
 
-                        syncTask.PotentialUnreachableDependents?.Clear();
+                        syncTask.PotentialUnreachableDependents = null;
                     }
                     else if (syncTask.PotentialUnreachableDependents != remainNodes)
                     {

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskDependencyGraph.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskDependencyGraph.cs
@@ -786,19 +786,17 @@ namespace Microsoft.VisualStudio.Threading
                 JoinableTask? thisJoinableTask = taskOrCollection as JoinableTask;
                 if (thisJoinableTask is object)
                 {
-                    if (thisJoinableTask.IsFullyCompleted)
-                    {
-                        return null;
-                    }
-
                     if (thisJoinableTask.IsCompleteRequested)
                     {
-                        // A completed task might still have pending items in the queue.
-                        int pendingCount = thisJoinableTask.GetPendingEventCountForSynchronousTask(synchronousTask);
-                        if (pendingCount > 0)
+                        if (!thisJoinableTask.IsFullyCompleted)
                         {
-                            totalEventsPending += pendingCount;
-                            return thisJoinableTask;
+                            // A completed task might still have pending items in the queue.
+                            int pendingCount = thisJoinableTask.GetPendingEventCountForSynchronousTask(synchronousTask);
+                            if (pendingCount > 0)
+                            {
+                                totalEventsPending += pendingCount;
+                                return thisJoinableTask;
+                            }
                         }
 
                         return null;


### PR DESCRIPTION
1, prevent allocating an empty set when we clean up a synchronized task.

2, adjust condition check orders

3, prevent OnQueueCompleted to run twice.

4, some renaming & clean up expired comments.

No functional impact.