### PR TITLE
Fix build breaks in main

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,7 +36,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Internal.MicroBuild.VisualStudio" Version="$(MicroBuildVersion)" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="all" Condition=" '$(MSBuildProjectName)' != 'SosThreadingTools' " />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.5.37-alpha" PrivateAssets="all" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.5.54-alpha" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.354" PrivateAssets="all" />
     <PackageReference Include="CSharpIsNullAnalyzer" Version="0.1.300" PrivateAssets="all" />
   </ItemGroup>

--- a/azure-pipelines/artifacts/VSInsertion.ps1
+++ b/azure-pipelines/artifacts/VSInsertion.ps1
@@ -11,7 +11,7 @@ $config = 'Debug'
 if ($env:BUILDCONFIGURATION) { $config = $env:BUILDCONFIGURATION }
 $NuGetPackages = "$RepoRoot\bin\Packages\$config\NuGet"
 $CoreXTPackages = "$RepoRoot\bin\Packages\$config\CoreXT"
-if (-not (Test-Path $NuGetPackages)) { Write-Error "No NuGet packages found. Has a build been run?"; return @{} }
+if (-not (Test-Path $NuGetPackages)) { Write-Warning "No NuGet packages found. Has a build been run?"; return @{} }
 $ArtifactBasePath = "$RepoRoot\obj\_artifacts"
 $ArtifactPath = "$ArtifactBasePath\VSInsertion"
 if (-not (Test-Path $ArtifactPath)) { New-Item -ItemType Directory -Path $ArtifactPath | Out-Null }


### PR DESCRIPTION
- Don't break artifact publishing on partial builds
  This was keeping us from collecting msbuild.binlog's from failed pipeline runs.