### PR TITLE
Extend member access analysis to events

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/Microsoft.VisualStudio.Threading.Analyzers.CSharp.csproj
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/Microsoft.VisualStudio.Threading.Analyzers.CSharp.csproj
@@ -6,7 +6,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.8.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.10.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD010MainThreadUsageAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD010MainThreadUsageAnalyzer.cs
@@ -258,11 +258,15 @@ namespace Microsoft.VisualStudio.Threading.Analyzers
                     targetMethod = GetPropertyAccessor(propertyReference.Property);
                     break;
                 case IEventAssignmentOperation eventAssignmentOperation:
-                    IEventReferenceOperation eventReference = eventAssignmentOperation.EventReference;
-                    targetMethod = eventAssignmentOperation.Adds
-                        ? eventReference.Event.AddMethod
-                        : eventReference.Event.RemoveMethod;
-                    locationToBlame = eventReference.Syntax;
+                    IOperation eventReferenceOp = eventAssignmentOperation.EventReference;
+                    if (eventReferenceOp is IEventReferenceOperation eventReference)
+                    {
+                        targetMethod = eventAssignmentOperation.Adds
+                            ? eventReference.Event.AddMethod
+                            : eventReference.Event.RemoveMethod;
+                        locationToBlame = eventReference.Syntax;
+                    }
+
                     break;
             }
 

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes.csproj
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes.csproj
@@ -32,7 +32,7 @@
   </ItemDefinitionGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="2.8.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="2.10.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0" PrivateAssets="all" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.VisualBasic/Microsoft.VisualStudio.Threading.Analyzers.VisualBasic.csproj
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.VisualBasic/Microsoft.VisualStudio.Threading.Analyzers.VisualBasic.csproj
@@ -6,7 +6,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="2.8.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="2.10.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Microsoft.VisualStudio.Threading.Analyzers.csproj
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Microsoft.VisualStudio.Threading.Analyzers.csproj
@@ -22,7 +22,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="2.8.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="2.10.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0" PrivateAssets="all" />
     <PackageReference Include="Nullable" Version="1.3.0">
       <PrivateAssets>all</PrivateAssets>

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD010MainThreadUsageAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD010MainThreadUsageAnalyzerTests.cs
@@ -1630,6 +1630,39 @@ class A
             await Verify.VerifyAnalyzerAsync(test, expected);
         }
 
+        [Fact]
+        public async Task Events()
+        {
+            var test = @"
+namespace TestNS
+{
+    interface SomeInterface
+    {
+        event System.Action UIEventName;
+    }
+}
+
+class A
+{
+    void Handler()
+    {
+    }
+
+    void Test(TestNS.SomeInterface i)
+    {
+        i.UIEventName += this.Handler;
+        i.UIEventName -= this.Handler;
+    }
+}
+";
+            DiagnosticResult[] expected =
+            {
+                Verify.Diagnostic(DescriptorSync).WithSpan(18, 11, 18, 22).WithArguments("SomeInterface", "Test.VerifyOnUIThread"),
+                Verify.Diagnostic(DescriptorSync).WithSpan(19, 11, 19, 22).WithArguments("SomeInterface", "Test.VerifyOnUIThread"),
+            };
+            await Verify.VerifyAnalyzerAsync(test, expected);
+        }
+
         /// <summary>
         /// Field initializers should never have thread affinity since the thread cannot be enforced before the code is executed,
         /// since initializers run before the user-defined constructor.


### PR DESCRIPTION
Presently, only methods and properties are handled.

Caveat: only += and -= are handled - raw event accesses didn't fit nicely, since there's no method invocation, and didn't seem high-priority (since they can only occur within the declaring type).