### PR TITLE
VSTHRD010 now recognizes when struct members require the main thread

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD010MainThreadUsageAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD010MainThreadUsageAnalyzer.cs
@@ -443,7 +443,7 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
                     throw new ArgumentNullException(nameof(type));
                 }
 
-                bool requiresUIThread = (type.TypeKind == TypeKind.Interface || type.TypeKind == TypeKind.Class)
+                bool requiresUIThread = (type.TypeKind == TypeKind.Interface || type.TypeKind == TypeKind.Class || type.TypeKind == TypeKind.Struct)
                     && this.MembersRequiringMainThread.Contains(type, symbol);
 
                 if (requiresUIThread)

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/AdditionalFiles/vs-threading.MembersRequiringMainThread.mocks.txt
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/AdditionalFiles/vs-threading.MembersRequiringMainThread.mocks.txt
@@ -1,4 +1,5 @@
 ﻿[TestNS.*]
+[TestNS.SomeStruct]
 ![TestNS.FreeThreadedType]
 ![TestNS2.FreeThreadedType]
 [TestNS2.*]

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD010MainThreadUsageAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD010MainThreadUsageAnalyzerTests.cs
@@ -970,7 +970,7 @@ using System;
 
 namespace TestNS {
     class SomeClass { }
-    class SomeInterface { }
+    interface SomeInterface { }
 }
 
 class Test {
@@ -1053,7 +1053,7 @@ using System;
 
 namespace TestNS {
     class SomeClass { }
-    class SomeInterface { }
+    interface SomeInterface { }
 }
 
 class Test {
@@ -1096,7 +1096,7 @@ using System;
 
 namespace TestNS {
     class SomeClass { }
-    class SomeInterface { }
+    interface SomeInterface { }
 }
 
 class Test {

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD010MainThreadUsageAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD010MainThreadUsageAnalyzerTests.cs
@@ -1864,6 +1864,46 @@ class Test
             await Verify.VerifyAnalyzerAsync(test, expect);
         }
 
+        [Fact]
+        public async Task StructMembers()
+        {
+            var test = @"
+namespace TestNS
+{
+    struct SomeStruct
+    {
+        public static void DoSomething()
+        {
+        }
+
+        public string Name { get; set; }
+    }
+}
+
+namespace Foo
+{
+    class MyProgram
+    {
+        static void Main()
+        {
+            TestNS.SomeStruct.DoSomething();
+
+            var st = new TestNS.SomeStruct();
+            st.Name = ""TheValue"";
+            string val = st.Name;
+        }
+    }
+}
+";
+            var expect = new DiagnosticResult[]
+            {
+                Verify.Diagnostic(DescriptorSync).WithSpan(20, 31, 20, 42).WithArguments("SomeStruct", "Test.VerifyOnUIThread"),
+                Verify.Diagnostic(DescriptorSync).WithSpan(23, 16, 23, 20).WithArguments("SomeStruct", "Test.VerifyOnUIThread"),
+                Verify.Diagnostic(DescriptorSync).WithSpan(24, 29, 24, 33).WithArguments("SomeStruct", "Test.VerifyOnUIThread"),
+            };
+            await Verify.VerifyAnalyzerAsync(test, expect);
+        }
+
         private static class CodeFixIndex
         {
             public const int SwitchToMainThreadAsync = 0;


### PR DESCRIPTION
VSTHRD010 now recognizes when struct members require the main thread.

In addition, some minor fixes for three VSTHRD010 Cast unit tests where the test code was using `class` instead of `interface`.

Closes #456