### PR TITLE
Prevent creating two task waiting chains when joins AsyncLazy.

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/AsyncLazy`1.cs
+++ b/src/Microsoft.VisualStudio.Threading/AsyncLazy`1.cs
@@ -183,12 +183,7 @@ namespace Microsoft.VisualStudio.Threading
                 resumableAwaiter?.Resume();
             }
 
-            if (!this.value.IsCompleted)
-            {
-                return this.joinableTask?.JoinAsync(cancellationToken) ?? this.value.WithCancellation(cancellationToken);
-            }
-
-            return this.value.WithCancellation(cancellationToken);
+            return this.joinableTask?.JoinAsync(cancellationToken) ?? this.value.WithCancellation(cancellationToken);
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.Threading/AsyncLazy`1.cs
+++ b/src/Microsoft.VisualStudio.Threading/AsyncLazy`1.cs
@@ -185,7 +185,7 @@ namespace Microsoft.VisualStudio.Threading
 
             if (!this.value.IsCompleted)
             {
-                this.joinableTask?.JoinAsync(cancellationToken).Forget();
+                return this.joinableTask?.JoinAsync(cancellationToken) ?? this.value.WithCancellation(cancellationToken);
             }
 
             return this.value.WithCancellation(cancellationToken);


### PR DESCRIPTION
Prevent creating two task waiting chains when AsyncLazy.GetValueAsync is called. Especially when a cancellation token is being used, we don't need register cancellation token twice. A single task waiting chain would make dump analysis simply (otherwise, it is hard to link the JTF join chain and task waiting chain together.)

Note: this change will help to investigate some issues like excessive amount of tasks waiting for AsyncLazy. Because the current code chains JTF and task waiting separately, it is much harder to connect the JTF and waiting task together. When there are huge amount of waiting tasks, this code would make them doubled. With this change, it will keep a single task waiting chain to make it easier to investigate. Also, when the cancellation token can be cancelled, we will only register one callback instead of two.