### PR TITLE
Dev/lifengl/minor cleanup

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/AsyncReaderWriterResourceLock`2.cs
+++ b/src/Microsoft.VisualStudio.Threading/AsyncReaderWriterResourceLock`2.cs
@@ -660,9 +660,6 @@ namespace Microsoft.VisualStudio.Threading
                     {
                         this.SetResourceAsAccessed(resource);
 
-                        // We can't currently use the caller's cancellation token for this task because
-                        // this task may be shared with others or call this method later, and we wouldn't
-                        // want their requests to be cancelled as a result of this first caller cancelling.
                         preparationTask = this.PrepareResourceAsync(resource, cancellationToken);
                     }
 
@@ -740,6 +737,9 @@ namespace Microsoft.VisualStudio.Threading
                     // Let's also hide the ARWL from the delegate if this is a shared lock request.
                     using (forConcurrentUse ? this.service.HideLocks() : default(Suppression))
                     {
+                        // We can't currently use the caller's cancellation token for this task because
+                        // this task may be shared with others or call this method later, and we wouldn't
+                        // want their requests to be cancelled as a result of this first caller cancelling.
                         preparationTask = new ResourcePreparationTaskAndValidity(
                             Task.Factory.StartNew(NullableHelpers.AsNullableArgFunc(preparationDelegate), stateObject, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap(),
                             finalState);
@@ -771,18 +771,12 @@ namespace Microsoft.VisualStudio.Threading
 
                 Task computationTask = preparationTask.PreparationTask;
 
-                if (forConcurrentUse && joinToExistingTask)
+                if (forConcurrentUse && joinToExistingTask && !computationTask.IsCompleted)
                 {
                     return computationTask.ContinueWith(
                         t =>
                         {
-                            switch (t.Status)
-                            {
-                                case TaskStatus.Faulted:
-                                case TaskStatus.Canceled:
-                                    t.GetAwaiter().GetResult();
-                                    break;
-                            }
+                            t.GetAwaiter().GetResult();
                         },
                         cancellationToken,
                         TaskContinuationOptions.RunContinuationsAsynchronously,

--- a/src/Microsoft.VisualStudio.Threading/AsyncReaderWriterResourceLock`2.cs
+++ b/src/Microsoft.VisualStudio.Threading/AsyncReaderWriterResourceLock`2.cs
@@ -774,10 +774,7 @@ namespace Microsoft.VisualStudio.Threading
                 if (forConcurrentUse && joinToExistingTask && !computationTask.IsCompleted && !cancellationToken.IsCancellationRequested)
                 {
                     return computationTask.ContinueWith(
-                        t =>
-                        {
-                            t.GetAwaiter().GetResult();
-                        },
+                        t => t.GetAwaiter().GetResult(),
                         cancellationToken,
                         TaskContinuationOptions.RunContinuationsAsynchronously,
                         TaskScheduler.Default);

--- a/src/Microsoft.VisualStudio.Threading/AsyncReaderWriterResourceLock`2.cs
+++ b/src/Microsoft.VisualStudio.Threading/AsyncReaderWriterResourceLock`2.cs
@@ -771,7 +771,7 @@ namespace Microsoft.VisualStudio.Threading
 
                 Task computationTask = preparationTask.PreparationTask;
 
-                if (forConcurrentUse && joinToExistingTask && !computationTask.IsCompleted)
+                if (forConcurrentUse && joinToExistingTask && !computationTask.IsCompleted && !cancellationToken.IsCancellationRequested)
                 {
                     return computationTask.ContinueWith(
                         t =>


### PR DESCRIPTION
Minor code cleanup based on earlier code review feedbacks.

1, remove unnecessary code
2, prevent creating task continuation under some conditions.