### PR TITLE
Provide a faster but less accurate way to check whether the current task blocking UI thread

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskContext.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskContext.cs
@@ -340,11 +340,11 @@ namespace Microsoft.VisualStudio.Threading
         }
 
         /// <summary>
-        /// Gets a proximate value whether the main thread is blocked for the caller's completion.
+        /// Gets a very likely value whether the main thread is blocked for the caller's completion.
         /// It is less accurate when the UI thread blocking task just starts and hasn't been blocked yet, or the dependency chain is just removed.
         /// However, unlike <see cref="IsMainThreadBlocked"/>, this implementation is lock free, and faster in high contention scenarios.
         /// </summary>
-        public bool IsMainThreadBlockedProximately()
+        public bool IsMainThreadMaybeBlocked()
         {
             JoinableTask? ambientTask = this.AmbientTask;
             if (ambientTask is object)
@@ -354,7 +354,7 @@ namespace Microsoft.VisualStudio.Threading
                     return true;
                 }
 
-                return JoinableTaskDependencyGraph.HasMainThreadSynchronousTaskWaitingProximately(ambientTask);
+                return JoinableTaskDependencyGraph.MaybeHasMainThreadSynchronousTaskWaiting(ambientTask);
             }
 
             return false;

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskDependencyGraph.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskDependencyGraph.cs
@@ -56,11 +56,11 @@ namespace Microsoft.VisualStudio.Threading
         }
 
         /// <summary>
-        /// Gets a proximate value whether the main thread is blocked for the caller's completion.
+        /// Gets a likely value whether the main thread is blocked for the caller's completion.
         /// </summary>
-        internal static bool HasMainThreadSynchronousTaskWaitingProximately(IJoinableTaskDependent taskItem)
+        internal static bool MaybeHasMainThreadSynchronousTaskWaiting(IJoinableTaskDependent taskItem)
         {
-            return taskItem.GetJoinableTaskDependentData().HasMainThreadSynchronousTaskWaitingProximately();
+            return taskItem.GetJoinableTaskDependentData().MaybeHasMainThreadSynchronousTaskWaiting();
         }
 
         /// <summary>
@@ -659,9 +659,9 @@ namespace Microsoft.VisualStudio.Threading
             }
 
             /// <summary>
-            /// Gets a proximate value whether the main thread is blocked for the caller's completion.
+            /// Gets a likely value whether the main thread is blocked for the caller's completion.
             /// </summary>
