### PR TITLE
Avoid reading resource unless needed

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/ReentrantSemaphore.cs
+++ b/src/Microsoft.VisualStudio.Threading/ReentrantSemaphore.cs
@@ -899,7 +899,10 @@ namespace Microsoft.VisualStudio.Threading
             /// </summary>
             protected override void ThrowIfFaulted()
             {
-                Verify.Operation(!this.faulted, Strings.SemaphoreMisused);
+                if (this.faulted)
+                {
+                    throw Verify.FailOperation(Strings.SemaphoreMisused);
+                }
             }
         }
 


### PR DESCRIPTION
This is called inside and outside of the semaphore and is unneeded lookup. Saw in a high contention trace with file watcher.