### PR TITLE
Publish SosThreadingTools with github releases

### DIFF
--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -43,8 +43,8 @@ stages:
                   { "label" : "enhancement", "displayName": "Enhancements", "state" : "closed" }
                 ]
 
-- stage: nuget_org
-  displayName: nuget.org
+- stage: push_packages
+  displayName: Push packages
   dependsOn: GitHubRelease
   jobs:
   - deployment: push
@@ -63,9 +63,16 @@ stages:
             inputs:
               versionSpec: 5.x
           - task: NuGetCommand@2
-            displayName: NuGet push
+            displayName: nuget.org
             inputs:
               command: push
               packagesToPush: $(Pipeline.Workspace)/CI/deployables-Windows/NuGet/*.nupkg
               nuGetFeedType: external
               publishFeedCredentials: VisualStudioExtensibility (nuget.org)
+          - task: NuGetCommand@2
+            displayName: WinDBG Gallery
+            inputs:
+              command: push
+              packagesToPush: $(Pipeline.Workspace)/CI/deployables-Windows/WinDBGGallery/*.nupkg
+              nuGetFeedType: external
+              publishFeedCredentials: microsoft package push (andarno)

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -21,7 +21,9 @@ stages:
       runOnce:
         deploy:
           steps:
-          - download: none
+          - download: CI
+            artifact: deployables-Windows
+            displayName: Download deployables-Windows artifact
           - powershell: |
               Write-Host "##vso[build.updatebuildnumber]$(resources.pipeline.CI.runName)"
             displayName: Set pipeline name
@@ -34,6 +36,8 @@ stages:
               tagSource: userSpecifiedTag
               tag: v$(resources.pipeline.CI.runName)
               title: v$(resources.pipeline.CI.runName)
+              assets: |
+                $(Pipeline.Workspace)/CI/deployables-Windows/SosThreadingTools.zip
               isDraft: true # After running this step, visit the new draft release, edit, and publish.
               changeLogCompareToRelease: lastNonDraftRelease
               changeLogType: issueBased

--- a/doc/dumpasync.md
+++ b/doc/dumpasync.md
@@ -8,7 +8,7 @@ for an app hang that is waiting for async methods to complete.
 
 Using this tool requires that you download and install [WinDbg][WinDbg], which can attach to a running process or DMP file. The `!dumpasync` extension is only available for WinDbg.
 
-The `!dumpasync` extension itself is exported from the `SosThreadingTools.dll` library, which you can acquire from [our releases page](https://github.com/Microsoft/vs-threading/releases).
+The `!dumpasync` extension itself is exported from the `SosThreadingTools.dll` library, which is included in a zip that you can acquire from [our releases page](https://github.com/Microsoft/vs-threading/releases).
 
 ## Usage
 

--- a/src/SosThreadingTools/SosThreadingTools.csproj
+++ b/src/SosThreadingTools/SosThreadingTools.csproj
@@ -15,7 +15,7 @@
 
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
-    <PackageOutputPath>$(RepoBinPath)Packages\$(Configuration)\WinDBGGallery\</PackageOutputPath>
+    <PackageOutputPath>$(RepoRootPath)bin\Packages\$(Configuration)\WinDBGGallery\</PackageOutputPath>
 
     <!-- We build a package with legacy PDBs included for the gallery's convenience. -->
     <DebugType>full</DebugType>


### PR DESCRIPTION
Also publish the nupkg with the same payload to the internal WinDBG Gallery.