### PR TITLE
Fix a task continuation hang related to project lock.

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/AsyncReaderWriterResourceLock`2.cs
+++ b/src/Microsoft.VisualStudio.Threading/AsyncReaderWriterResourceLock`2.cs
@@ -776,9 +776,12 @@ namespace Microsoft.VisualStudio.Threading
                     return computationTask.ContinueWith(
                         t =>
                         {
-                            if (t.IsFaulted)
+                            switch (t.Status)
                             {
-                                t.GetAwaiter().GetResult();
+                                case TaskStatus.Faulted:
+                                case TaskStatus.Canceled:
+                                    t.GetAwaiter().GetResult();
+                                    break;
                             }
                         },
                         cancellationToken,

--- a/src/Microsoft.VisualStudio.Threading/AsyncReaderWriterResourceLock`2.cs
+++ b/src/Microsoft.VisualStudio.Threading/AsyncReaderWriterResourceLock`2.cs
@@ -728,6 +728,7 @@ namespace Microsoft.VisualStudio.Threading
                     ? (object)resource
                     : Tuple.Create(resource, this.service.GetAggregateLockFlags());
 
+                bool joinToExistingTask = false;
                 if (!this.resourcePreparationTasks.TryGetValue(resource, out ResourcePreparationTaskAndValidity preparationTask))
                 {
                     Func<object, Task>? preparationDelegate = forConcurrentUse
@@ -760,14 +761,35 @@ namespace Microsoft.VisualStudio.Threading
                             finalState);
                     }
                 }
+                else
+                {
+                    joinToExistingTask = true;
+                }
 
                 Assumes.NotNull(preparationTask.PreparationTask);
                 this.resourcePreparationTasks[resource] = preparationTask;
 
+                Task computationTask = preparationTask.PreparationTask;
+
+                if (forConcurrentUse && joinToExistingTask)
+                {
+                    return computationTask.ContinueWith(
+                        t =>
+                        {
+                            if (t.IsFaulted)
+                            {
+                                t.GetAwaiter().GetResult();
+                            }
+                        },
+                        cancellationToken,
+                        TaskContinuationOptions.RunContinuationsAsynchronously,
+                        TaskScheduler.Default);
+                }
+
                 // We tack cancellation onto the task that we actually return to the caller.
                 // This doesn't cancel resource preparation, but it does allow the caller to return early
                 // in the event of their own cancellation token being canceled.
-                return preparationTask.PreparationTask.WithCancellation(cancellationToken);
+                return computationTask.WithCancellation(cancellationToken);
             }
 
             /// <summary>


### PR DESCRIPTION
We noticed web project code gets a project property value (through a rule), then fires an internal event. One of the event handler JTF.Run and switches to the UI thread. It blocks other project code happens to read the project state at the same time due to the special task continuation deadlock.

The change here takes advantage of the logic in the task library, which spins off async continuation first, then calls other continuations in sequence. The logic here is that we join existing computation in async way to prevent this type of deadlock, and let the first continuation keeps the original behavior to reduce potential perf impact.

It is related to a VS deadlock devdiv-1412808.