### PR TITLE
Remove dead, buggy code

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
@@ -1227,9 +1227,8 @@ namespace Microsoft.VisualStudio.Threading
                 if (invokeDelegate is object)
                 {
                     this.OnExecuting();
-#pragma warning disable CS8602 // Dereference of a possibly null reference.
-                    SynchronizationContext? syncContext = this.job is object ? this.job.ApplicableJobSyncContext : this.job.Factory.ApplicableJobSyncContext;
-#pragma warning restore CS8602 // Dereference of a possibly null reference.
+                    RoslynDebug.Assert(this.job is object);
+                    SynchronizationContext? syncContext = this.job.ApplicableJobSyncContext;
                     using (syncContext.Apply(checkForChangesOnRevert: false))
                     {
                         if (invokeDelegate is Action action)


### PR DESCRIPTION
Replaced the condition checking whether `this.job` exists with an assert (like is used elsewhere), and removed the #pragma that disabled the CS8602 warning.

My reasoning is that `SingleExecuteProtector` can only ever be constructed with a non-null job (validates with `Requires.NotNull`) and the job is only set to null when `TryExecute` succeeds. Therefore if TryExecute reaches line 1230 then the job will exist.

Closes #544