-            internal bool HasMainThreadSynchronousTaskWaitingProximately()
+            internal bool MaybeHasMainThreadSynchronousTaskWaiting()
             {
                 DependentSynchronousTask? existingTaskTracking = this.dependingSynchronousTaskTracking;
                 while (existingTaskTracking is object)

--- a/src/Microsoft.VisualStudio.Threading/net472/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/net472/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
 Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.AsyncReaderWriterLock(Microsoft.VisualStudio.Threading.JoinableTaskContext? joinableTaskContext, bool captureDiagnostics = false) -> void
 Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.AsyncReaderWriterResourceLock(Microsoft.VisualStudio.Threading.JoinableTaskContext? joinableTaskContext, bool captureDiagnostics) -> void
+Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadBlockedProximately() -> bool
 virtual Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.DeadlockCheckTimeout.get -> System.TimeSpan

--- a/src/Microsoft.VisualStudio.Threading/net472/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/net472/PublicAPI.Unshipped.txt
@@ -1,4 +1,4 @@
 Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.AsyncReaderWriterLock(Microsoft.VisualStudio.Threading.JoinableTaskContext? joinableTaskContext, bool captureDiagnostics = false) -> void
 Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.AsyncReaderWriterResourceLock(Microsoft.VisualStudio.Threading.JoinableTaskContext? joinableTaskContext, bool captureDiagnostics) -> void
-Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadBlockedProximately() -> bool
+Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadMaybeBlocked() -> bool
 virtual Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.DeadlockCheckTimeout.get -> System.TimeSpan

--- a/src/Microsoft.VisualStudio.Threading/netcoreapp3.1/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/netcoreapp3.1/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
 Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.AsyncReaderWriterLock(Microsoft.VisualStudio.Threading.JoinableTaskContext? joinableTaskContext, bool captureDiagnostics = false) -> void
 Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.AsyncReaderWriterResourceLock(Microsoft.VisualStudio.Threading.JoinableTaskContext? joinableTaskContext, bool captureDiagnostics) -> void
+Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadBlockedProximately() -> bool
 virtual Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.DeadlockCheckTimeout.get -> System.TimeSpan

--- a/src/Microsoft.VisualStudio.Threading/netcoreapp3.1/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/netcoreapp3.1/PublicAPI.Unshipped.txt
@@ -1,4 +1,4 @@
 Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.AsyncReaderWriterLock(Microsoft.VisualStudio.Threading.JoinableTaskContext? joinableTaskContext, bool captureDiagnostics = false) -> void
 Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.AsyncReaderWriterResourceLock(Microsoft.VisualStudio.Threading.JoinableTaskContext? joinableTaskContext, bool captureDiagnostics) -> void
-Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadBlockedProximately() -> bool
+Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadMaybeBlocked() -> bool
 virtual Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.DeadlockCheckTimeout.get -> System.TimeSpan

--- a/src/Microsoft.VisualStudio.Threading/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
 Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.AsyncReaderWriterLock(Microsoft.VisualStudio.Threading.JoinableTaskContext? joinableTaskContext, bool captureDiagnostics = false) -> void
 Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.AsyncReaderWriterResourceLock(Microsoft.VisualStudio.Threading.JoinableTaskContext? joinableTaskContext, bool captureDiagnostics) -> void
+Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadBlockedProximately() -> bool
 virtual Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.DeadlockCheckTimeout.get -> System.TimeSpan

--- a/src/Microsoft.VisualStudio.Threading/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,4 +1,4 @@
 Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.AsyncReaderWriterLock(Microsoft.VisualStudio.Threading.JoinableTaskContext? joinableTaskContext, bool captureDiagnostics = false) -> void
 Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.AsyncReaderWriterResourceLock(Microsoft.VisualStudio.Threading.JoinableTaskContext? joinableTaskContext, bool captureDiagnostics) -> void
-Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadBlockedProximately() -> bool
+Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadMaybeBlocked() -> bool
 virtual Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.DeadlockCheckTimeout.get -> System.TimeSpan

--- a/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskContextNodeTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskContextNodeTests.cs
@@ -63,8 +63,8 @@ public class JoinableTaskContextNodeTests : JoinableTaskTestBase
     {
         Assert.False(this.defaultNode.IsMainThreadBlocked());
         Assert.False(this.derivedNode.IsMainThreadBlocked());
-        Assert.False(this.defaultNode.Context.IsMainThreadBlockedProximately());
-        Assert.False(this.derivedNode.Context.IsMainThreadBlockedProximately());
+        Assert.False(this.defaultNode.Context.IsMainThreadMaybeBlocked());
+        Assert.False(this.derivedNode.Context.IsMainThreadMaybeBlocked());
     }
 
     [Fact]

--- a/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskContextNodeTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskContextNodeTests.cs
@@ -63,6 +63,8 @@ public class JoinableTaskContextNodeTests : JoinableTaskTestBase
     {
         Assert.False(this.defaultNode.IsMainThreadBlocked());
         Assert.False(this.derivedNode.IsMainThreadBlocked());
+        Assert.False(this.defaultNode.Context.IsMainThreadBlockedProximately());
+        Assert.False(this.derivedNode.Context.IsMainThreadBlockedProximately());
     }
 
     [Fact]

--- a/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskContextTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskContextTests.cs
@@ -498,6 +498,7 @@ public class JoinableTaskContextTests : JoinableTaskTestBase
     public void IsMainThreadBlockedFalseWithNoTask()
     {
         Assert.False(this.Context.IsMainThreadBlocked());
+        Assert.False(this.Context.IsMainThreadBlockedProximately());
     }
 
     [Fact]
@@ -506,8 +507,10 @@ public class JoinableTaskContextTests : JoinableTaskTestBase
         JoinableTask? joinable = this.Factory.RunAsync(async delegate
         {
             Assert.False(this.Context.IsMainThreadBlocked());
+            Assert.False(this.Context.IsMainThreadBlockedProximately());
             await Task.Yield();
             Assert.False(this.Context.IsMainThreadBlocked());
+            Assert.False(this.Context.IsMainThreadBlockedProximately());
             this.testFrame.Continue = false;
         });
 
@@ -520,18 +523,28 @@ public class JoinableTaskContextTests : JoinableTaskTestBase
     {
         JoinableTask? joinable = this.Factory.RunAsync(async delegate
         {
+            Assert.False(this.Context.IsMainThreadBlockedProximately());
             Assert.False(this.Context.IsMainThreadBlocked());
+
             await Task.Yield();
+            Assert.True(this.Context.IsMainThreadBlockedProximately());
             Assert.True(this.Context.IsMainThreadBlocked()); // we're now running on top of Join()
+
             await TaskScheduler.Default.SwitchTo(alwaysYield: true);
+            Assert.True(this.Context.IsMainThreadBlockedProximately());
             Assert.True(this.Context.IsMainThreadBlocked()); // although we're on background thread, we're blocking main thread.
 
             await this.Factory.RunAsync(async delegate
             {
+                Assert.True(this.Context.IsMainThreadBlockedProximately());
                 Assert.True(this.Context.IsMainThreadBlocked());
                 await Task.Yield();
+
+                Assert.True(this.Context.IsMainThreadBlockedProximately());
                 Assert.True(this.Context.IsMainThreadBlocked());
+
                 await this.Factory.SwitchToMainThreadAsync();
+                Assert.True(this.Context.IsMainThreadBlockedProximately());
                 Assert.True(this.Context.IsMainThreadBlocked());
             });
         });
@@ -544,14 +557,20 @@ public class JoinableTaskContextTests : JoinableTaskTestBase
     {
         JoinableTask? joinable = this.Factory.RunAsync(async delegate
         {
+            Assert.False(this.Context.IsMainThreadBlockedProximately());
             Assert.False(this.Context.IsMainThreadBlocked());
             await Task.Yield();
+
+            Assert.False(this.Context.IsMainThreadBlockedProximately());
             Assert.False(this.Context.IsMainThreadBlocked());
+
             await TaskScheduler.Default.SwitchTo(alwaysYield: true);
+            Assert.False(this.Context.IsMainThreadBlockedProximately());
             Assert.False(this.Context.IsMainThreadBlocked());
 
             await this.Factory.RunAsync(async delegate
             {
+                Assert.False(this.Context.IsMainThreadBlockedProximately());
                 Assert.False(this.Context.IsMainThreadBlocked());
 
                 // Now release the message pump so we hit the Join() call
@@ -560,8 +579,11 @@ public class JoinableTaskContextTests : JoinableTaskTestBase
                 await Task.Yield();
 
                 // From now on, we're blocking.
+                Assert.True(this.Context.IsMainThreadBlockedProximately());
                 Assert.True(this.Context.IsMainThreadBlocked());
+
                 await TaskScheduler.Default.SwitchTo(alwaysYield: true);
+                Assert.True(this.Context.IsMainThreadBlockedProximately());
                 Assert.True(this.Context.IsMainThreadBlocked());
             });
         });
@@ -575,18 +597,28 @@ public class JoinableTaskContextTests : JoinableTaskTestBase
     {
         this.Factory.Run(async delegate
         {
+            Assert.True(this.Context.IsMainThreadBlockedProximately());
             Assert.True(this.Context.IsMainThreadBlocked());
             await Task.Yield();
+
+            Assert.True(this.Context.IsMainThreadBlockedProximately());
             Assert.True(this.Context.IsMainThreadBlocked());
+
             await TaskScheduler.Default.SwitchTo(alwaysYield: true);
+            Assert.True(this.Context.IsMainThreadBlockedProximately());
             Assert.True(this.Context.IsMainThreadBlocked());
 
             await this.Factory.RunAsync(async delegate
             {
+                Assert.True(this.Context.IsMainThreadBlockedProximately());
                 Assert.True(this.Context.IsMainThreadBlocked());
+
                 await Task.Yield();
+                Assert.True(this.Context.IsMainThreadBlockedProximately());
                 Assert.True(this.Context.IsMainThreadBlocked());
+
                 await this.Factory.SwitchToMainThreadAsync();
+                Assert.True(this.Context.IsMainThreadBlockedProximately());
                 Assert.True(this.Context.IsMainThreadBlocked());
             });
         });
@@ -599,8 +631,11 @@ public class JoinableTaskContextTests : JoinableTaskTestBase
         {
             this.Factory.Run(async delegate
             {
+                Assert.False(this.Context.IsMainThreadBlockedProximately());
                 Assert.False(this.Context.IsMainThreadBlocked());
+
                 await Task.Yield();
+                Assert.False(this.Context.IsMainThreadBlockedProximately());
                 Assert.False(this.Context.IsMainThreadBlocked());
             });
         }).WaitWithoutInlining(throwOriginalException: true);
@@ -616,10 +651,14 @@ public class JoinableTaskContextTests : JoinableTaskTestBase
         {
             joinableTask = this.Factory.RunAsync(async delegate
             {
+                Assert.False(this.Context.IsMainThreadBlockedProximately());
                 Assert.False(this.Context.IsMainThreadBlocked());
+
                 nonBlockingStateObserved.Set();
                 await Task.Yield();
                 await nowBlocking;
+
+                Assert.True(this.Context.IsMainThreadBlockedProximately());
                 Assert.True(this.Context.IsMainThreadBlocked());
             });
         }).Wait();

--- a/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskContextTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskContextTests.cs
@@ -498,7 +498,7 @@ public class JoinableTaskContextTests : JoinableTaskTestBase
     public void IsMainThreadBlockedFalseWithNoTask()
     {
         Assert.False(this.Context.IsMainThreadBlocked());
-        Assert.False(this.Context.IsMainThreadBlockedProximately());
+        Assert.False(this.Context.IsMainThreadMaybeBlocked());
     }
 
     [Fact]
@@ -507,10 +507,10 @@ public class JoinableTaskContextTests : JoinableTaskTestBase
         JoinableTask? joinable = this.Factory.RunAsync(async delegate
         {
             Assert.False(this.Context.IsMainThreadBlocked());
-            Assert.False(this.Context.IsMainThreadBlockedProximately());
+            Assert.False(this.Context.IsMainThreadMaybeBlocked());
             await Task.Yield();
             Assert.False(this.Context.IsMainThreadBlocked());
-            Assert.False(this.Context.IsMainThreadBlockedProximately());
+            Assert.False(this.Context.IsMainThreadMaybeBlocked());
             this.testFrame.Continue = false;
         });
 
@@ -523,28 +523,28 @@ public class JoinableTaskContextTests : JoinableTaskTestBase
     {
         JoinableTask? joinable = this.Factory.RunAsync(async delegate
         {
-            Assert.False(this.Context.IsMainThreadBlockedProximately());
+            Assert.False(this.Context.IsMainThreadMaybeBlocked());
             Assert.False(this.Context.IsMainThreadBlocked());
 
             await Task.Yield();
-            Assert.True(this.Context.IsMainThreadBlockedProximately());
+            Assert.True(this.Context.IsMainThreadMaybeBlocked());
             Assert.True(this.Context.IsMainThreadBlocked()); // we're now running on top of Join()
 
             await TaskScheduler.Default.SwitchTo(alwaysYield: true);
-            Assert.True(this.Context.IsMainThreadBlockedProximately());
+            Assert.True(this.Context.IsMainThreadMaybeBlocked());
             Assert.True(this.Context.IsMainThreadBlocked()); // although we're on background thread, we're blocking main thread.
 
             await this.Factory.RunAsync(async delegate
             {
-                Assert.True(this.Context.IsMainThreadBlockedProximately());
+                Assert.True(this.Context.IsMainThreadMaybeBlocked());
                 Assert.True(this.Context.IsMainThreadBlocked());
                 await Task.Yield();
 
-                Assert.True(this.Context.IsMainThreadBlockedProximately());
+                Assert.True(this.Context.IsMainThreadMaybeBlocked());
                 Assert.True(this.Context.IsMainThreadBlocked());
 
                 await this.Factory.SwitchToMainThreadAsync();
-                Assert.True(this.Context.IsMainThreadBlockedProximately());
+                Assert.True(this.Context.IsMainThreadMaybeBlocked());
                 Assert.True(this.Context.IsMainThreadBlocked());
             });
         });
@@ -557,20 +557,20 @@ public class JoinableTaskContextTests : JoinableTaskTestBase
     {
         JoinableTask? joinable = this.Factory.RunAsync(async delegate
         {
-            Assert.False(this.Context.IsMainThreadBlockedProximately());
+            Assert.False(this.Context.IsMainThreadMaybeBlocked());
             Assert.False(this.Context.IsMainThreadBlocked());
             await Task.Yield();
 
-            Assert.False(this.Context.IsMainThreadBlockedProximately());
+            Assert.False(this.Context.IsMainThreadMaybeBlocked());
             Assert.False(this.Context.IsMainThreadBlocked());
 
             await TaskScheduler.Default.SwitchTo(alwaysYield: true);
-            Assert.False(this.Context.IsMainThreadBlockedProximately());
+            Assert.False(this.Context.IsMainThreadMaybeBlocked());
             Assert.False(this.Context.IsMainThreadBlocked());
 
             await this.Factory.RunAsync(async delegate
             {
-                Assert.False(this.Context.IsMainThreadBlockedProximately());
+                Assert.False(this.Context.IsMainThreadMaybeBlocked());
                 Assert.False(this.Context.IsMainThreadBlocked());
 
                 // Now release the message pump so we hit the Join() call
@@ -579,11 +579,11 @@ public class JoinableTaskContextTests : JoinableTaskTestBase
                 await Task.Yield();
 
                 // From now on, we're blocking.
-                Assert.True(this.Context.IsMainThreadBlockedProximately());
+                Assert.True(this.Context.IsMainThreadMaybeBlocked());
                 Assert.True(this.Context.IsMainThreadBlocked());
 
                 await TaskScheduler.Default.SwitchTo(alwaysYield: true);
-                Assert.True(this.Context.IsMainThreadBlockedProximately());
+                Assert.True(this.Context.IsMainThreadMaybeBlocked());
                 Assert.True(this.Context.IsMainThreadBlocked());
             });
         });
@@ -597,28 +597,28 @@ public class JoinableTaskContextTests : JoinableTaskTestBase
     {
         this.Factory.Run(async delegate
         {
-            Assert.True(this.Context.IsMainThreadBlockedProximately());
+            Assert.True(this.Context.IsMainThreadMaybeBlocked());
             Assert.True(this.Context.IsMainThreadBlocked());
             await Task.Yield();
 
-            Assert.True(this.Context.IsMainThreadBlockedProximately());
+            Assert.True(this.Context.IsMainThreadMaybeBlocked());
             Assert.True(this.Context.IsMainThreadBlocked());
 
             await TaskScheduler.Default.SwitchTo(alwaysYield: true);
-            Assert.True(this.Context.IsMainThreadBlockedProximately());
+            Assert.True(this.Context.IsMainThreadMaybeBlocked());
             Assert.True(this.Context.IsMainThreadBlocked());
 
             await this.Factory.RunAsync(async delegate
             {
-                Assert.True(this.Context.IsMainThreadBlockedProximately());
+                Assert.True(this.Context.IsMainThreadMaybeBlocked());
                 Assert.True(this.Context.IsMainThreadBlocked());
 
                 await Task.Yield();
-                Assert.True(this.Context.IsMainThreadBlockedProximately());
+                Assert.True(this.Context.IsMainThreadMaybeBlocked());
                 Assert.True(this.Context.IsMainThreadBlocked());
 
                 await this.Factory.SwitchToMainThreadAsync();
-                Assert.True(this.Context.IsMainThreadBlockedProximately());
+                Assert.True(this.Context.IsMainThreadMaybeBlocked());
                 Assert.True(this.Context.IsMainThreadBlocked());
             });
         });
@@ -631,11 +631,11 @@ public class JoinableTaskContextTests : JoinableTaskTestBase
         {
             this.Factory.Run(async delegate
             {
-                Assert.False(this.Context.IsMainThreadBlockedProximately());
+                Assert.False(this.Context.IsMainThreadMaybeBlocked());
                 Assert.False(this.Context.IsMainThreadBlocked());
 
                 await Task.Yield();
-                Assert.False(this.Context.IsMainThreadBlockedProximately());
+                Assert.False(this.Context.IsMainThreadMaybeBlocked());
                 Assert.False(this.Context.IsMainThreadBlocked());
             });
         }).WaitWithoutInlining(throwOriginalException: true);
@@ -651,14 +651,14 @@ public class JoinableTaskContextTests : JoinableTaskTestBase
         {
             joinableTask = this.Factory.RunAsync(async delegate
             {
-                Assert.False(this.Context.IsMainThreadBlockedProximately());
+                Assert.False(this.Context.IsMainThreadMaybeBlocked());
                 Assert.False(this.Context.IsMainThreadBlocked());
 
                 nonBlockingStateObserved.Set();
                 await Task.Yield();
                 await nowBlocking;
 
-                Assert.True(this.Context.IsMainThreadBlockedProximately());
+                Assert.True(this.Context.IsMainThreadMaybeBlocked());
                 Assert.True(this.Context.IsMainThreadBlocked());
             });
         }).Wait();


### PR DESCRIPTION
I talked about this during a discussion of using this to set task priority or capture slow stacks.

The original MainThreadBlocking check can be slow, and requires a global sync lock. That makes it not suitable to be used in hot paths. We already notice it to pop up in some slow perf traces. 

The new one is lock free, and doesn't check a few special conditions. Notably, under those conditions the new function would return wrong values:

1, the UI blocking task disjoins some tasks after certain condition is reached. The new method usually will return correct value. However, it does return incorrect value, if there are some circular dependencies, and the cleanup code can be delayed. If this check is done between that time frame, it can be false positive. (This was done to reduce repeating running cleanup logic).

2, a UI blocking task just starts, and it spin off child tasks, before the first blocking time of the UI blocking task, this new method will return false negative value inside spin-off tasks. The reason is that the data structure to track blocking dependencies is not created until the first blocking point. (This was done to prevent extra computation/allocation for JTF.Run task which can finish without any blocking time.)

Dealing with those special conditions are the main reason to slow down the current more accurate implementation. However in many cases, we can live with those gaps by getting perf gains, which is the reason to create the new implementation and exposes it differently. 
