### PR TITLE
Use strong references for JTF dependencies.

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskDependencyGraph.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskDependencyGraph.cs
@@ -290,7 +290,7 @@ namespace Microsoft.VisualStudio.Threading
             /// When the value in an entry is decremented to 0, the entry is removed from the map.
             /// </remarks>
             [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-            private WeakKeyDictionary<IJoinableTaskDependent, int> childDependentNodes;
+            private Dictionary<IJoinableTaskDependent, int> childDependentNodes;
 
             /// <summary>
             /// The head of a singly linked list of records to track which task may process events of this task.
@@ -301,7 +301,7 @@ namespace Microsoft.VisualStudio.Threading
             /// <summary>
             /// Gets a value indicating whether the <see cref="childDependentNodes"/> is empty.
             /// </summary>
-            internal bool HasNoChildDependentNode => this.childDependentNodes is null || this.childDependentNodes.Count == 0 || !this.childDependentNodes.Any();
+            internal bool HasNoChildDependentNode => this.childDependentNodes is null || this.childDependentNodes.Count == 0;
 
             /// <summary>
             /// Gets a snapshot of all joined tasks.
@@ -352,7 +352,7 @@ namespace Microsoft.VisualStudio.Threading
                         ref JoinableTaskDependentData data = ref parentTaskOrCollection.GetJoinableTaskDependentData();
                         if (data.childDependentNodes is null)
                         {
-                            data.childDependentNodes = new WeakKeyDictionary<IJoinableTaskDependent, int>(capacity: 2);
+                            data.childDependentNodes = new Dictionary<IJoinableTaskDependent, int>(capacity: 2);
                         }
 
                         if (data.childDependentNodes.TryGetValue(joinChild, out int refCount) && !parentTaskOrCollection.NeedRefCountChildDependencies)
@@ -471,7 +471,7 @@ namespace Microsoft.VisualStudio.Threading
                     }
                 }
 
-                WeakKeyDictionary<IJoinableTaskDependent, int>? childDependentNodes = taskOrCollection.GetJoinableTaskDependentData().childDependentNodes;
+                Dictionary<IJoinableTaskDependent, int>? childDependentNodes = taskOrCollection.GetJoinableTaskDependentData().childDependentNodes;
                 if (childDependentNodes is object)
                 {
                     foreach (KeyValuePair<IJoinableTaskDependent, int> item in childDependentNodes)
@@ -555,7 +555,7 @@ namespace Microsoft.VisualStudio.Threading
                             return;
                         }
 
-                        WeakKeyDictionary<IJoinableTaskDependent, int>? dependencies = taskOrCollection.GetJoinableTaskDependentData().childDependentNodes;
+                        Dictionary<IJoinableTaskDependent, int>? dependencies = taskOrCollection.GetJoinableTaskDependentData().childDependentNodes;
                         if (dependencies is object)
                         {
                             foreach (KeyValuePair<IJoinableTaskDependent, int> item in dependencies)
@@ -664,7 +664,7 @@ namespace Microsoft.VisualStudio.Threading
 
                     if (this.childDependentNodes is object)
                     {
-                        var childrenTasks = new List<IJoinableTaskDependent>(this.childDependentNodes.Keys);
+                        Dictionary<IJoinableTaskDependent, int>.KeyCollection? childrenTasks = this.childDependentNodes.Keys;
                         while (existingTaskTracking is object)
                         {
                             RemoveDependingSynchronousTaskFrom(childrenTasks, existingTaskTracking.SynchronousTask, force: existingTaskTracking.SynchronousTask == thisDependentNode);
@@ -871,7 +871,7 @@ namespace Microsoft.VisualStudio.Threading
             /// <param name="tasks">A list of tasks we need update the tracking list.</param>
             /// <param name="syncTask">The synchronous task we want to remove.</param>
             /// <param name="force">We always remove it from the tracking list if it is true.  Otherwise, we keep tracking the reference count.</param>
-            private static void RemoveDependingSynchronousTaskFrom(IReadOnlyList<IJoinableTaskDependent> tasks, JoinableTask syncTask, bool force)
+            private static void RemoveDependingSynchronousTaskFrom(IReadOnlyCollection<IJoinableTaskDependent> tasks, JoinableTask syncTask, bool force)
             {
                 Requires.NotNull(tasks, nameof(tasks));
                 Requires.NotNull(syncTask, nameof(syncTask));


### PR DESCRIPTION
Consider in Dev 17.

Move away from WeakReferenceDictionary, and switch to strong reference in JTF dependency graph. This would reduce the complexity/overhead of the data structure & also makes it much easier to walk through the dependencies tree in a debug session.

Weak reference gives very little value to us here, because:
 1, all incompleted JTF tasks are referenced by a global strong reference table inside JTF Context, so a weak reference to them will lead them to be GCed.
2, when JTF task is completed, it always removes itself from the graph

Basically, a weak reference to a JTF task inside JTF dependency graph never gives any memory benefit.

A weak reference to a JTF Collection does give some benefit, if it is no longer used and empty, but is still held by a not completed JTF task (Joins to a collection). In that case, the weak reference does allow the JTF collection to be GCed. But in the real product, this is fairly rare, and the memory usage of an empty JTF collection is limited, comparing the overhead of using weak reference dictionary in all JTF tasks/collections to track their dependencies.
