### PR TITLE
Update reentrant exception to be of specific type

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/ReentrantSemaphore.cs
+++ b/src/Microsoft.VisualStudio.Threading/ReentrantSemaphore.cs
@@ -759,7 +759,7 @@ namespace Microsoft.VisualStudio.Threading
                                     // When the semaphore faults, we will drain and throw for awaiting tasks one by one.
                                     this.faulted = true;
 #pragma warning disable CA2219 // Do not raise exceptions in finally clauses
-                                    throw Verify.FailOperation(Strings.SemaphoreStackNestingViolated, ReentrancyMode.Stack);
+                                    throw new StackReentrantSemaphoreNestingViolationException();
 #pragma warning restore CA2219 // Do not raise exceptions in finally clauses
                                 }
                             }
@@ -873,7 +873,7 @@ namespace Microsoft.VisualStudio.Threading
                                     // When the semaphore faults, we will drain and throw for awaiting tasks one by one.
                                     this.faulted = true;
 #pragma warning disable CA2219 // Do not raise exceptions in finally clauses
-                                    throw Verify.FailOperation(Strings.SemaphoreStackNestingViolated, ReentrancyMode.Stack);
+                                    throw new StackReentrantSemaphoreNestingViolationException();
 #pragma warning restore CA2219 // Do not raise exceptions in finally clauses
                                 }
                             }
@@ -901,7 +901,7 @@ namespace Microsoft.VisualStudio.Threading
             {
                 if (this.faulted)
                 {
-                    throw Verify.FailOperation(Strings.SemaphoreMisused);
+                    throw new SemaphoreFaultedException();
                 }
             }
         }

--- a/src/Microsoft.VisualStudio.Threading/SemaphoreFaultedException.cs
+++ b/src/Microsoft.VisualStudio.Threading/SemaphoreFaultedException.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.Threading
+{
+    using System;
+
+    public class SemaphoreFaultedException : InvalidOperationException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SemaphoreFaultedException"/> class.
+        /// </summary>
+        public SemaphoreFaultedException()
+            : base(Strings.SemaphoreMisused)
+        {
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Threading/SemaphoreFaultedException.cs
+++ b/src/Microsoft.VisualStudio.Threading/SemaphoreFaultedException.cs
@@ -5,6 +5,9 @@ namespace Microsoft.VisualStudio.Threading
 {
     using System;
 
+    /// <summary>
+    /// Exception thrown when Semaphore is in a faulted state.
+    /// </summary>
     public class SemaphoreFaultedException : InvalidOperationException
     {
         /// <summary>

--- a/src/Microsoft.VisualStudio.Threading/StackReentrantSemaphoreNestingViolationException.cs
+++ b/src/Microsoft.VisualStudio.Threading/StackReentrantSemaphoreNestingViolationException.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.Threading
+{
+    using System;
+
+    /// <summary>
+    /// Exception which is thrown by the Reentrant Semaphore when it's reentrancy is violated.
+    /// </summary>
+    public class StackReentrantSemaphoreNestingViolationException : InvalidOperationException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StackReentrantSemaphoreNestingViolationException"/> class.
+        /// </summary>
+        public StackReentrantSemaphoreNestingViolationException()
+            : base(string.Format(Strings.SemaphoreStackNestingViolated, ReentrantSemaphore.ReentrancyMode.Stack))
+        {
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Threading/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,4 +1,8 @@
 Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.AsyncReaderWriterLock(Microsoft.VisualStudio.Threading.JoinableTaskContext? joinableTaskContext, bool captureDiagnostics = false) -> void
 Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.AsyncReaderWriterResourceLock(Microsoft.VisualStudio.Threading.JoinableTaskContext? joinableTaskContext, bool captureDiagnostics) -> void
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadMaybeBlocked() -> bool
+Microsoft.VisualStudio.Threading.SemaphoreFaultedException
+Microsoft.VisualStudio.Threading.SemaphoreFaultedException.SemaphoreFaultedException() -> void
+Microsoft.VisualStudio.Threading.StackReentrantSemaphoreNestingViolationException
+Microsoft.VisualStudio.Threading.StackReentrantSemaphoreNestingViolationException.StackReentrantSemaphoreNestingViolationException() -> void
 virtual Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.DeadlockCheckTimeout.get -> System.TimeSpan


### PR DESCRIPTION
Change the existing InvalidOperationException to specific exceptions for first (StackReentrantSemaphoreNestingViolationException) and subsequent (SemaphoreFaultedException) semaphore violations.