### PR TITLE
Make use of fast HashSet.Contains check

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskDependencyGraph.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskDependencyGraph.cs
@@ -211,9 +211,9 @@ namespace Microsoft.VisualStudio.Threading
             while (queue.Count > 0)
             {
                 IJoinableTaskDependent startDepenentNode = queue.Dequeue();
-                if (candidates.Contains(startDepenentNode))
+                if (startDepenentNode is JoinableTask startTask && candidates.Contains(startTask))
                 {
-                    results.Add((JoinableTask)startDepenentNode);
+                    results.Add(startTask);
                 }
 
                 lock (startDepenentNode.JoinableTaskContext.SyncContextLock)


### PR DESCRIPTION
Fixes #883

Moving the typecast up into the if-condition so it can be leveraged for the Contains-check. When the interface is not a `JoinableTask` it can't be in the `HashSet<JoinableTask>` so you can just skip the branch in this case.

Not doing this means there is a type-mismatch between the `HashSet<JoinableTask>` and the variable you're checking (`IJoinableTaskDependent`) which causes C# to pick the LINQ `Enumerable.Contains` extension over the `HashSet.Contains` member.