### PR TITLE
Fix an unnecessary thread pool dependency when waiting JTF collection.

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskCollection.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskCollection.cs
@@ -175,7 +175,7 @@ namespace Microsoft.VisualStudio.Threading
 
             using (this.Join())
             {
-                await this.emptyEvent.WaitAsync(cancellationToken).ConfigureAwait(false);
+                await this.emptyEvent.WaitAsync(cancellationToken).ConfigureAwaitRunInline();
             }
         }
 


### PR DESCRIPTION
It leads slowdown during solution closing time.

On my local testing trace during closing Roslyn, this can lead 0.5s delay during solution closing time inside:
![image](https://user-images.githubusercontent.com/11638466/131185661-59818546-b80c-4cb8-82f7-9392dfdd35a3.png)

All tracking tasks are UI thread background tasks. This extra delay is caused by the code requires an extra thread pool dependency, which hits the problem due to thread pools are busy serialize DTBB caches (and a few other clean-up tasks), this block waiting would run to scheduling problems.

@davkean to aware of this change.