### PR TITLE
Avoid compiler hang from invalid text in AdditionalFiles

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Analyzers/CommonInterest.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/CommonInterest.cs
@@ -93,6 +93,7 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
                 }
                 catch (RegexMatchTimeoutException)
                 {
+                    throw new InvalidOperationException($"Regex.Match timeout when parsing line: {line}");
                 }
 
                 if (match == null || !match.Success)
@@ -192,6 +193,7 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
             }
             catch (RegexMatchTimeoutException)
             {
+                throw new InvalidOperationException($"Regex.Match timeout when parsing line: {line}");
             }
 
             if (match == null || !match.Success)

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/CommonInterest.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/CommonInterest.cs
@@ -63,9 +63,11 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
 
         private const RegexOptions FileNamePatternRegexOptions = RegexOptions.IgnoreCase | RegexOptions.Singleline;
 
-        private static readonly Regex NegatableTypeOrMemberReferenceRegex = new Regex(@"^(?<negated>!)?\[(?<typeName>[^\[\]\:]+)+\](?:\:\:(?<memberName>\S+))?\s*$", RegexOptions.Singleline | RegexOptions.CultureInvariant);
+        private static readonly TimeSpan RegexMatchTimeout = TimeSpan.FromMilliseconds(100);  // Prevent expensive CPU hang in Regex.Match if backtracking occurs due to pathological input (see #485).
 
-        private static readonly Regex MemberReferenceRegex = new Regex(@"^\[(?<typeName>[^\[\]\:]+)+\]::(?<memberName>\S+)\s*$", RegexOptions.Singleline | RegexOptions.CultureInvariant);
+        private static readonly Regex NegatableTypeOrMemberReferenceRegex = new Regex(@"^(?<negated>!)?\[(?<typeName>[^\[\]\:]+)+\](?:\:\:(?<memberName>\S+))?\s*$", RegexOptions.Singleline | RegexOptions.CultureInvariant, RegexMatchTimeout);
+
+        private static readonly Regex MemberReferenceRegex = new Regex(@"^\[(?<typeName>[^\[\]\:]+)+\]::(?<memberName>\S+)\s*$", RegexOptions.Singleline | RegexOptions.CultureInvariant, RegexMatchTimeout);
 
         /// <summary>
         /// An array with '.' as its only element.
@@ -84,8 +86,16 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
         {
             foreach (string line in ReadAdditionalFiles(analyzerOptions, fileNamePattern, cancellationToken))
             {
-                Match match = NegatableTypeOrMemberReferenceRegex.Match(line);
-                if (!match.Success)
+                Match? match = null;
+                try
+                {
+                    match = NegatableTypeOrMemberReferenceRegex.Match(line);
+                }
+                catch (RegexMatchTimeoutException)
+                {
+                }
+
+                if (match == null || !match.Success)
                 {
                     throw new InvalidOperationException($"Parsing error on line: {line}");
                 }
@@ -175,8 +185,16 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
 
         internal static QualifiedMember ParseAdditionalFileMethodLine(string line)
         {
-            Match match = MemberReferenceRegex.Match(line);
-            if (!match.Success)
+            Match? match = null;
+            try
+            {
+                match = MemberReferenceRegex.Match(line);
+            }
+            catch (RegexMatchTimeoutException)
+            {
+            }
+
+            if (match == null || !match.Success)
             {
                 throw new InvalidOperationException($"Parsing error on line: {line}");
             }

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/CommonInterest.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/CommonInterest.cs
@@ -63,7 +63,7 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
 
         private const RegexOptions FileNamePatternRegexOptions = RegexOptions.IgnoreCase | RegexOptions.Singleline;
 
-        private static readonly TimeSpan RegexMatchTimeout = TimeSpan.FromMilliseconds(100);  // Prevent expensive CPU hang in Regex.Match if backtracking occurs due to pathological input (see #485).
+        private static readonly TimeSpan RegexMatchTimeout = TimeSpan.FromSeconds(5);  // Prevent expensive CPU hang in Regex.Match if backtracking occurs due to pathological input (see #485).
 
         private static readonly Regex NegatableTypeOrMemberReferenceRegex = new Regex(@"^(?<negated>!)?\[(?<typeName>[^\[\]\:]+)+\](?:\:\:(?<memberName>\S+))?\s*$", RegexOptions.Singleline | RegexOptions.CultureInvariant, RegexMatchTimeout);
 

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/CommonInterest.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/CommonInterest.cs
@@ -96,7 +96,7 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
                     throw new InvalidOperationException($"Regex.Match timeout when parsing line: {line}");
                 }
 
-                if (match == null || !match.Success)
+                if (!match.Success)
                 {
                     throw new InvalidOperationException($"Parsing error on line: {line}");
                 }
@@ -196,7 +196,7 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
                 throw new InvalidOperationException($"Regex.Match timeout when parsing line: {line}");
             }
 
-            if (match == null || !match.Success)
+            if (!match.Success)
             {
                 throw new InvalidOperationException($"Parsing error on line: {line}");
             }


### PR DESCRIPTION
Added a timeout to `NegatableTypeOrMemberReferenceRegex` and `MemberReferenceRegex` to prevent a CPU hang when given input that causes (what I believe to be) very expensive regex backtracking.

Incidentally, some invalid input causes a hang but other invalid input just causes a no-match (as expected).

These cause a hang (or timeout when the Regex is given one):

```
![Microsoft.VisualStudio.Shell.Interop.SVsAppContainerProjectDeploy].   <-- original report

[Microsoft.VisualStud]FooBar
[Microsoft.VisualStudio]FooBar
[aaaaaaaaa.bbbbbbbbbb]FooBar                                            <-- 9 'a' then 10 'b'
```

But the following do not hang and instead return a Regex with no match (as expected).

```
[Microsoft.VisualStu]FooBar
[aaaaaaaaa.bbbbbbbbb]FooBar                                             <-- 9 'a' then 9 'b'
```

Maybe there's something internal to Regex which changes its implementation depending on the length of the input string?

Closes #485