### PR TITLE
Avoid internal exception on timeout of AsyncSemaphore request that races with disposal

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/AsyncSemaphore.cs
+++ b/src/Microsoft.VisualStudio.Threading/AsyncSemaphore.cs
@@ -193,6 +193,7 @@ namespace Microsoft.VisualStudio.Threading
                             head.Value.Trigger.TrySetException(new ObjectDisposedException(this.GetType().FullName));
                             waitersCopy.Add(head.Value);
                             this.waiters.RemoveFirst();
+                            head.Value.Node = null;
                         }
                     }
 


### PR DESCRIPTION
The repro is a very particularly timed race between a timer thread and disposal on another thread. As such, no test can reliably repro it except with careful scheduling under a debugger.

## The scenario

1. A contested enter request is made of the `AsyncSemaphore` that includes a timeout.
1. The timeout expires and `CancellationHandler` is invoked. The `WaiterInfo.Trigger.TrySetCanceled` call succeeds. This thread is now suspended, before it enters the lock on `AsyncSemaphore.syncObject`.
1. Another thread calls `AsyncSemaphore.Dispose()`, which runs to completion.
1. The timeout thread now resumes, acquires the lock and tries to remove its `WaiterInfo.Node` from the `LinkedList`, but the `LinkedList` was already cleared in `Dispose`, so an exception is thrown.

The fix is simply to clear the `WaiterInfo.Node` property when that node no longer belongs to it. This causes the racing `CancellationHandler` to skip the code to remove and recycle the node.

Fixes #906