### PR TITLE
Drop .NET Core 2.1 support

### DIFF
--- a/azure-pipelines/dotnet.yml
+++ b/azure-pipelines/dotnet.yml
@@ -21,15 +21,6 @@ steps:
   condition: and(ne(variables['OptProf'], 'true'), eq(variables['Agent.OS'], 'Windows_NT'))
 
 - task: DotNetCoreCLI@2
-  displayName: dotnet test -f netcoreapp2.1
-  inputs:
-    command: test
-    arguments: --no-build -c $(BuildConfiguration) -f netcoreapp2.1 --filter "TestCategory!=FailsInCloudTest" -v n /p:CollectCoverage=true --settings "$(Build.Repository.LocalPath)/azure-pipelines/$(Agent.OS).runsettings" /bl:"$(Build.ArtifactStagingDirectory)/build_logs/test_netcoreapp2.1.binlog"
-    testRunTitle: netcoreapp2.1-$(Agent.JobName)
-    workingDirectory: test/Microsoft.VisualStudio.Threading.Tests
-  condition: ne(variables['OptProf'], 'true')
-
-- task: DotNetCoreCLI@2
   displayName: dotnet test -f netcoreapp3.1
   inputs:
     command: test

--- a/test/Microsoft.VisualStudio.Threading.Tests/Microsoft.VisualStudio.Threading.Tests.csproj
+++ b/test/Microsoft.VisualStudio.Threading.Tests/Microsoft.VisualStudio.Threading.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.1;net5.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsTestProject>true</IsTestProject>
 


### PR DESCRIPTION
.NET Core 2.1 falls out of LTS support on August 21, 2021. No reason to continue targeting it with new versions of this library.