### PR TITLE
Suppress reporting VSTHRD114 diagnostic on `Task?` returning methods

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/CSharpUtils.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/CSharpUtils.cs
@@ -203,6 +203,29 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
             return objectCreation.Syntax;
         }
 
+        internal override bool MethodReturnsNullableReferenceType(IMethodSymbol methodSymbol)
+        {
+            SyntaxReference? syntaxReference = methodSymbol.DeclaringSyntaxReferences.FirstOrDefault();
+            if (syntaxReference == null)
+            {
+                return false;
+            }
+
+            SyntaxNode syntaxNode = syntaxReference.GetSyntax();
+            TypeSyntax? returnType = null;
+
+            if (syntaxNode is MethodDeclarationSyntax methodDeclSyntax)
+            {
+                returnType = methodDeclSyntax.ReturnType;
+            }
+            else if (syntaxNode is LocalFunctionStatementSyntax localFunc)
+            {
+                returnType = localFunc.ReturnType;
+            }
+
+            return returnType != null && returnType.IsKind(SyntaxKind.NullableType);
+        }
+
         internal readonly struct ContainingFunctionData
         {
             internal ContainingFunctionData(CSharpSyntaxNode function, bool isAsync, ParameterListSyntax parameterList, CSharpSyntaxNode blockOrExpression)

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/CSharpVSTHRD114AvoidReturningNullTaskAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/CSharpVSTHRD114AvoidReturningNullTaskAnalyzer.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.Threading.Analyzers
+{
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.Diagnostics;
+
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class CSharpVSTHRD114AvoidReturningNullTaskAnalyzer : AbstractVSTHRD114AvoidReturningNullTaskAnalyzer
+    {
+        private protected override LanguageUtils LanguageUtils => CSharpUtils.Instance;
+    }
+}

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/VSTHRD114AvoidReturningNullTaskCodeFix.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/VSTHRD114AvoidReturningNullTaskCodeFix.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
     public class VSTHRD114AvoidReturningNullTaskCodeFix : CodeFixProvider
     {
         private static readonly ImmutableArray<string> ReusableFixableDiagnosticIds = ImmutableArray.Create(
-            VSTHRD114AvoidReturningNullTaskAnalyzer.Id);
+            AbstractVSTHRD114AvoidReturningNullTaskAnalyzer.Id);
 
         /// <inheritdoc />
         public override ImmutableArray<string> FixableDiagnosticIds => ReusableFixableDiagnosticIds;

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.VisualBasic/VisualBasicUtils.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.VisualBasic/VisualBasicUtils.cs
@@ -87,5 +87,11 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
         {
             return objectCreation.Syntax;
         }
+
+        internal override bool MethodReturnsNullableReferenceType(IMethodSymbol methodSymbol)
+        {
+            // VB.NET doesn't support nullable reference types
+            return false;
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.VisualBasic/VisualBasicVSTHRD114AvoidReturningNullTaskAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.VisualBasic/VisualBasicVSTHRD114AvoidReturningNullTaskAnalyzer.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.Threading.Analyzers
+{
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.Diagnostics;
+
+    [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
+    public sealed class VisualBasicVSTHRD114AvoidReturningNullTaskAnalyzer : AbstractVSTHRD114AvoidReturningNullTaskAnalyzer
+    {
+        private protected override LanguageUtils LanguageUtils => VisualBasicUtils.Instance;
+    }
+}

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/LanguageUtils.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/LanguageUtils.cs
@@ -14,5 +14,7 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
         internal abstract SyntaxNode IsolateMethodName(IInvocationOperation invocation);
 
         internal abstract SyntaxNode IsolateMethodName(IObjectCreationOperation objectCreation);
+
+        internal abstract bool MethodReturnsNullableReferenceType(IMethodSymbol method);
     }
 }

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD114AvoidReturningNullTaskAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD114AvoidReturningNullTaskAnalyzerTests.cs
@@ -5,8 +5,8 @@ namespace Microsoft.VisualStudio.Threading.Analyzers.Tests
 {
     using System.Threading.Tasks;
     using Xunit;
-    using VerifyCS = CSharpCodeFixVerifier<VSTHRD114AvoidReturningNullTaskAnalyzer, CodeAnalysis.Testing.EmptyCodeFixProvider>;
-    using VerifyVB = VisualBasicCodeFixVerifier<VSTHRD114AvoidReturningNullTaskAnalyzer, CodeAnalysis.Testing.EmptyCodeFixProvider>;
+    using VerifyCS = CSharpCodeFixVerifier<CSharpVSTHRD114AvoidReturningNullTaskAnalyzer, CodeAnalysis.Testing.EmptyCodeFixProvider>;
+    using VerifyVB = VisualBasicCodeFixVerifier<VisualBasicVSTHRD114AvoidReturningNullTaskAnalyzer, CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
     public class VSTHRD114AvoidReturningNullTaskAnalyzerTests
     {
@@ -275,6 +275,45 @@ class Test
     public void Foo()
     {
         async Task<object> GetTaskObj()
+        {
+            return null;
+        }
+    }
+}
+";
+            await new VerifyCS.Test
+            {
+                TestCode = csharpTest,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task ReturnNullableTask_NoDiagnostic()
+        {
+            var csharpTest = @"
+using System;
+using System.Threading.Tasks;
+
+class Test
+{
+    public Task? GetTask()
+    {
+        return null;
+    }
+
+    public Task<int>? GetTaskOfInt()
+    {
+        return null;
+    }
+
+    public Task<object?>? GetTaskOfNullableObject()
+    {
+        return null;
+    }
+
+    public void LocalFunc()
+    {
+        Task<object>? GetTaskObj()
         {
             return null;
         }

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD114AvoidReturningNullTaskCodeFixTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD114AvoidReturningNullTaskCodeFixTests.cs
@@ -5,8 +5,8 @@ namespace Microsoft.VisualStudio.Threading.Analyzers.Tests
 {
     using System.Threading.Tasks;
     using Xunit;
-    using VerifyCS = CSharpCodeFixVerifier<VSTHRD114AvoidReturningNullTaskAnalyzer, VSTHRD114AvoidReturningNullTaskCodeFix>;
-    using VerifyVB = VisualBasicCodeFixVerifier<VSTHRD114AvoidReturningNullTaskAnalyzer, VSTHRD114AvoidReturningNullTaskCodeFix>;
+    using VerifyCS = CSharpCodeFixVerifier<CSharpVSTHRD114AvoidReturningNullTaskAnalyzer, VSTHRD114AvoidReturningNullTaskCodeFix>;
+    using VerifyVB = VisualBasicCodeFixVerifier<VisualBasicVSTHRD114AvoidReturningNullTaskAnalyzer, VSTHRD114AvoidReturningNullTaskCodeFix>;
 
     public class VSTHRD114AvoidReturningNullTaskCodeFixTests
     {


### PR DESCRIPTION
VSTHRD114 now ignores C# methods returning `Task?`

Converted VSTHRD114 to an abstract base class in order to use LanguageUtils.

This implementation uses syntax nodes to detect the nullable return type, which means the Roslyn CodeAnalysis does not need to be upgraded.

It prevents VSTHRD114 warnings on cases like these:

```
public Task? GetTask()
{
    return null;
}

public Task<int>? GetTaskOfInt()
{
    return null;
}

public Task<object?>? GetTaskOfNullableObject()
{
    return null;
}

public void LocalFunc()
{
    Task<object>? GetTaskObj()
    {
        return null;
    }
}
```

But it doesn't prevent warnings for anonymous functions or lambdas, like:

```
public void StillProducesWarning()
{
    Func<Task?> func = () =>
    {
        return null;
    };
}
```

If and when the Roslyn upgrade happens the implementation can be simplified to use [IMethodSymbol.ReturnNullableAnnotation](https://docs.microsoft.com/en-us/dotnet/api/microsoft.codeanalysis.imethodsymbol.returnnullableannotation?view=roslyn-dotnet-3.9.0) and that will solve the anon/lambda cases too.

Closes #637