### PR TITLE
Update VSTHRD110 to handle conditional access expressions

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD110ObserveResultOfAsyncCallsAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD110ObserveResultOfAsyncCallsAnalyzer.cs
@@ -46,7 +46,7 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
 
                 // Only consider invocations that are direct statements. Otherwise, we assume their
                 // result is awaited, assigned, or otherwise consumed.
-                if (invocation.Parent?.GetType().Equals(typeof(ExpressionStatementSyntax)) ?? false)
+                if (invocation.Parent is ExpressionStatementSyntax || invocation.Parent is ConditionalAccessExpressionSyntax)
                 {
                     var methodSymbol = context.SemanticModel.GetSymbolInfo(context.Node).Symbol as IMethodSymbol;
                     if (this.IsAwaitableType(methodSymbol?.ReturnType, context.Compilation, context.CancellationToken))

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD110ObserveResultOfAsyncCallsAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD110ObserveResultOfAsyncCallsAnalyzerTests.cs
@@ -363,6 +363,45 @@ class Test {
             await Verify.VerifyAnalyzerAsync(test, expected);
         }
 
+        [Fact]
+        public async Task ConditionalAccess_ProducesDiagnostic()
+        {
+            var test = @"
+using System.Threading.Tasks;
+
+class Test {
+    void Foo(Test? tester)
+    {
+        tester?.BarAsync();
+    }
+
+    Task BarAsync() => null;
+}
+";
+
+            DiagnosticResult expected = this.CreateDiagnostic(7, 17, 8);
+            await Verify.VerifyAnalyzerAsync(test, expected);
+        }
+
+        [Fact]
+        public async Task ConditionalAccessAwaited_ProducesNoDiagnostic()
+        {
+            var test = @"
+using System.Threading.Tasks;
+
+class Test {
+    async Task Foo(Test? tester)
+    {
+        await (tester?.BarAsync() ?? Task.CompletedTask);
+    }
+
+    Task BarAsync() => null;
+}
+";
+
+            await Verify.VerifyAnalyzerAsync(test);
+        }
+
         private DiagnosticResult CreateDiagnostic(int line, int column, int length)
             => Verify.Diagnostic().WithSpan(line, column, line, column + length);
     }


### PR DESCRIPTION
VSTHRD110 now detects a ConditionalAccessExpressionSyntax parent of the invocation.

Closes #772