### PR TITLE
Add net5.0 and net5.0-windows TFMs

### DIFF
--- a/azure-pipelines/dotnet.yml
+++ b/azure-pipelines/dotnet.yml
@@ -45,7 +45,7 @@ steps:
     arguments: --no-build -c $(BuildConfiguration) -f net5.0-windows --filter "TestCategory!=FailsInCloudTest" -v n /p:CollectCoverage=true --settings "$(Build.Repository.LocalPath)/azure-pipelines/$(Agent.OS).runsettings" /bl:"$(Build.ArtifactStagingDirectory)/build_logs/test_net5.0-windows.binlog"
     testRunTitle: net5.0-windows-$(Agent.JobName)
     workingDirectory: test/Microsoft.VisualStudio.Threading.Tests
-  condition: ne(variables['OptProf'], 'true')
+  condition: and(ne(variables['OptProf'], 'true'), eq(variables['Agent.OS'], 'Windows_NT'))
 
 # We have to artifically run this script so that the extra .nupkg is produced for variables/InsertConfigValues.ps1 to notice.
 - powershell: azure-pipelines\artifacts\VSInsertion.ps1

--- a/azure-pipelines/dotnet.yml
+++ b/azure-pipelines/dotnet.yml
@@ -38,6 +38,15 @@ steps:
     workingDirectory: test/Microsoft.VisualStudio.Threading.Tests
   condition: ne(variables['OptProf'], 'true')
 
+- task: DotNetCoreCLI@2
+  displayName: dotnet test -f net5.0-windows
+  inputs:
+    command: test
+    arguments: --no-build -c $(BuildConfiguration) -f net5.0-windows --filter "TestCategory!=FailsInCloudTest" -v n /p:CollectCoverage=true --settings "$(Build.Repository.LocalPath)/azure-pipelines/$(Agent.OS).runsettings" /bl:"$(Build.ArtifactStagingDirectory)/build_logs/test_net5.0-windows.binlog"
+    testRunTitle: net5.0-windows-$(Agent.JobName)
+    workingDirectory: test/Microsoft.VisualStudio.Threading.Tests
+  condition: ne(variables['OptProf'], 'true')
+
 # We have to artifically run this script so that the extra .nupkg is produced for variables/InsertConfigValues.ps1 to notice.
 - powershell: azure-pipelines\artifacts\VSInsertion.ps1
   displayName: Prepare VSInsertion artifact

--- a/src/Microsoft.VisualStudio.Threading/AsyncReaderWriterLock.cs
+++ b/src/Microsoft.VisualStudio.Threading/AsyncReaderWriterLock.cs
@@ -1104,9 +1104,7 @@ namespace Microsoft.VisualStudio.Threading
                                     // an accidental execution fork that is exposing concurrency inappropriately.
                                     if (this.CanCurrentThreadHoldActiveLock && !(SynchronizationContext.Current is NonConcurrentSynchronizationContext))
                                     {
-#if NETFRAMEWORK || NETCOREAPP // Assertion failures crash on .NET Core < 3.0
                                         Report.Fail("Dangerous request for read lock from fork of write lock.");
-#endif
                                         Verify.FailOperation(Strings.DangerousReadLockRequestFromWriteLockFork);
                                     }
 

--- a/src/Microsoft.VisualStudio.Threading/AwaitExtensions.cs
+++ b/src/Microsoft.VisualStudio.Threading/AwaitExtensions.cs
@@ -10,6 +10,7 @@ namespace Microsoft.VisualStudio.Threading
     using System.Diagnostics.CodeAnalysis;
     using System.Runtime.CompilerServices;
     using System.Runtime.ExceptionServices;
+    using System.Runtime.InteropServices;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Win32;
@@ -122,6 +123,11 @@ namespace Microsoft.VisualStudio.Threading
         /// </returns>
         public static Task WaitForChangeAsync(this RegistryKey registryKey, bool watchSubtree = true, RegistryChangeNotificationFilters change = RegistryChangeNotificationFilters.Value | RegistryChangeNotificationFilters.Subkey, CancellationToken cancellationToken = default(CancellationToken))
         {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                throw new PlatformNotSupportedException();
+            }
+
             Requires.NotNull(registryKey, nameof(registryKey));
 
             return WaitForRegistryChangeAsync(registryKey.Handle, watchSubtree, change, cancellationToken);

--- a/src/Microsoft.VisualStudio.Threading/Dgml.cs
+++ b/src/Microsoft.VisualStudio.Threading/Dgml.cs
@@ -33,12 +33,12 @@ namespace Microsoft.VisualStudio.Threading
                     new XAttribute("Layout", layout)));
             if (direction is object)
             {
-                dgml.Root.Add(new XAttribute("GraphDirection", direction));
+                dgml.Root!.Add(new XAttribute("GraphDirection", direction));
             }
 
             nodes = new XElement(XName.Get("Nodes", Namespace));
             links = new XElement(XName.Get("Links", Namespace));
-            dgml.Root.Add(nodes);
+            dgml.Root!.Add(nodes);
             dgml.Root.Add(links);
             dgml.WithCategories(Category("Contains", isContainment: true));
             return dgml;
@@ -107,7 +107,7 @@ namespace Microsoft.VisualStudio.Threading
 
         internal static XElement Link(XElement source, XElement target)
         {
-            return Link(source.Attribute("Id").Value, target.Attribute("Id").Value);
+            return Link(source.Attribute("Id")!.Value, target.Attribute("Id")!.Value);
         }
 
         internal static XDocument WithLink(this XDocument document, XElement link)
@@ -192,7 +192,7 @@ namespace Microsoft.VisualStudio.Threading
             Requires.NotNull(node, nameof(node));
             Requires.NotNullOrEmpty(containerId, nameof(containerId));
 
-            document.WithLink(Link(containerId, node.Attribute("Id").Value).WithCategories("Contains"));
+            document.WithLink(Link(containerId, node.Attribute("Id")!.Value).WithCategories("Contains"));
             return node;
         }
 
@@ -230,7 +230,7 @@ namespace Microsoft.VisualStudio.Threading
             Requires.NotNull(properties, nameof(properties));
             Requires.NotNullOrEmpty(targetType, nameof(targetType));
 
-            XElement? container = document.Root.Element(StylesName);
+            XElement? container = document.Root!.Element(StylesName);
             if (container is null)
             {
                 document.Root.Add(container = new XElement(StylesName));
@@ -241,7 +241,7 @@ namespace Microsoft.VisualStudio.Threading
                 new XAttribute("TargetType", targetType),
                 new XAttribute("GroupLabel", categoryId),
                 new XElement(XName.Get("Condition", Namespace), new XAttribute("Expression", "HasCategory('" + categoryId + "')")));
-            style.Add(properties.Select(p => new XElement(XName.Get("Setter", Namespace), new XAttribute("Property", p.Key), new XAttribute("Value", p.Value))));
+            style.Add(properties.Select(p => new XElement(XName.Get("Setter", Namespace), new XAttribute("Property", p.Key), new XAttribute("Value", p.Value!))));
 
             container.Add(style);
 
@@ -274,7 +274,7 @@ namespace Microsoft.VisualStudio.Threading
             Requires.NotNull(document, nameof(document));
             Requires.NotNull(name, nameof(name));
 
-            XElement? container = document.Root.Element(name);
+            XElement? container = document.Root!.Element(name);
             if (container is null)
             {
                 document.Root.Add(container = new XElement(name));

--- a/src/Microsoft.VisualStudio.Threading/DispatcherExtensions.cs
+++ b/src/Microsoft.VisualStudio.Threading/DispatcherExtensions.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if NETFRAMEWORK
+#if NETFRAMEWORK || WINDOWS
 
 namespace Microsoft.VisualStudio.Threading
 {

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskContext+HangReportContributor.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskContext+HangReportContributor.cs
@@ -129,7 +129,7 @@ namespace Microsoft.VisualStudio.Threading
                 foreach (JoinableTaskFactory.SingleExecuteProtector? pendingTasksElement in pendingTask.MainThreadQueueContents)
                 {
                     queueIndex++;
-                    XElement? callstackNode = Dgml.Node(node.Attribute("Id").Value + "MTQueue#" + queueIndex, GetAsyncReturnStack(pendingTasksElement));
+                    XElement? callstackNode = Dgml.Node(node.Attribute("Id")!.Value + "MTQueue#" + queueIndex, GetAsyncReturnStack(pendingTasksElement));
                     XElement? callstackLink = Dgml.Link(callstackNode, node);
                     result.Add(Tuple.Create(callstackNode, callstackLink));
                 }
@@ -137,7 +137,7 @@ namespace Microsoft.VisualStudio.Threading
                 foreach (JoinableTaskFactory.SingleExecuteProtector? pendingTasksElement in pendingTask.ThreadPoolQueueContents)
                 {
                     queueIndex++;
-                    XElement? callstackNode = Dgml.Node(node.Attribute("Id").Value + "TPQueue#" + queueIndex, GetAsyncReturnStack(pendingTasksElement));
+                    XElement? callstackNode = Dgml.Node(node.Attribute("Id")!.Value + "TPQueue#" + queueIndex, GetAsyncReturnStack(pendingTasksElement));
                     XElement? callstackLink = Dgml.Link(callstackNode, node);
                     result.Add(Tuple.Create(callstackNode, callstackLink));
                 }

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
@@ -650,9 +650,7 @@ namespace Microsoft.VisualStudio.Threading
             // Don't use Verify.Operation here to avoid loading a string resource in success cases.
             if (SynchronizationContext.Current is AsyncReaderWriterLock.NonConcurrentSynchronizationContext)
             {
-#if NETFRAMEWORK || NETCOREAPP // Assertion failures crash on .NET Core < 3.0
                 Report.Fail(Strings.NotAllowedUnderURorWLock); // pops a CHK assert dialog, but doesn't throw.
-#endif
                 Verify.FailOperation(Strings.NotAllowedUnderURorWLock); // actually throws, even in RET.
             }
         }

--- a/src/Microsoft.VisualStudio.Threading/Microsoft.VisualStudio.Threading.csproj
+++ b/src/Microsoft.VisualStudio.Threading/Microsoft.VisualStudio.Threading.csproj
@@ -1,13 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0;net5.0-windows;net472</TargetFrameworks>
-    <UseWPF Condition=" '$(TargetFramework)' != 'net5.0' ">true</UseWPF>
-    
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0;net472</TargetFrameworks>
+
     <Summary>Async synchronization primitives, async collections, TPL and dataflow extensions.</Summary>
     <Description>Async synchronization primitives, async collections, TPL and dataflow extensions. The JoinableTaskFactory allows synchronously blocking the UI thread for async work. This package is applicable to any .NET application (not just Visual Studio).</Description>
     <PackageTags>Threading Async Lock Synchronization Threadsafe</PackageTags>
 
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+    <TargetFrameworks>$(TargetFrameworks);net5.0-windows</TargetFrameworks>
+    <UseWPF Condition=" '$(TargetFramework)' != 'net5.0' ">true</UseWPF>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Update="Strings.resx">

--- a/src/Microsoft.VisualStudio.Threading/Microsoft.VisualStudio.Threading.csproj
+++ b/src/Microsoft.VisualStudio.Threading/Microsoft.VisualStudio.Threading.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net472</TargetFrameworks>
-
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0;net5.0-windows;net472</TargetFrameworks>
+    <UseWPF Condition=" '$(TargetFramework)' != 'net5.0' ">true</UseWPF>
+    
     <Summary>Async synchronization primitives, async collections, TPL and dataflow extensions.</Summary>
     <Description>Async synchronization primitives, async collections, TPL and dataflow extensions. The JoinableTaskFactory allows synchronously blocking the UI thread for async work. This package is applicable to any .NET application (not just Visual Studio).</Description>
     <PackageTags>Threading Async Lock Synchronization Threadsafe</PackageTags>

--- a/src/Microsoft.VisualStudio.Threading/net5.0-windows/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/net5.0-windows/PublicAPI.Shipped.txt
@@ -1,0 +1,460 @@
+#nullable enable
+Microsoft.VisualStudio.Threading.AsyncAutoResetEvent
+Microsoft.VisualStudio.Threading.AsyncAutoResetEvent.AsyncAutoResetEvent() -> void
+Microsoft.VisualStudio.Threading.AsyncAutoResetEvent.AsyncAutoResetEvent(bool allowInliningAwaiters) -> void
+Microsoft.VisualStudio.Threading.AsyncAutoResetEvent.Set() -> void
+Microsoft.VisualStudio.Threading.AsyncAutoResetEvent.WaitAsync() -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Threading.AsyncAutoResetEvent.WaitAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Threading.AsyncBarrier
+Microsoft.VisualStudio.Threading.AsyncBarrier.AsyncBarrier(int participants) -> void
+Microsoft.VisualStudio.Threading.AsyncBarrier.SignalAndWait() -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Threading.AsyncCountdownEvent
+Microsoft.VisualStudio.Threading.AsyncCountdownEvent.AsyncCountdownEvent(int initialCount) -> void
+Microsoft.VisualStudio.Threading.AsyncCountdownEvent.Signal() -> void
+Microsoft.VisualStudio.Threading.AsyncCountdownEvent.SignalAndWaitAsync() -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Threading.AsyncCountdownEvent.SignalAsync() -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Threading.AsyncCountdownEvent.WaitAsync() -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Threading.AsyncEventHandler
+Microsoft.VisualStudio.Threading.AsyncEventHandler<TEventArgs>
+Microsoft.VisualStudio.Threading.AsyncLazy<T>
+Microsoft.VisualStudio.Threading.AsyncLazy<T>.AsyncLazy(System.Func<System.Threading.Tasks.Task<T>!>! valueFactory, Microsoft.VisualStudio.Threading.JoinableTaskFactory? joinableTaskFactory = null) -> void
+Microsoft.VisualStudio.Threading.AsyncLazy<T>.GetValue() -> T
+Microsoft.VisualStudio.Threading.AsyncLazy<T>.GetValue(System.Threading.CancellationToken cancellationToken) -> T
+Microsoft.VisualStudio.Threading.AsyncLazy<T>.GetValueAsync() -> System.Threading.Tasks.Task<T>!
+Microsoft.VisualStudio.Threading.AsyncLazy<T>.GetValueAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T>!
+Microsoft.VisualStudio.Threading.AsyncLazy<T>.IsValueCreated.get -> bool
+Microsoft.VisualStudio.Threading.AsyncLazy<T>.IsValueFactoryCompleted.get -> bool
+Microsoft.VisualStudio.Threading.AsyncLazyInitializer
+Microsoft.VisualStudio.Threading.AsyncLazyInitializer.AsyncLazyInitializer(System.Func<System.Threading.Tasks.Task!>! action, Microsoft.VisualStudio.Threading.JoinableTaskFactory? joinableTaskFactory = null) -> void
+Microsoft.VisualStudio.Threading.AsyncLazyInitializer.Initialize(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
+Microsoft.VisualStudio.Threading.AsyncLazyInitializer.InitializeAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Threading.AsyncLazyInitializer.IsCompleted.get -> bool
+Microsoft.VisualStudio.Threading.AsyncLazyInitializer.IsCompletedSuccessfully.get -> bool
+Microsoft.VisualStudio.Threading.AsyncLocal<T>
+Microsoft.VisualStudio.Threading.AsyncLocal<T>.AsyncLocal() -> void
+Microsoft.VisualStudio.Threading.AsyncLocal<T>.Value.get -> T?
+Microsoft.VisualStudio.Threading.AsyncLocal<T>.Value.set -> void
+Microsoft.VisualStudio.Threading.AsyncManualResetEvent
+Microsoft.VisualStudio.Threading.AsyncManualResetEvent.AsyncManualResetEvent(bool initialState = false, bool allowInliningAwaiters = false) -> void
+Microsoft.VisualStudio.Threading.AsyncManualResetEvent.GetAwaiter() -> System.Runtime.CompilerServices.TaskAwaiter
+Microsoft.VisualStudio.Threading.AsyncManualResetEvent.IsSet.get -> bool
+Microsoft.VisualStudio.Threading.AsyncManualResetEvent.PulseAll() -> void
+Microsoft.VisualStudio.Threading.AsyncManualResetEvent.PulseAllAsync() -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Threading.AsyncManualResetEvent.Reset() -> void
+Microsoft.VisualStudio.Threading.AsyncManualResetEvent.Set() -> void
+Microsoft.VisualStudio.Threading.AsyncManualResetEvent.SetAsync() -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Threading.AsyncManualResetEvent.WaitAsync() -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Threading.AsyncManualResetEvent.WaitAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Threading.AsyncQueue<T>
+Microsoft.VisualStudio.Threading.AsyncQueue<T>.AsyncQueue() -> void
+Microsoft.VisualStudio.Threading.AsyncQueue<T>.Complete() -> void
+Microsoft.VisualStudio.Threading.AsyncQueue<T>.Completion.get -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Threading.AsyncQueue<T>.Count.get -> int
+Microsoft.VisualStudio.Threading.AsyncQueue<T>.DequeueAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<T>!
+Microsoft.VisualStudio.Threading.AsyncQueue<T>.Enqueue(T value) -> void
+Microsoft.VisualStudio.Threading.AsyncQueue<T>.IsCompleted.get -> bool
+Microsoft.VisualStudio.Threading.AsyncQueue<T>.IsEmpty.get -> bool
+Microsoft.VisualStudio.Threading.AsyncQueue<T>.Peek() -> T
+Microsoft.VisualStudio.Threading.AsyncQueue<T>.SyncRoot.get -> object!
+Microsoft.VisualStudio.Threading.AsyncQueue<T>.TryDequeue(System.Predicate<T>! valueCheck, out T value) -> bool
+Microsoft.VisualStudio.Threading.AsyncQueue<T>.TryDequeue(out T value) -> bool
+Microsoft.VisualStudio.Threading.AsyncQueue<T>.TryEnqueue(T value) -> bool
+Microsoft.VisualStudio.Threading.AsyncQueue<T>.TryPeek(out T value) -> bool
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.AmbientLock.get -> Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockHandle
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.AsyncReaderWriterLock() -> void
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.AsyncReaderWriterLock(bool captureDiagnostics) -> void
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Awaitable
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Awaitable.GetAwaiter() -> Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Awaiter!
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Awaiter
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Awaiter.GetResult() -> Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Releaser
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Awaiter.IsCompleted.get -> bool
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Awaiter.OnCompleted(System.Action! continuation) -> void
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Awaiter.UnsafeOnCompleted(System.Action! continuation) -> void
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.CaptureDiagnostics.get -> bool
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.CaptureDiagnostics.set -> void
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Complete() -> void
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Completion.get -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Dispose() -> void
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.GetAggregateLockFlags() -> Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockFlags
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.HideLocks() -> Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Suppression
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.IsAnyLockHeld.get -> bool
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.IsAnyPassiveLockHeld.get -> bool
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.IsPassiveReadLockHeld.get -> bool
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.IsPassiveUpgradeableReadLockHeld.get -> bool
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.IsPassiveWriteLockHeld.get -> bool
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.IsReadLockHeld.get -> bool
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.IsUpgradeableReadLockHeld.get -> bool
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.IsWriteLockHeld.get -> bool
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockFlags
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockFlags.None = 0 -> Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockFlags
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockFlags.StickyWrite = 1 -> Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockFlags
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockHandle
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockHandle.Data.get -> object?
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockHandle.Data.set -> void
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockHandle.Flags.get -> Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockFlags
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockHandle.HasReadLock.get -> bool
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockHandle.HasUpgradeableReadLock.get -> bool
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockHandle.HasWriteLock.get -> bool
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockHandle.IsActive.get -> bool
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockHandle.IsReadLock.get -> bool
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockHandle.IsUpgradeableReadLock.get -> bool
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockHandle.IsValid.get -> bool
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockHandle.IsWriteLock.get -> bool
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockHandle.NestingLock.get -> Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockHandle
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockStackContains(Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockFlags flags, Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockHandle handle) -> bool
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.OnBeforeWriteLockReleased(System.Func<System.Threading.Tasks.Task!>! action) -> void
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.OnCriticalFailure(string! message) -> System.Exception!
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.ReadLockAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Awaitable
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Releaser
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Releaser.Dispose() -> void
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Releaser.ReleaseAsync() -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Suppression
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Suppression.Dispose() -> void
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.SyncObject.get -> object!
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.UpgradeableReadLockAsync(Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockFlags options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Awaitable
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.UpgradeableReadLockAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Awaitable
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.WriteLockAsync(Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockFlags options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Awaitable
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.WriteLockAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Awaitable
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.AsyncReaderWriterResourceLock() -> void
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.AsyncReaderWriterResourceLock(bool captureDiagnostics) -> void
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.GetAggregateLockFlags() -> Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.LockFlags
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.LockFlags
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.LockFlags.None = 0 -> Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.LockFlags
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.LockFlags.SkipInitialPreparation = 4096 -> Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.LockFlags
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.LockFlags.StickyWrite = 1 -> Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.LockFlags
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ReadLockAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ResourceAwaitable
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ResourceAwaitable
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ResourceAwaitable.GetAwaiter() -> Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ResourceAwaiter
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ResourceAwaiter
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ResourceAwaiter.GetResult() -> Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ResourceReleaser
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ResourceAwaiter.IsCompleted.get -> bool
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ResourceAwaiter.OnCompleted(System.Action! continuation) -> void
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ResourceAwaiter.UnsafeOnCompleted(System.Action! continuation) -> void
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ResourceReleaser
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ResourceReleaser.Dispose() -> void
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ResourceReleaser.GetResourceAsync(TMoniker resourceMoniker, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResource!>!
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ResourceReleaser.ReleaseAsync() -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.SetAllResourcesToUnknownState() -> void
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.SetResourceAsAccessed(System.Func<TResource!, object?, bool>! resourceCheck, object? state) -> bool
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.SetResourceAsAccessed(TResource! resource) -> void
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.UpgradeableReadLockAsync(Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.LockFlags options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ResourceAwaitable
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.UpgradeableReadLockAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ResourceAwaitable
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.WriteLockAsync(Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.LockFlags options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ResourceAwaitable
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.WriteLockAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ResourceAwaitable
+Microsoft.VisualStudio.Threading.AsyncSemaphore
+Microsoft.VisualStudio.Threading.AsyncSemaphore.AsyncSemaphore(int initialCount) -> void
+Microsoft.VisualStudio.Threading.AsyncSemaphore.CurrentCount.get -> int
+Microsoft.VisualStudio.Threading.AsyncSemaphore.Dispose() -> void
+Microsoft.VisualStudio.Threading.AsyncSemaphore.EnterAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.VisualStudio.Threading.AsyncSemaphore.Releaser>!
+Microsoft.VisualStudio.Threading.AsyncSemaphore.EnterAsync(System.TimeSpan timeout, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.VisualStudio.Threading.AsyncSemaphore.Releaser>!
+Microsoft.VisualStudio.Threading.AsyncSemaphore.EnterAsync(int timeout, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.VisualStudio.Threading.AsyncSemaphore.Releaser>!
+Microsoft.VisualStudio.Threading.AsyncSemaphore.Releaser
+Microsoft.VisualStudio.Threading.AsyncSemaphore.Releaser.Dispose() -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions
+Microsoft.VisualStudio.Threading.AwaitExtensions.ConfiguredTaskYieldAwaitable
+Microsoft.VisualStudio.Threading.AwaitExtensions.ConfiguredTaskYieldAwaitable.ConfiguredTaskYieldAwaitable(bool continueOnCapturedContext) -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.ConfiguredTaskYieldAwaitable.GetAwaiter() -> Microsoft.VisualStudio.Threading.AwaitExtensions.ConfiguredTaskYieldAwaiter
+Microsoft.VisualStudio.Threading.AwaitExtensions.ConfiguredTaskYieldAwaiter
+Microsoft.VisualStudio.Threading.AwaitExtensions.ConfiguredTaskYieldAwaiter.ConfiguredTaskYieldAwaiter(bool continueOnCapturedContext) -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.ConfiguredTaskYieldAwaiter.GetResult() -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.ConfiguredTaskYieldAwaiter.IsCompleted.get -> bool
+Microsoft.VisualStudio.Threading.AwaitExtensions.ConfiguredTaskYieldAwaiter.OnCompleted(System.Action! continuation) -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.ConfiguredTaskYieldAwaiter.UnsafeOnCompleted(System.Action! continuation) -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.ExecuteContinuationSynchronouslyAwaitable
+Microsoft.VisualStudio.Threading.AwaitExtensions.ExecuteContinuationSynchronouslyAwaitable.ExecuteContinuationSynchronouslyAwaitable(System.Threading.Tasks.Task! antecedent) -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.ExecuteContinuationSynchronouslyAwaitable.GetAwaiter() -> Microsoft.VisualStudio.Threading.AwaitExtensions.ExecuteContinuationSynchronouslyAwaiter
+Microsoft.VisualStudio.Threading.AwaitExtensions.ExecuteContinuationSynchronouslyAwaitable<T>
+Microsoft.VisualStudio.Threading.AwaitExtensions.ExecuteContinuationSynchronouslyAwaitable<T>.ExecuteContinuationSynchronouslyAwaitable(System.Threading.Tasks.Task<T>! antecedent) -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.ExecuteContinuationSynchronouslyAwaitable<T>.GetAwaiter() -> Microsoft.VisualStudio.Threading.AwaitExtensions.ExecuteContinuationSynchronouslyAwaiter<T>
+Microsoft.VisualStudio.Threading.AwaitExtensions.ExecuteContinuationSynchronouslyAwaiter
+Microsoft.VisualStudio.Threading.AwaitExtensions.ExecuteContinuationSynchronouslyAwaiter.ExecuteContinuationSynchronouslyAwaiter(System.Threading.Tasks.Task! antecedent) -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.ExecuteContinuationSynchronouslyAwaiter.GetResult() -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.ExecuteContinuationSynchronouslyAwaiter.IsCompleted.get -> bool
+Microsoft.VisualStudio.Threading.AwaitExtensions.ExecuteContinuationSynchronouslyAwaiter.OnCompleted(System.Action! continuation) -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.ExecuteContinuationSynchronouslyAwaiter<T>
+Microsoft.VisualStudio.Threading.AwaitExtensions.ExecuteContinuationSynchronouslyAwaiter<T>.ExecuteContinuationSynchronouslyAwaiter(System.Threading.Tasks.Task<T>! antecedent) -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.ExecuteContinuationSynchronouslyAwaiter<T>.GetResult() -> T
+Microsoft.VisualStudio.Threading.AwaitExtensions.ExecuteContinuationSynchronouslyAwaiter<T>.IsCompleted.get -> bool
+Microsoft.VisualStudio.Threading.AwaitExtensions.ExecuteContinuationSynchronouslyAwaiter<T>.OnCompleted(System.Action! continuation) -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.TaskSchedulerAwaitable
+Microsoft.VisualStudio.Threading.AwaitExtensions.TaskSchedulerAwaitable.GetAwaiter() -> Microsoft.VisualStudio.Threading.AwaitExtensions.TaskSchedulerAwaiter
+Microsoft.VisualStudio.Threading.AwaitExtensions.TaskSchedulerAwaitable.TaskSchedulerAwaitable(System.Threading.Tasks.TaskScheduler! taskScheduler, bool alwaysYield = false) -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.TaskSchedulerAwaiter
+Microsoft.VisualStudio.Threading.AwaitExtensions.TaskSchedulerAwaiter.GetResult() -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.TaskSchedulerAwaiter.IsCompleted.get -> bool
+Microsoft.VisualStudio.Threading.AwaitExtensions.TaskSchedulerAwaiter.OnCompleted(System.Action! continuation) -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.TaskSchedulerAwaiter.TaskSchedulerAwaiter(System.Threading.Tasks.TaskScheduler! scheduler, bool alwaysYield = false) -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.TaskSchedulerAwaiter.UnsafeOnCompleted(System.Action! continuation) -> void
+Microsoft.VisualStudio.Threading.CancellationTokenExtensions
+Microsoft.VisualStudio.Threading.CancellationTokenExtensions.CombinedCancellationToken
+Microsoft.VisualStudio.Threading.CancellationTokenExtensions.CombinedCancellationToken.CombinedCancellationToken(System.Threading.CancellationToken cancellationToken) -> void
+Microsoft.VisualStudio.Threading.CancellationTokenExtensions.CombinedCancellationToken.CombinedCancellationToken(System.Threading.CancellationTokenSource! cancellationTokenSource) -> void
+Microsoft.VisualStudio.Threading.CancellationTokenExtensions.CombinedCancellationToken.Dispose() -> void
+Microsoft.VisualStudio.Threading.CancellationTokenExtensions.CombinedCancellationToken.Equals(Microsoft.VisualStudio.Threading.CancellationTokenExtensions.CombinedCancellationToken other) -> bool
+Microsoft.VisualStudio.Threading.CancellationTokenExtensions.CombinedCancellationToken.Token.get -> System.Threading.CancellationToken
+Microsoft.VisualStudio.Threading.DelegatingJoinableTaskFactory
+Microsoft.VisualStudio.Threading.DelegatingJoinableTaskFactory.DelegatingJoinableTaskFactory(Microsoft.VisualStudio.Threading.JoinableTaskFactory! innerFactory) -> void
+Microsoft.VisualStudio.Threading.DispatcherExtensions
+Microsoft.VisualStudio.Threading.HangReportContribution
+Microsoft.VisualStudio.Threading.HangReportContribution.Content.get -> string!
+Microsoft.VisualStudio.Threading.HangReportContribution.ContentName.get -> string?
+Microsoft.VisualStudio.Threading.HangReportContribution.ContentType.get -> string?
+Microsoft.VisualStudio.Threading.HangReportContribution.HangReportContribution(string! content, string? contentType, string? contentName) -> void
+Microsoft.VisualStudio.Threading.HangReportContribution.HangReportContribution(string! content, string? contentType, string? contentName, params Microsoft.VisualStudio.Threading.HangReportContribution![]? nestedReports) -> void
+Microsoft.VisualStudio.Threading.HangReportContribution.NestedReports.get -> System.Collections.Generic.IReadOnlyCollection<Microsoft.VisualStudio.Threading.HangReportContribution!>?
+Microsoft.VisualStudio.Threading.IAsyncDisposable
+Microsoft.VisualStudio.Threading.IAsyncDisposable.DisposeAsync() -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Threading.IHangReportContributor
+Microsoft.VisualStudio.Threading.IHangReportContributor.GetHangReport() -> Microsoft.VisualStudio.Threading.HangReportContribution!
+Microsoft.VisualStudio.Threading.JoinableTask
+Microsoft.VisualStudio.Threading.JoinableTask.GetAwaiter() -> System.Runtime.CompilerServices.TaskAwaiter
+Microsoft.VisualStudio.Threading.JoinableTask.IsCompleted.get -> bool
+Microsoft.VisualStudio.Threading.JoinableTask.Join(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
+Microsoft.VisualStudio.Threading.JoinableTask.JoinAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Threading.JoinableTask.Task.get -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Threading.JoinableTask<T>
+Microsoft.VisualStudio.Threading.JoinableTask<T>.GetAwaiter() -> System.Runtime.CompilerServices.TaskAwaiter<T>
+Microsoft.VisualStudio.Threading.JoinableTask<T>.Join(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> T
+Microsoft.VisualStudio.Threading.JoinableTask<T>.JoinAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<T>!
+Microsoft.VisualStudio.Threading.JoinableTask<T>.Task.get -> System.Threading.Tasks.Task<T>!
+Microsoft.VisualStudio.Threading.JoinableTaskCollection
+Microsoft.VisualStudio.Threading.JoinableTaskCollection.Add(Microsoft.VisualStudio.Threading.JoinableTask! joinableTask) -> void
+Microsoft.VisualStudio.Threading.JoinableTaskCollection.Contains(Microsoft.VisualStudio.Threading.JoinableTask! joinableTask) -> bool
+Microsoft.VisualStudio.Threading.JoinableTaskCollection.Context.get -> Microsoft.VisualStudio.Threading.JoinableTaskContext!
+Microsoft.VisualStudio.Threading.JoinableTaskCollection.DisplayName.get -> string?
+Microsoft.VisualStudio.Threading.JoinableTaskCollection.DisplayName.set -> void
+Microsoft.VisualStudio.Threading.JoinableTaskCollection.GetEnumerator() -> System.Collections.Generic.IEnumerator<Microsoft.VisualStudio.Threading.JoinableTask!>!
+Microsoft.VisualStudio.Threading.JoinableTaskCollection.Join() -> Microsoft.VisualStudio.Threading.JoinableTaskCollection.JoinRelease
+Microsoft.VisualStudio.Threading.JoinableTaskCollection.JoinRelease
+Microsoft.VisualStudio.Threading.JoinableTaskCollection.JoinRelease.Dispose() -> void
+Microsoft.VisualStudio.Threading.JoinableTaskCollection.JoinTillEmptyAsync() -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Threading.JoinableTaskCollection.JoinTillEmptyAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Threading.JoinableTaskCollection.JoinableTaskCollection(Microsoft.VisualStudio.Threading.JoinableTaskContext! context, bool refCountAddedJobs = false) -> void
+Microsoft.VisualStudio.Threading.JoinableTaskCollection.Remove(Microsoft.VisualStudio.Threading.JoinableTask! joinableTask) -> void
+Microsoft.VisualStudio.Threading.JoinableTaskContext
+Microsoft.VisualStudio.Threading.JoinableTaskContext.CreateCollection() -> Microsoft.VisualStudio.Threading.JoinableTaskCollection!
+Microsoft.VisualStudio.Threading.JoinableTaskContext.Dispose() -> void
+Microsoft.VisualStudio.Threading.JoinableTaskContext.Factory.get -> Microsoft.VisualStudio.Threading.JoinableTaskFactory!
+Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails
+Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.EntryMethod.get -> System.Reflection.MethodInfo?
+Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.HangDetails(System.TimeSpan hangDuration, int notificationCount, System.Guid hangId, System.Reflection.MethodInfo? entryMethod) -> void
+Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.HangDuration.get -> System.TimeSpan
+Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.HangId.get -> System.Guid
+Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.NotificationCount.get -> int
+Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadBlocked() -> bool
+Microsoft.VisualStudio.Threading.JoinableTaskContext.IsOnMainThread.get -> bool
+Microsoft.VisualStudio.Threading.JoinableTaskContext.IsWithinJoinableTask.get -> bool
+Microsoft.VisualStudio.Threading.JoinableTaskContext.JoinableTaskContext() -> void
+Microsoft.VisualStudio.Threading.JoinableTaskContext.JoinableTaskContext(System.Threading.Thread? mainThread = null, System.Threading.SynchronizationContext? synchronizationContext = null) -> void
+Microsoft.VisualStudio.Threading.JoinableTaskContext.MainThread.get -> System.Threading.Thread!
+Microsoft.VisualStudio.Threading.JoinableTaskContext.RevertRelevance
+Microsoft.VisualStudio.Threading.JoinableTaskContext.RevertRelevance.Dispose() -> void
+Microsoft.VisualStudio.Threading.JoinableTaskContext.SuppressRelevance() -> Microsoft.VisualStudio.Threading.JoinableTaskContext.RevertRelevance
+Microsoft.VisualStudio.Threading.JoinableTaskContextException
+Microsoft.VisualStudio.Threading.JoinableTaskContextException.JoinableTaskContextException() -> void
+Microsoft.VisualStudio.Threading.JoinableTaskContextException.JoinableTaskContextException(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
+Microsoft.VisualStudio.Threading.JoinableTaskContextException.JoinableTaskContextException(string? message) -> void
+Microsoft.VisualStudio.Threading.JoinableTaskContextException.JoinableTaskContextException(string? message, System.Exception? inner) -> void
+Microsoft.VisualStudio.Threading.JoinableTaskContextNode
+Microsoft.VisualStudio.Threading.JoinableTaskContextNode.Context.get -> Microsoft.VisualStudio.Threading.JoinableTaskContext!
+Microsoft.VisualStudio.Threading.JoinableTaskContextNode.CreateCollection() -> Microsoft.VisualStudio.Threading.JoinableTaskCollection!
+Microsoft.VisualStudio.Threading.JoinableTaskContextNode.Factory.get -> Microsoft.VisualStudio.Threading.JoinableTaskFactory!
+Microsoft.VisualStudio.Threading.JoinableTaskContextNode.IsMainThreadBlocked() -> bool
+Microsoft.VisualStudio.Threading.JoinableTaskContextNode.IsOnMainThread.get -> bool
+Microsoft.VisualStudio.Threading.JoinableTaskContextNode.JoinableTaskContextNode(Microsoft.VisualStudio.Threading.JoinableTaskContext! context) -> void
+Microsoft.VisualStudio.Threading.JoinableTaskContextNode.MainThread.get -> System.Threading.Thread!
+Microsoft.VisualStudio.Threading.JoinableTaskContextNode.RegisterOnHangDetected() -> System.IDisposable!
+Microsoft.VisualStudio.Threading.JoinableTaskContextNode.SuppressRelevance() -> Microsoft.VisualStudio.Threading.JoinableTaskContext.RevertRelevance
+Microsoft.VisualStudio.Threading.JoinableTaskCreationOptions
+Microsoft.VisualStudio.Threading.JoinableTaskCreationOptions.LongRunning = 1 -> Microsoft.VisualStudio.Threading.JoinableTaskCreationOptions
+Microsoft.VisualStudio.Threading.JoinableTaskCreationOptions.None = 0 -> Microsoft.VisualStudio.Threading.JoinableTaskCreationOptions
+Microsoft.VisualStudio.Threading.JoinableTaskFactory
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.Add(Microsoft.VisualStudio.Threading.JoinableTask! joinable) -> void
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.Context.get -> Microsoft.VisualStudio.Threading.JoinableTaskContext!
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.HangDetectionTimeout.get -> System.TimeSpan
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.HangDetectionTimeout.set -> void
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.IsWaitingOnLongRunningTask() -> bool
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.JoinableTaskFactory(Microsoft.VisualStudio.Threading.JoinableTaskCollection! collection) -> void
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.JoinableTaskFactory(Microsoft.VisualStudio.Threading.JoinableTaskContext! owner) -> void
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.MainThreadAwaitable
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.MainThreadAwaitable.GetAwaiter() -> Microsoft.VisualStudio.Threading.JoinableTaskFactory.MainThreadAwaiter
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.MainThreadAwaiter
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.MainThreadAwaiter.GetResult() -> void
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.MainThreadAwaiter.IsCompleted.get -> bool
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.MainThreadAwaiter.OnCompleted(System.Action! continuation) -> void
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.MainThreadAwaiter.UnsafeOnCompleted(System.Action! continuation) -> void
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.Run(System.Func<System.Threading.Tasks.Task!>! asyncMethod) -> void
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.Run(System.Func<System.Threading.Tasks.Task!>! asyncMethod, Microsoft.VisualStudio.Threading.JoinableTaskCreationOptions creationOptions) -> void
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.Run<T>(System.Func<System.Threading.Tasks.Task<T>!>! asyncMethod) -> T
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.Run<T>(System.Func<System.Threading.Tasks.Task<T>!>! asyncMethod, Microsoft.VisualStudio.Threading.JoinableTaskCreationOptions creationOptions) -> T
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.RunAsync(System.Func<System.Threading.Tasks.Task!>! asyncMethod) -> Microsoft.VisualStudio.Threading.JoinableTask!
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.RunAsync(System.Func<System.Threading.Tasks.Task!>! asyncMethod, Microsoft.VisualStudio.Threading.JoinableTaskCreationOptions creationOptions) -> Microsoft.VisualStudio.Threading.JoinableTask!
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.RunAsync<T>(System.Func<System.Threading.Tasks.Task<T>!>! asyncMethod) -> Microsoft.VisualStudio.Threading.JoinableTask<T>!
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.RunAsync<T>(System.Func<System.Threading.Tasks.Task<T>!>! asyncMethod, Microsoft.VisualStudio.Threading.JoinableTaskCreationOptions creationOptions) -> Microsoft.VisualStudio.Threading.JoinableTask<T>!
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.SwitchToMainThreadAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.VisualStudio.Threading.JoinableTaskFactory.MainThreadAwaitable
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.SwitchToMainThreadAsync(bool alwaysYield, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.VisualStudio.Threading.JoinableTaskFactory.MainThreadAwaitable
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.UnderlyingSynchronizationContext.get -> System.Threading.SynchronizationContext?
+Microsoft.VisualStudio.Threading.NoMessagePumpSyncContext
+Microsoft.VisualStudio.Threading.NoMessagePumpSyncContext.NoMessagePumpSyncContext() -> void
+Microsoft.VisualStudio.Threading.ProgressWithCompletion<T>
+Microsoft.VisualStudio.Threading.ProgressWithCompletion<T>.ProgressWithCompletion(System.Action<T>! handler) -> void
+Microsoft.VisualStudio.Threading.ProgressWithCompletion<T>.ProgressWithCompletion(System.Action<T>! handler, Microsoft.VisualStudio.Threading.JoinableTaskFactory? joinableTaskFactory) -> void
+Microsoft.VisualStudio.Threading.ProgressWithCompletion<T>.ProgressWithCompletion(System.Func<T, System.Threading.Tasks.Task!>! handler) -> void
+Microsoft.VisualStudio.Threading.ProgressWithCompletion<T>.ProgressWithCompletion(System.Func<T, System.Threading.Tasks.Task!>! handler, Microsoft.VisualStudio.Threading.JoinableTaskFactory? joinableTaskFactory) -> void
+Microsoft.VisualStudio.Threading.ProgressWithCompletion<T>.WaitAsync() -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Threading.ProgressWithCompletion<T>.WaitAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Threading.ReentrantSemaphore
+Microsoft.VisualStudio.Threading.ReentrantSemaphore.CurrentCount.get -> int
+Microsoft.VisualStudio.Threading.ReentrantSemaphore.Dispose() -> void
+Microsoft.VisualStudio.Threading.ReentrantSemaphore.ReentrancyMode
+Microsoft.VisualStudio.Threading.ReentrantSemaphore.ReentrancyMode.Freeform = 3 -> Microsoft.VisualStudio.Threading.ReentrantSemaphore.ReentrancyMode
+Microsoft.VisualStudio.Threading.ReentrantSemaphore.ReentrancyMode.NotAllowed = 0 -> Microsoft.VisualStudio.Threading.ReentrantSemaphore.ReentrancyMode
+Microsoft.VisualStudio.Threading.ReentrantSemaphore.ReentrancyMode.NotRecognized = 1 -> Microsoft.VisualStudio.Threading.ReentrantSemaphore.ReentrancyMode
+Microsoft.VisualStudio.Threading.ReentrantSemaphore.ReentrancyMode.Stack = 2 -> Microsoft.VisualStudio.Threading.ReentrantSemaphore.ReentrancyMode
+Microsoft.VisualStudio.Threading.ReentrantSemaphore.RevertRelevance
+Microsoft.VisualStudio.Threading.ReentrantSemaphore.RevertRelevance.Dispose() -> void
+Microsoft.VisualStudio.Threading.RegistryChangeNotificationFilters
+Microsoft.VisualStudio.Threading.RegistryChangeNotificationFilters.Attributes = 2 -> Microsoft.VisualStudio.Threading.RegistryChangeNotificationFilters
+Microsoft.VisualStudio.Threading.RegistryChangeNotificationFilters.Security = 8 -> Microsoft.VisualStudio.Threading.RegistryChangeNotificationFilters
+Microsoft.VisualStudio.Threading.RegistryChangeNotificationFilters.Subkey = 1 -> Microsoft.VisualStudio.Threading.RegistryChangeNotificationFilters
+Microsoft.VisualStudio.Threading.RegistryChangeNotificationFilters.Value = 4 -> Microsoft.VisualStudio.Threading.RegistryChangeNotificationFilters
+Microsoft.VisualStudio.Threading.SingleThreadedSynchronizationContext
+Microsoft.VisualStudio.Threading.SingleThreadedSynchronizationContext.Frame
+Microsoft.VisualStudio.Threading.SingleThreadedSynchronizationContext.Frame.Continue.get -> bool
+Microsoft.VisualStudio.Threading.SingleThreadedSynchronizationContext.Frame.Continue.set -> void
+Microsoft.VisualStudio.Threading.SingleThreadedSynchronizationContext.Frame.Frame() -> void
+Microsoft.VisualStudio.Threading.SingleThreadedSynchronizationContext.PushFrame(Microsoft.VisualStudio.Threading.SingleThreadedSynchronizationContext.Frame! frame) -> void
+Microsoft.VisualStudio.Threading.SingleThreadedSynchronizationContext.SingleThreadedSynchronizationContext() -> void
+Microsoft.VisualStudio.Threading.SpecializedSyncContext
+Microsoft.VisualStudio.Threading.SpecializedSyncContext.Dispose() -> void
+Microsoft.VisualStudio.Threading.ThreadingTools
+Microsoft.VisualStudio.Threading.TplExtensions
+Microsoft.VisualStudio.Threading.TplExtensions.NoThrowTaskAwaitable
+Microsoft.VisualStudio.Threading.TplExtensions.NoThrowTaskAwaitable.GetAwaiter() -> Microsoft.VisualStudio.Threading.TplExtensions.NoThrowTaskAwaiter
+Microsoft.VisualStudio.Threading.TplExtensions.NoThrowTaskAwaitable.NoThrowTaskAwaitable(System.Threading.Tasks.Task! task, bool captureContext) -> void
+Microsoft.VisualStudio.Threading.TplExtensions.NoThrowTaskAwaiter
+Microsoft.VisualStudio.Threading.TplExtensions.NoThrowTaskAwaiter.GetResult() -> void
+Microsoft.VisualStudio.Threading.TplExtensions.NoThrowTaskAwaiter.IsCompleted.get -> bool
+Microsoft.VisualStudio.Threading.TplExtensions.NoThrowTaskAwaiter.NoThrowTaskAwaiter(System.Threading.Tasks.Task! task, bool captureContext) -> void
+Microsoft.VisualStudio.Threading.TplExtensions.NoThrowTaskAwaiter.OnCompleted(System.Action! continuation) -> void
+Microsoft.VisualStudio.Threading.TplExtensions.NoThrowTaskAwaiter.UnsafeOnCompleted(System.Action! continuation) -> void
+abstract Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.GetResourceAsync(TMoniker resourceMoniker, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TResource!>!
+abstract Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.PrepareResourceForConcurrentAccessAsync(TResource! resource, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+abstract Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.PrepareResourceForExclusiveAccessAsync(TResource! resource, Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.LockFlags lockFlags, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+abstract Microsoft.VisualStudio.Threading.ReentrantSemaphore.ExecuteAsync(System.Func<System.Threading.Tasks.Task!>! operation, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+abstract Microsoft.VisualStudio.Threading.ReentrantSemaphore.ExecuteAsync<T>(System.Func<System.Threading.Tasks.ValueTask<T>>! operation, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<T>
+override Microsoft.VisualStudio.Threading.AsyncLazy<T>.ToString() -> string!
+override Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.OnExclusiveLockReleasedAsync() -> System.Threading.Tasks.Task!
+override Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.OnUpgradeableReadLockReleased() -> void
+override Microsoft.VisualStudio.Threading.CancellationTokenExtensions.CombinedCancellationToken.Equals(object? obj) -> bool
+override Microsoft.VisualStudio.Threading.CancellationTokenExtensions.CombinedCancellationToken.GetHashCode() -> int
+override Microsoft.VisualStudio.Threading.DelegatingJoinableTaskFactory.OnTransitionedToMainThread(Microsoft.VisualStudio.Threading.JoinableTask! joinableTask, bool canceled) -> void
+override Microsoft.VisualStudio.Threading.DelegatingJoinableTaskFactory.OnTransitioningToMainThread(Microsoft.VisualStudio.Threading.JoinableTask! joinableTask) -> void
+override Microsoft.VisualStudio.Threading.DelegatingJoinableTaskFactory.PostToUnderlyingSynchronizationContext(System.Threading.SendOrPostCallback! callback, object! state) -> void
+override Microsoft.VisualStudio.Threading.DelegatingJoinableTaskFactory.WaitSynchronously(System.Threading.Tasks.Task! task) -> void
+override Microsoft.VisualStudio.Threading.NoMessagePumpSyncContext.Wait(System.IntPtr[]! waitHandles, bool waitAll, int millisecondsTimeout) -> int
+override Microsoft.VisualStudio.Threading.SingleThreadedSynchronizationContext.CreateCopy() -> System.Threading.SynchronizationContext!
+override Microsoft.VisualStudio.Threading.SingleThreadedSynchronizationContext.Post(System.Threading.SendOrPostCallback! d, object? state) -> void
+override Microsoft.VisualStudio.Threading.SingleThreadedSynchronizationContext.Send(System.Threading.SendOrPostCallback! d, object? state) -> void
+static Microsoft.VisualStudio.Threading.AwaitExtensions.ConfigureAwait(this System.Runtime.CompilerServices.YieldAwaitable yieldAwaitable, bool continueOnCapturedContext) -> Microsoft.VisualStudio.Threading.AwaitExtensions.ConfiguredTaskYieldAwaitable
+static Microsoft.VisualStudio.Threading.AwaitExtensions.ConfigureAwaitRunInline(this System.Threading.Tasks.Task! antecedent) -> Microsoft.VisualStudio.Threading.AwaitExtensions.ExecuteContinuationSynchronouslyAwaitable
+static Microsoft.VisualStudio.Threading.AwaitExtensions.ConfigureAwaitRunInline<T>(this System.Threading.Tasks.Task<T>! antecedent) -> Microsoft.VisualStudio.Threading.AwaitExtensions.ExecuteContinuationSynchronouslyAwaitable<T>
+static Microsoft.VisualStudio.Threading.AwaitExtensions.GetAwaiter(this System.Threading.Tasks.TaskScheduler! scheduler) -> Microsoft.VisualStudio.Threading.AwaitExtensions.TaskSchedulerAwaiter
+static Microsoft.VisualStudio.Threading.AwaitExtensions.GetAwaiter(this System.Threading.WaitHandle! handle) -> System.Runtime.CompilerServices.TaskAwaiter
+static Microsoft.VisualStudio.Threading.AwaitExtensions.SwitchTo(this System.Threading.Tasks.TaskScheduler! scheduler, bool alwaysYield = false) -> Microsoft.VisualStudio.Threading.AwaitExtensions.TaskSchedulerAwaitable
+static Microsoft.VisualStudio.Threading.AwaitExtensions.WaitForChangeAsync(this Microsoft.Win32.RegistryKey! registryKey, bool watchSubtree = true, Microsoft.VisualStudio.Threading.RegistryChangeNotificationFilters change = Microsoft.VisualStudio.Threading.RegistryChangeNotificationFilters.Subkey | Microsoft.VisualStudio.Threading.RegistryChangeNotificationFilters.Value, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+static Microsoft.VisualStudio.Threading.AwaitExtensions.WaitForExitAsync(this System.Diagnostics.Process! process, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>!
+static Microsoft.VisualStudio.Threading.CancellationTokenExtensions.CombineWith(this System.Threading.CancellationToken original, System.Threading.CancellationToken other) -> Microsoft.VisualStudio.Threading.CancellationTokenExtensions.CombinedCancellationToken
+static Microsoft.VisualStudio.Threading.CancellationTokenExtensions.CombineWith(this System.Threading.CancellationToken original, params System.Threading.CancellationToken[]! others) -> Microsoft.VisualStudio.Threading.CancellationTokenExtensions.CombinedCancellationToken
+static Microsoft.VisualStudio.Threading.CancellationTokenExtensions.CombinedCancellationToken.operator !=(Microsoft.VisualStudio.Threading.CancellationTokenExtensions.CombinedCancellationToken left, Microsoft.VisualStudio.Threading.CancellationTokenExtensions.CombinedCancellationToken right) -> bool
+static Microsoft.VisualStudio.Threading.CancellationTokenExtensions.CombinedCancellationToken.operator ==(Microsoft.VisualStudio.Threading.CancellationTokenExtensions.CombinedCancellationToken left, Microsoft.VisualStudio.Threading.CancellationTokenExtensions.CombinedCancellationToken right) -> bool
+static Microsoft.VisualStudio.Threading.DispatcherExtensions.WithPriority(this Microsoft.VisualStudio.Threading.JoinableTaskFactory! joinableTaskFactory, System.Windows.Threading.Dispatcher! dispatcher, System.Windows.Threading.DispatcherPriority priority) -> Microsoft.VisualStudio.Threading.JoinableTaskFactory!
+static Microsoft.VisualStudio.Threading.NoMessagePumpSyncContext.Default.get -> System.Threading.SynchronizationContext!
+static Microsoft.VisualStudio.Threading.ReentrantSemaphore.Create(int initialCount = 1, Microsoft.VisualStudio.Threading.JoinableTaskContext? joinableTaskContext = null, Microsoft.VisualStudio.Threading.ReentrantSemaphore.ReentrancyMode mode = Microsoft.VisualStudio.Threading.ReentrantSemaphore.ReentrancyMode.NotAllowed) -> Microsoft.VisualStudio.Threading.ReentrantSemaphore!
+static Microsoft.VisualStudio.Threading.SpecializedSyncContext.Apply(System.Threading.SynchronizationContext? syncContext, bool checkForChangesOnRevert = true) -> Microsoft.VisualStudio.Threading.SpecializedSyncContext
+static Microsoft.VisualStudio.Threading.ThreadingTools.Apply(this System.Threading.SynchronizationContext? syncContext, bool checkForChangesOnRevert = true) -> Microsoft.VisualStudio.Threading.SpecializedSyncContext
+static Microsoft.VisualStudio.Threading.ThreadingTools.ApplyChangeOptimistically<T, TArg>(ref T hotLocation, TArg applyChangeArgument, System.Func<T, TArg, T>! applyChange) -> bool
+static Microsoft.VisualStudio.Threading.ThreadingTools.ApplyChangeOptimistically<T>(ref T hotLocation, System.Func<T, T>! applyChange) -> bool
+static Microsoft.VisualStudio.Threading.ThreadingTools.WithCancellation(this System.Threading.Tasks.Task! task, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+static Microsoft.VisualStudio.Threading.ThreadingTools.WithCancellation<T>(this System.Threading.Tasks.Task<T>! task, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T>!
+static Microsoft.VisualStudio.Threading.TplExtensions.AppendAction(this System.Threading.Tasks.Task! task, System.Action! action, System.Threading.Tasks.TaskContinuationOptions options = System.Threading.Tasks.TaskContinuationOptions.None, System.Threading.CancellationToken cancellation = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+static Microsoft.VisualStudio.Threading.TplExtensions.ApplyResultTo<T>(this System.Threading.Tasks.Task! task, System.Threading.Tasks.TaskCompletionSource<T>! tcs) -> void
+static Microsoft.VisualStudio.Threading.TplExtensions.ApplyResultTo<T>(this System.Threading.Tasks.Task<T>! task, System.Threading.Tasks.TaskCompletionSource<T>! tcs) -> void
+static Microsoft.VisualStudio.Threading.TplExtensions.AttachToParent(this System.Threading.Tasks.Task! task) -> System.Threading.Tasks.Task!
+static Microsoft.VisualStudio.Threading.TplExtensions.AttachToParent<T>(this System.Threading.Tasks.Task<T>! task) -> System.Threading.Tasks.Task<T>!
+static Microsoft.VisualStudio.Threading.TplExtensions.FollowCancelableTaskToCompletion<T>(System.Func<System.Threading.Tasks.Task<T>!>! taskToFollow, System.Threading.CancellationToken ultimateCancellation, System.Threading.Tasks.TaskCompletionSource<T>? taskThatFollows = null) -> System.Threading.Tasks.Task<T>!
+static Microsoft.VisualStudio.Threading.TplExtensions.Forget(this System.Threading.Tasks.Task? task) -> void
+static Microsoft.VisualStudio.Threading.TplExtensions.InvokeAsync(this Microsoft.VisualStudio.Threading.AsyncEventHandler? handlers, object? sender, System.EventArgs! args) -> System.Threading.Tasks.Task!
+static Microsoft.VisualStudio.Threading.TplExtensions.InvokeAsync<TEventArgs>(this Microsoft.VisualStudio.Threading.AsyncEventHandler<TEventArgs>? handlers, object? sender, TEventArgs args) -> System.Threading.Tasks.Task!
+static Microsoft.VisualStudio.Threading.TplExtensions.NoThrowAwaitable(this System.Threading.Tasks.Task! task, bool captureContext = true) -> Microsoft.VisualStudio.Threading.TplExtensions.NoThrowTaskAwaitable
+static Microsoft.VisualStudio.Threading.TplExtensions.ToApm(this System.Threading.Tasks.Task! task, System.AsyncCallback? callback, object? state) -> System.Threading.Tasks.Task!
+static Microsoft.VisualStudio.Threading.TplExtensions.ToApm<TResult>(this System.Threading.Tasks.Task<TResult>! task, System.AsyncCallback? callback, object? state) -> System.Threading.Tasks.Task<TResult>!
+static Microsoft.VisualStudio.Threading.TplExtensions.ToTask(this System.Threading.WaitHandle! handle, int timeout = -1, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>!
+static Microsoft.VisualStudio.Threading.TplExtensions.WaitWithoutInlining(this System.Threading.Tasks.Task! task) -> void
+static Microsoft.VisualStudio.Threading.TplExtensions.WithTimeout(this System.Threading.Tasks.Task! task, System.TimeSpan timeout) -> System.Threading.Tasks.Task!
+static Microsoft.VisualStudio.Threading.TplExtensions.WithTimeout<T>(this System.Threading.Tasks.Task<T>! task, System.TimeSpan timeout) -> System.Threading.Tasks.Task<T>!
+static readonly Microsoft.VisualStudio.Threading.TplExtensions.CanceledTask -> System.Threading.Tasks.Task!
+static readonly Microsoft.VisualStudio.Threading.TplExtensions.CompletedTask -> System.Threading.Tasks.Task!
+static readonly Microsoft.VisualStudio.Threading.TplExtensions.FalseTask -> System.Threading.Tasks.Task<bool>!
+static readonly Microsoft.VisualStudio.Threading.TplExtensions.TrueTask -> System.Threading.Tasks.Task<bool>!
+virtual Microsoft.VisualStudio.Threading.AsyncQueue<T>.InitialCapacity.get -> int
+virtual Microsoft.VisualStudio.Threading.AsyncQueue<T>.OnCompleted() -> void
+virtual Microsoft.VisualStudio.Threading.AsyncQueue<T>.OnDequeued(T value) -> void
+virtual Microsoft.VisualStudio.Threading.AsyncQueue<T>.OnEnqueued(T value, bool alreadyDispatched) -> void
+virtual Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.CanCurrentThreadHoldActiveLock.get -> bool
+virtual Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Dispose(bool disposing) -> void
+virtual Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.GetHangReport() -> Microsoft.VisualStudio.Threading.HangReportContribution!
+virtual Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.GetTaskSchedulerForReadLockRequest() -> System.Threading.Tasks.TaskScheduler!
+virtual Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.IsUnsupportedSynchronizationContext.get -> bool
+virtual Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.NoMessagePumpSynchronizationContext.get -> System.Threading.SynchronizationContext!
+virtual Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.OnBeforeExclusiveLockReleasedAsync() -> System.Threading.Tasks.Task!
+virtual Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.OnBeforeLockReleasedAsync(bool exclusiveLockRelease, Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockHandle releasingLock) -> System.Threading.Tasks.Task!
+virtual Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.OnCriticalFailure(System.Exception! ex) -> System.Exception!
+virtual Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.OnExclusiveLockReleasedAsync() -> System.Threading.Tasks.Task!
+virtual Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.OnUpgradeableReadLockReleased() -> void
+virtual Microsoft.VisualStudio.Threading.AsyncSemaphore.Dispose(bool disposing) -> void
+virtual Microsoft.VisualStudio.Threading.JoinableTaskContext.CreateDefaultFactory() -> Microsoft.VisualStudio.Threading.JoinableTaskFactory!
+virtual Microsoft.VisualStudio.Threading.JoinableTaskContext.CreateFactory(Microsoft.VisualStudio.Threading.JoinableTaskCollection! collection) -> Microsoft.VisualStudio.Threading.JoinableTaskFactory!
+virtual Microsoft.VisualStudio.Threading.JoinableTaskContext.Dispose(bool disposing) -> void
+virtual Microsoft.VisualStudio.Threading.JoinableTaskContext.GetHangReport() -> Microsoft.VisualStudio.Threading.HangReportContribution!
+virtual Microsoft.VisualStudio.Threading.JoinableTaskContext.NoMessagePumpSynchronizationContext.get -> System.Threading.SynchronizationContext!
+virtual Microsoft.VisualStudio.Threading.JoinableTaskContext.OnFalseHangDetected(System.TimeSpan hangDuration, System.Guid hangId) -> void
+virtual Microsoft.VisualStudio.Threading.JoinableTaskContext.OnHangDetected(System.TimeSpan hangDuration, int notificationCount, System.Guid hangId) -> void
+virtual Microsoft.VisualStudio.Threading.JoinableTaskContextNode.CreateDefaultFactory() -> Microsoft.VisualStudio.Threading.JoinableTaskFactory!
+virtual Microsoft.VisualStudio.Threading.JoinableTaskContextNode.CreateFactory(Microsoft.VisualStudio.Threading.JoinableTaskCollection! collection) -> Microsoft.VisualStudio.Threading.JoinableTaskFactory!
+virtual Microsoft.VisualStudio.Threading.JoinableTaskContextNode.OnFalseHangDetected(System.TimeSpan hangDuration, System.Guid hangId) -> void
+virtual Microsoft.VisualStudio.Threading.JoinableTaskContextNode.OnHangDetected(Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails! details) -> void
+virtual Microsoft.VisualStudio.Threading.JoinableTaskContextNode.OnHangDetected(System.TimeSpan hangDuration, int notificationCount, System.Guid hangId) -> void
+virtual Microsoft.VisualStudio.Threading.JoinableTaskFactory.OnTransitionedToMainThread(Microsoft.VisualStudio.Threading.JoinableTask! joinableTask, bool canceled) -> void
+virtual Microsoft.VisualStudio.Threading.JoinableTaskFactory.OnTransitioningToMainThread(Microsoft.VisualStudio.Threading.JoinableTask! joinableTask) -> void
+virtual Microsoft.VisualStudio.Threading.JoinableTaskFactory.PostToUnderlyingSynchronizationContext(System.Threading.SendOrPostCallback! callback, object! state) -> void
+virtual Microsoft.VisualStudio.Threading.JoinableTaskFactory.WaitSynchronously(System.Threading.Tasks.Task! task) -> void
+virtual Microsoft.VisualStudio.Threading.JoinableTaskFactory.WaitSynchronouslyCore(System.Threading.Tasks.Task! task) -> void
+virtual Microsoft.VisualStudio.Threading.ProgressWithCompletion<T>.Report(T value) -> void
+virtual Microsoft.VisualStudio.Threading.ReentrantSemaphore.SuppressRelevance() -> Microsoft.VisualStudio.Threading.ReentrantSemaphore.RevertRelevance
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Releaser.DisposeAsync() -> System.Threading.Tasks.ValueTask
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ResourceReleaser.DisposeAsync() -> System.Threading.Tasks.ValueTask
+Microsoft.VisualStudio.Threading.NonConcurrentSynchronizationContext
+Microsoft.VisualStudio.Threading.NonConcurrentSynchronizationContext.NonConcurrentSynchronizationContext(bool sticky) -> void
+Microsoft.VisualStudio.Threading.NonConcurrentSynchronizationContext.UnhandledException -> System.EventHandler<System.Exception!>?
+override Microsoft.VisualStudio.Threading.NonConcurrentSynchronizationContext.CreateCopy() -> System.Threading.SynchronizationContext!
+override Microsoft.VisualStudio.Threading.NonConcurrentSynchronizationContext.Post(System.Threading.SendOrPostCallback! d, object? state) -> void
+override Microsoft.VisualStudio.Threading.NonConcurrentSynchronizationContext.Send(System.Threading.SendOrPostCallback! d, object? state) -> void
+static Microsoft.VisualStudio.Threading.TplExtensions.Forget(this System.Threading.Tasks.ValueTask task) -> void
+static Microsoft.VisualStudio.Threading.TplExtensions.Forget<T>(this System.Threading.Tasks.ValueTask<T> task) -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.AggregateExceptionAwaitable
+Microsoft.VisualStudio.Threading.AwaitExtensions.AggregateExceptionAwaitable.AggregateExceptionAwaitable(System.Threading.Tasks.Task! task, bool continueOnCapturedContext) -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.AggregateExceptionAwaitable.GetAwaiter() -> Microsoft.VisualStudio.Threading.AwaitExtensions.AggregateExceptionAwaiter
+Microsoft.VisualStudio.Threading.AwaitExtensions.AggregateExceptionAwaiter
+Microsoft.VisualStudio.Threading.AwaitExtensions.AggregateExceptionAwaiter.AggregateExceptionAwaiter(System.Threading.Tasks.Task! task, bool continueOnCapturedContext) -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.AggregateExceptionAwaiter.GetResult() -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.AggregateExceptionAwaiter.IsCompleted.get -> bool
+Microsoft.VisualStudio.Threading.AwaitExtensions.AggregateExceptionAwaiter.OnCompleted(System.Action! continuation) -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.AggregateExceptionAwaiter.UnsafeOnCompleted(System.Action! continuation) -> void
+static Microsoft.VisualStudio.Threading.AwaitExtensions.ConfigureAwaitForAggregateException(this System.Threading.Tasks.Task! task, bool continueOnCapturedContext = true) -> Microsoft.VisualStudio.Threading.AwaitExtensions.AggregateExceptionAwaitable
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.AsyncReaderWriterLock(Microsoft.VisualStudio.Threading.JoinableTaskContext? joinableTaskContext, bool captureDiagnostics = false) -> void
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.AsyncReaderWriterResourceLock(Microsoft.VisualStudio.Threading.JoinableTaskContext? joinableTaskContext, bool captureDiagnostics) -> void
+Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadMaybeBlocked() -> bool
+virtual Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.DeadlockCheckTimeout.get -> System.TimeSpan

--- a/src/Microsoft.VisualStudio.Threading/net5.0-windows/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/net5.0-windows/PublicAPI.Unshipped.txt
@@ -1,0 +1,12 @@
+Microsoft.VisualStudio.Threading.AsyncQueue<T>.ToArray() -> T[]!
+Microsoft.VisualStudio.Threading.AwaitExtensions.SynchronizationContextAwaiter
+Microsoft.VisualStudio.Threading.AwaitExtensions.SynchronizationContextAwaiter.GetResult() -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.SynchronizationContextAwaiter.IsCompleted.get -> bool
+Microsoft.VisualStudio.Threading.AwaitExtensions.SynchronizationContextAwaiter.OnCompleted(System.Action! continuation) -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.SynchronizationContextAwaiter.SynchronizationContextAwaiter(System.Threading.SynchronizationContext! syncContext) -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.SynchronizationContextAwaiter.UnsafeOnCompleted(System.Action! continuation) -> void
+Microsoft.VisualStudio.Threading.SemaphoreFaultedException
+Microsoft.VisualStudio.Threading.SemaphoreFaultedException.SemaphoreFaultedException() -> void
+Microsoft.VisualStudio.Threading.IllegalSemaphoreUsageException
+Microsoft.VisualStudio.Threading.IllegalSemaphoreUsageException.IllegalSemaphoreUsageException(string! message) -> void
+static Microsoft.VisualStudio.Threading.AwaitExtensions.GetAwaiter(this System.Threading.SynchronizationContext! synchronizationContext) -> Microsoft.VisualStudio.Threading.AwaitExtensions.SynchronizationContextAwaiter

--- a/src/Microsoft.VisualStudio.Threading/net5.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/net5.0/PublicAPI.Shipped.txt
@@ -1,0 +1,458 @@
+#nullable enable
+Microsoft.VisualStudio.Threading.AsyncAutoResetEvent
+Microsoft.VisualStudio.Threading.AsyncAutoResetEvent.AsyncAutoResetEvent() -> void
+Microsoft.VisualStudio.Threading.AsyncAutoResetEvent.AsyncAutoResetEvent(bool allowInliningAwaiters) -> void
+Microsoft.VisualStudio.Threading.AsyncAutoResetEvent.Set() -> void
+Microsoft.VisualStudio.Threading.AsyncAutoResetEvent.WaitAsync() -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Threading.AsyncAutoResetEvent.WaitAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Threading.AsyncBarrier
+Microsoft.VisualStudio.Threading.AsyncBarrier.AsyncBarrier(int participants) -> void
+Microsoft.VisualStudio.Threading.AsyncBarrier.SignalAndWait() -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Threading.AsyncCountdownEvent
+Microsoft.VisualStudio.Threading.AsyncCountdownEvent.AsyncCountdownEvent(int initialCount) -> void
+Microsoft.VisualStudio.Threading.AsyncCountdownEvent.Signal() -> void
+Microsoft.VisualStudio.Threading.AsyncCountdownEvent.SignalAndWaitAsync() -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Threading.AsyncCountdownEvent.SignalAsync() -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Threading.AsyncCountdownEvent.WaitAsync() -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Threading.AsyncEventHandler
+Microsoft.VisualStudio.Threading.AsyncEventHandler<TEventArgs>
+Microsoft.VisualStudio.Threading.AsyncLazy<T>
+Microsoft.VisualStudio.Threading.AsyncLazy<T>.AsyncLazy(System.Func<System.Threading.Tasks.Task<T>!>! valueFactory, Microsoft.VisualStudio.Threading.JoinableTaskFactory? joinableTaskFactory = null) -> void
+Microsoft.VisualStudio.Threading.AsyncLazy<T>.GetValue() -> T
+Microsoft.VisualStudio.Threading.AsyncLazy<T>.GetValue(System.Threading.CancellationToken cancellationToken) -> T
+Microsoft.VisualStudio.Threading.AsyncLazy<T>.GetValueAsync() -> System.Threading.Tasks.Task<T>!
+Microsoft.VisualStudio.Threading.AsyncLazy<T>.GetValueAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T>!
+Microsoft.VisualStudio.Threading.AsyncLazy<T>.IsValueCreated.get -> bool
+Microsoft.VisualStudio.Threading.AsyncLazy<T>.IsValueFactoryCompleted.get -> bool
+Microsoft.VisualStudio.Threading.AsyncLazyInitializer
+Microsoft.VisualStudio.Threading.AsyncLazyInitializer.AsyncLazyInitializer(System.Func<System.Threading.Tasks.Task!>! action, Microsoft.VisualStudio.Threading.JoinableTaskFactory? joinableTaskFactory = null) -> void
+Microsoft.VisualStudio.Threading.AsyncLazyInitializer.Initialize(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
+Microsoft.VisualStudio.Threading.AsyncLazyInitializer.InitializeAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Threading.AsyncLazyInitializer.IsCompleted.get -> bool
+Microsoft.VisualStudio.Threading.AsyncLazyInitializer.IsCompletedSuccessfully.get -> bool
+Microsoft.VisualStudio.Threading.AsyncLocal<T>
+Microsoft.VisualStudio.Threading.AsyncLocal<T>.AsyncLocal() -> void
+Microsoft.VisualStudio.Threading.AsyncLocal<T>.Value.get -> T?
+Microsoft.VisualStudio.Threading.AsyncLocal<T>.Value.set -> void
+Microsoft.VisualStudio.Threading.AsyncManualResetEvent
+Microsoft.VisualStudio.Threading.AsyncManualResetEvent.AsyncManualResetEvent(bool initialState = false, bool allowInliningAwaiters = false) -> void
+Microsoft.VisualStudio.Threading.AsyncManualResetEvent.GetAwaiter() -> System.Runtime.CompilerServices.TaskAwaiter
+Microsoft.VisualStudio.Threading.AsyncManualResetEvent.IsSet.get -> bool
+Microsoft.VisualStudio.Threading.AsyncManualResetEvent.PulseAll() -> void
+Microsoft.VisualStudio.Threading.AsyncManualResetEvent.PulseAllAsync() -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Threading.AsyncManualResetEvent.Reset() -> void
+Microsoft.VisualStudio.Threading.AsyncManualResetEvent.Set() -> void
+Microsoft.VisualStudio.Threading.AsyncManualResetEvent.SetAsync() -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Threading.AsyncManualResetEvent.WaitAsync() -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Threading.AsyncManualResetEvent.WaitAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Threading.AsyncQueue<T>
+Microsoft.VisualStudio.Threading.AsyncQueue<T>.AsyncQueue() -> void
+Microsoft.VisualStudio.Threading.AsyncQueue<T>.Complete() -> void
+Microsoft.VisualStudio.Threading.AsyncQueue<T>.Completion.get -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Threading.AsyncQueue<T>.Count.get -> int
+Microsoft.VisualStudio.Threading.AsyncQueue<T>.DequeueAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<T>!
+Microsoft.VisualStudio.Threading.AsyncQueue<T>.Enqueue(T value) -> void
+Microsoft.VisualStudio.Threading.AsyncQueue<T>.IsCompleted.get -> bool
+Microsoft.VisualStudio.Threading.AsyncQueue<T>.IsEmpty.get -> bool
+Microsoft.VisualStudio.Threading.AsyncQueue<T>.Peek() -> T
+Microsoft.VisualStudio.Threading.AsyncQueue<T>.SyncRoot.get -> object!
+Microsoft.VisualStudio.Threading.AsyncQueue<T>.TryDequeue(System.Predicate<T>! valueCheck, out T value) -> bool
+Microsoft.VisualStudio.Threading.AsyncQueue<T>.TryDequeue(out T value) -> bool
+Microsoft.VisualStudio.Threading.AsyncQueue<T>.TryEnqueue(T value) -> bool
+Microsoft.VisualStudio.Threading.AsyncQueue<T>.TryPeek(out T value) -> bool
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.AmbientLock.get -> Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockHandle
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.AsyncReaderWriterLock() -> void
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.AsyncReaderWriterLock(bool captureDiagnostics) -> void
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Awaitable
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Awaitable.GetAwaiter() -> Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Awaiter!
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Awaiter
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Awaiter.GetResult() -> Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Releaser
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Awaiter.IsCompleted.get -> bool
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Awaiter.OnCompleted(System.Action! continuation) -> void
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Awaiter.UnsafeOnCompleted(System.Action! continuation) -> void
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.CaptureDiagnostics.get -> bool
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.CaptureDiagnostics.set -> void
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Complete() -> void
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Completion.get -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Dispose() -> void
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.GetAggregateLockFlags() -> Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockFlags
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.HideLocks() -> Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Suppression
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.IsAnyLockHeld.get -> bool
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.IsAnyPassiveLockHeld.get -> bool
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.IsPassiveReadLockHeld.get -> bool
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.IsPassiveUpgradeableReadLockHeld.get -> bool
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.IsPassiveWriteLockHeld.get -> bool
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.IsReadLockHeld.get -> bool
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.IsUpgradeableReadLockHeld.get -> bool
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.IsWriteLockHeld.get -> bool
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockFlags
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockFlags.None = 0 -> Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockFlags
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockFlags.StickyWrite = 1 -> Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockFlags
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockHandle
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockHandle.Data.get -> object?
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockHandle.Data.set -> void
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockHandle.Flags.get -> Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockFlags
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockHandle.HasReadLock.get -> bool
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockHandle.HasUpgradeableReadLock.get -> bool
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockHandle.HasWriteLock.get -> bool
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockHandle.IsActive.get -> bool
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockHandle.IsReadLock.get -> bool
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockHandle.IsUpgradeableReadLock.get -> bool
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockHandle.IsValid.get -> bool
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockHandle.IsWriteLock.get -> bool
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockHandle.NestingLock.get -> Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockHandle
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockStackContains(Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockFlags flags, Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockHandle handle) -> bool
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.OnBeforeWriteLockReleased(System.Func<System.Threading.Tasks.Task!>! action) -> void
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.OnCriticalFailure(string! message) -> System.Exception!
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.ReadLockAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Awaitable
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Releaser
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Releaser.Dispose() -> void
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Releaser.ReleaseAsync() -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Suppression
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Suppression.Dispose() -> void
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.SyncObject.get -> object!
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.UpgradeableReadLockAsync(Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockFlags options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Awaitable
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.UpgradeableReadLockAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Awaitable
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.WriteLockAsync(Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockFlags options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Awaitable
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.WriteLockAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Awaitable
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.AsyncReaderWriterResourceLock() -> void
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.AsyncReaderWriterResourceLock(bool captureDiagnostics) -> void
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.GetAggregateLockFlags() -> Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.LockFlags
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.LockFlags
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.LockFlags.None = 0 -> Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.LockFlags
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.LockFlags.SkipInitialPreparation = 4096 -> Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.LockFlags
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.LockFlags.StickyWrite = 1 -> Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.LockFlags
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ReadLockAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ResourceAwaitable
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ResourceAwaitable
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ResourceAwaitable.GetAwaiter() -> Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ResourceAwaiter
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ResourceAwaiter
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ResourceAwaiter.GetResult() -> Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ResourceReleaser
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ResourceAwaiter.IsCompleted.get -> bool
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ResourceAwaiter.OnCompleted(System.Action! continuation) -> void
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ResourceAwaiter.UnsafeOnCompleted(System.Action! continuation) -> void
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ResourceReleaser
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ResourceReleaser.Dispose() -> void
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ResourceReleaser.GetResourceAsync(TMoniker resourceMoniker, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResource!>!
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ResourceReleaser.ReleaseAsync() -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.SetAllResourcesToUnknownState() -> void
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.SetResourceAsAccessed(System.Func<TResource!, object?, bool>! resourceCheck, object? state) -> bool
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.SetResourceAsAccessed(TResource! resource) -> void
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.UpgradeableReadLockAsync(Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.LockFlags options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ResourceAwaitable
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.UpgradeableReadLockAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ResourceAwaitable
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.WriteLockAsync(Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.LockFlags options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ResourceAwaitable
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.WriteLockAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ResourceAwaitable
+Microsoft.VisualStudio.Threading.AsyncSemaphore
+Microsoft.VisualStudio.Threading.AsyncSemaphore.AsyncSemaphore(int initialCount) -> void
+Microsoft.VisualStudio.Threading.AsyncSemaphore.CurrentCount.get -> int
+Microsoft.VisualStudio.Threading.AsyncSemaphore.Dispose() -> void
+Microsoft.VisualStudio.Threading.AsyncSemaphore.EnterAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.VisualStudio.Threading.AsyncSemaphore.Releaser>!
+Microsoft.VisualStudio.Threading.AsyncSemaphore.EnterAsync(System.TimeSpan timeout, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.VisualStudio.Threading.AsyncSemaphore.Releaser>!
+Microsoft.VisualStudio.Threading.AsyncSemaphore.EnterAsync(int timeout, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.VisualStudio.Threading.AsyncSemaphore.Releaser>!
+Microsoft.VisualStudio.Threading.AsyncSemaphore.Releaser
+Microsoft.VisualStudio.Threading.AsyncSemaphore.Releaser.Dispose() -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions
+Microsoft.VisualStudio.Threading.AwaitExtensions.ConfiguredTaskYieldAwaitable
+Microsoft.VisualStudio.Threading.AwaitExtensions.ConfiguredTaskYieldAwaitable.ConfiguredTaskYieldAwaitable(bool continueOnCapturedContext) -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.ConfiguredTaskYieldAwaitable.GetAwaiter() -> Microsoft.VisualStudio.Threading.AwaitExtensions.ConfiguredTaskYieldAwaiter
+Microsoft.VisualStudio.Threading.AwaitExtensions.ConfiguredTaskYieldAwaiter
+Microsoft.VisualStudio.Threading.AwaitExtensions.ConfiguredTaskYieldAwaiter.ConfiguredTaskYieldAwaiter(bool continueOnCapturedContext) -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.ConfiguredTaskYieldAwaiter.GetResult() -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.ConfiguredTaskYieldAwaiter.IsCompleted.get -> bool
+Microsoft.VisualStudio.Threading.AwaitExtensions.ConfiguredTaskYieldAwaiter.OnCompleted(System.Action! continuation) -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.ConfiguredTaskYieldAwaiter.UnsafeOnCompleted(System.Action! continuation) -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.ExecuteContinuationSynchronouslyAwaitable
+Microsoft.VisualStudio.Threading.AwaitExtensions.ExecuteContinuationSynchronouslyAwaitable.ExecuteContinuationSynchronouslyAwaitable(System.Threading.Tasks.Task! antecedent) -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.ExecuteContinuationSynchronouslyAwaitable.GetAwaiter() -> Microsoft.VisualStudio.Threading.AwaitExtensions.ExecuteContinuationSynchronouslyAwaiter
+Microsoft.VisualStudio.Threading.AwaitExtensions.ExecuteContinuationSynchronouslyAwaitable<T>
+Microsoft.VisualStudio.Threading.AwaitExtensions.ExecuteContinuationSynchronouslyAwaitable<T>.ExecuteContinuationSynchronouslyAwaitable(System.Threading.Tasks.Task<T>! antecedent) -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.ExecuteContinuationSynchronouslyAwaitable<T>.GetAwaiter() -> Microsoft.VisualStudio.Threading.AwaitExtensions.ExecuteContinuationSynchronouslyAwaiter<T>
+Microsoft.VisualStudio.Threading.AwaitExtensions.ExecuteContinuationSynchronouslyAwaiter
+Microsoft.VisualStudio.Threading.AwaitExtensions.ExecuteContinuationSynchronouslyAwaiter.ExecuteContinuationSynchronouslyAwaiter(System.Threading.Tasks.Task! antecedent) -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.ExecuteContinuationSynchronouslyAwaiter.GetResult() -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.ExecuteContinuationSynchronouslyAwaiter.IsCompleted.get -> bool
+Microsoft.VisualStudio.Threading.AwaitExtensions.ExecuteContinuationSynchronouslyAwaiter.OnCompleted(System.Action! continuation) -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.ExecuteContinuationSynchronouslyAwaiter<T>
+Microsoft.VisualStudio.Threading.AwaitExtensions.ExecuteContinuationSynchronouslyAwaiter<T>.ExecuteContinuationSynchronouslyAwaiter(System.Threading.Tasks.Task<T>! antecedent) -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.ExecuteContinuationSynchronouslyAwaiter<T>.GetResult() -> T
+Microsoft.VisualStudio.Threading.AwaitExtensions.ExecuteContinuationSynchronouslyAwaiter<T>.IsCompleted.get -> bool
+Microsoft.VisualStudio.Threading.AwaitExtensions.ExecuteContinuationSynchronouslyAwaiter<T>.OnCompleted(System.Action! continuation) -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.TaskSchedulerAwaitable
+Microsoft.VisualStudio.Threading.AwaitExtensions.TaskSchedulerAwaitable.GetAwaiter() -> Microsoft.VisualStudio.Threading.AwaitExtensions.TaskSchedulerAwaiter
+Microsoft.VisualStudio.Threading.AwaitExtensions.TaskSchedulerAwaitable.TaskSchedulerAwaitable(System.Threading.Tasks.TaskScheduler! taskScheduler, bool alwaysYield = false) -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.TaskSchedulerAwaiter
+Microsoft.VisualStudio.Threading.AwaitExtensions.TaskSchedulerAwaiter.GetResult() -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.TaskSchedulerAwaiter.IsCompleted.get -> bool
+Microsoft.VisualStudio.Threading.AwaitExtensions.TaskSchedulerAwaiter.OnCompleted(System.Action! continuation) -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.TaskSchedulerAwaiter.TaskSchedulerAwaiter(System.Threading.Tasks.TaskScheduler! scheduler, bool alwaysYield = false) -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.TaskSchedulerAwaiter.UnsafeOnCompleted(System.Action! continuation) -> void
+Microsoft.VisualStudio.Threading.CancellationTokenExtensions
+Microsoft.VisualStudio.Threading.CancellationTokenExtensions.CombinedCancellationToken
+Microsoft.VisualStudio.Threading.CancellationTokenExtensions.CombinedCancellationToken.CombinedCancellationToken(System.Threading.CancellationToken cancellationToken) -> void
+Microsoft.VisualStudio.Threading.CancellationTokenExtensions.CombinedCancellationToken.CombinedCancellationToken(System.Threading.CancellationTokenSource! cancellationTokenSource) -> void
+Microsoft.VisualStudio.Threading.CancellationTokenExtensions.CombinedCancellationToken.Dispose() -> void
+Microsoft.VisualStudio.Threading.CancellationTokenExtensions.CombinedCancellationToken.Equals(Microsoft.VisualStudio.Threading.CancellationTokenExtensions.CombinedCancellationToken other) -> bool
+Microsoft.VisualStudio.Threading.CancellationTokenExtensions.CombinedCancellationToken.Token.get -> System.Threading.CancellationToken
+Microsoft.VisualStudio.Threading.DelegatingJoinableTaskFactory
+Microsoft.VisualStudio.Threading.DelegatingJoinableTaskFactory.DelegatingJoinableTaskFactory(Microsoft.VisualStudio.Threading.JoinableTaskFactory! innerFactory) -> void
+Microsoft.VisualStudio.Threading.HangReportContribution
+Microsoft.VisualStudio.Threading.HangReportContribution.Content.get -> string!
+Microsoft.VisualStudio.Threading.HangReportContribution.ContentName.get -> string?
+Microsoft.VisualStudio.Threading.HangReportContribution.ContentType.get -> string?
+Microsoft.VisualStudio.Threading.HangReportContribution.HangReportContribution(string! content, string? contentType, string? contentName) -> void
+Microsoft.VisualStudio.Threading.HangReportContribution.HangReportContribution(string! content, string? contentType, string? contentName, params Microsoft.VisualStudio.Threading.HangReportContribution![]? nestedReports) -> void
+Microsoft.VisualStudio.Threading.HangReportContribution.NestedReports.get -> System.Collections.Generic.IReadOnlyCollection<Microsoft.VisualStudio.Threading.HangReportContribution!>?
+Microsoft.VisualStudio.Threading.IAsyncDisposable
+Microsoft.VisualStudio.Threading.IAsyncDisposable.DisposeAsync() -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Threading.IHangReportContributor
+Microsoft.VisualStudio.Threading.IHangReportContributor.GetHangReport() -> Microsoft.VisualStudio.Threading.HangReportContribution!
+Microsoft.VisualStudio.Threading.JoinableTask
+Microsoft.VisualStudio.Threading.JoinableTask.GetAwaiter() -> System.Runtime.CompilerServices.TaskAwaiter
+Microsoft.VisualStudio.Threading.JoinableTask.IsCompleted.get -> bool
+Microsoft.VisualStudio.Threading.JoinableTask.Join(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
+Microsoft.VisualStudio.Threading.JoinableTask.JoinAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Threading.JoinableTask.Task.get -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Threading.JoinableTask<T>
+Microsoft.VisualStudio.Threading.JoinableTask<T>.GetAwaiter() -> System.Runtime.CompilerServices.TaskAwaiter<T>
+Microsoft.VisualStudio.Threading.JoinableTask<T>.Join(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> T
+Microsoft.VisualStudio.Threading.JoinableTask<T>.JoinAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<T>!
+Microsoft.VisualStudio.Threading.JoinableTask<T>.Task.get -> System.Threading.Tasks.Task<T>!
+Microsoft.VisualStudio.Threading.JoinableTaskCollection
+Microsoft.VisualStudio.Threading.JoinableTaskCollection.Add(Microsoft.VisualStudio.Threading.JoinableTask! joinableTask) -> void
+Microsoft.VisualStudio.Threading.JoinableTaskCollection.Contains(Microsoft.VisualStudio.Threading.JoinableTask! joinableTask) -> bool
+Microsoft.VisualStudio.Threading.JoinableTaskCollection.Context.get -> Microsoft.VisualStudio.Threading.JoinableTaskContext!
+Microsoft.VisualStudio.Threading.JoinableTaskCollection.DisplayName.get -> string?
+Microsoft.VisualStudio.Threading.JoinableTaskCollection.DisplayName.set -> void
+Microsoft.VisualStudio.Threading.JoinableTaskCollection.GetEnumerator() -> System.Collections.Generic.IEnumerator<Microsoft.VisualStudio.Threading.JoinableTask!>!
+Microsoft.VisualStudio.Threading.JoinableTaskCollection.Join() -> Microsoft.VisualStudio.Threading.JoinableTaskCollection.JoinRelease
+Microsoft.VisualStudio.Threading.JoinableTaskCollection.JoinRelease
+Microsoft.VisualStudio.Threading.JoinableTaskCollection.JoinRelease.Dispose() -> void
+Microsoft.VisualStudio.Threading.JoinableTaskCollection.JoinTillEmptyAsync() -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Threading.JoinableTaskCollection.JoinTillEmptyAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Threading.JoinableTaskCollection.JoinableTaskCollection(Microsoft.VisualStudio.Threading.JoinableTaskContext! context, bool refCountAddedJobs = false) -> void
+Microsoft.VisualStudio.Threading.JoinableTaskCollection.Remove(Microsoft.VisualStudio.Threading.JoinableTask! joinableTask) -> void
+Microsoft.VisualStudio.Threading.JoinableTaskContext
+Microsoft.VisualStudio.Threading.JoinableTaskContext.CreateCollection() -> Microsoft.VisualStudio.Threading.JoinableTaskCollection!
+Microsoft.VisualStudio.Threading.JoinableTaskContext.Dispose() -> void
+Microsoft.VisualStudio.Threading.JoinableTaskContext.Factory.get -> Microsoft.VisualStudio.Threading.JoinableTaskFactory!
+Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails
+Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.EntryMethod.get -> System.Reflection.MethodInfo?
+Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.HangDetails(System.TimeSpan hangDuration, int notificationCount, System.Guid hangId, System.Reflection.MethodInfo? entryMethod) -> void
+Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.HangDuration.get -> System.TimeSpan
+Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.HangId.get -> System.Guid
+Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.NotificationCount.get -> int
+Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadBlocked() -> bool
+Microsoft.VisualStudio.Threading.JoinableTaskContext.IsOnMainThread.get -> bool
+Microsoft.VisualStudio.Threading.JoinableTaskContext.IsWithinJoinableTask.get -> bool
+Microsoft.VisualStudio.Threading.JoinableTaskContext.JoinableTaskContext() -> void
+Microsoft.VisualStudio.Threading.JoinableTaskContext.JoinableTaskContext(System.Threading.Thread? mainThread = null, System.Threading.SynchronizationContext? synchronizationContext = null) -> void
+Microsoft.VisualStudio.Threading.JoinableTaskContext.MainThread.get -> System.Threading.Thread!
+Microsoft.VisualStudio.Threading.JoinableTaskContext.RevertRelevance
+Microsoft.VisualStudio.Threading.JoinableTaskContext.RevertRelevance.Dispose() -> void
+Microsoft.VisualStudio.Threading.JoinableTaskContext.SuppressRelevance() -> Microsoft.VisualStudio.Threading.JoinableTaskContext.RevertRelevance
+Microsoft.VisualStudio.Threading.JoinableTaskContextException
+Microsoft.VisualStudio.Threading.JoinableTaskContextException.JoinableTaskContextException() -> void
+Microsoft.VisualStudio.Threading.JoinableTaskContextException.JoinableTaskContextException(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
+Microsoft.VisualStudio.Threading.JoinableTaskContextException.JoinableTaskContextException(string? message) -> void
+Microsoft.VisualStudio.Threading.JoinableTaskContextException.JoinableTaskContextException(string? message, System.Exception? inner) -> void
+Microsoft.VisualStudio.Threading.JoinableTaskContextNode
+Microsoft.VisualStudio.Threading.JoinableTaskContextNode.Context.get -> Microsoft.VisualStudio.Threading.JoinableTaskContext!
+Microsoft.VisualStudio.Threading.JoinableTaskContextNode.CreateCollection() -> Microsoft.VisualStudio.Threading.JoinableTaskCollection!
+Microsoft.VisualStudio.Threading.JoinableTaskContextNode.Factory.get -> Microsoft.VisualStudio.Threading.JoinableTaskFactory!
+Microsoft.VisualStudio.Threading.JoinableTaskContextNode.IsMainThreadBlocked() -> bool
+Microsoft.VisualStudio.Threading.JoinableTaskContextNode.IsOnMainThread.get -> bool
+Microsoft.VisualStudio.Threading.JoinableTaskContextNode.JoinableTaskContextNode(Microsoft.VisualStudio.Threading.JoinableTaskContext! context) -> void
+Microsoft.VisualStudio.Threading.JoinableTaskContextNode.MainThread.get -> System.Threading.Thread!
+Microsoft.VisualStudio.Threading.JoinableTaskContextNode.RegisterOnHangDetected() -> System.IDisposable!
+Microsoft.VisualStudio.Threading.JoinableTaskContextNode.SuppressRelevance() -> Microsoft.VisualStudio.Threading.JoinableTaskContext.RevertRelevance
+Microsoft.VisualStudio.Threading.JoinableTaskCreationOptions
+Microsoft.VisualStudio.Threading.JoinableTaskCreationOptions.LongRunning = 1 -> Microsoft.VisualStudio.Threading.JoinableTaskCreationOptions
+Microsoft.VisualStudio.Threading.JoinableTaskCreationOptions.None = 0 -> Microsoft.VisualStudio.Threading.JoinableTaskCreationOptions
+Microsoft.VisualStudio.Threading.JoinableTaskFactory
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.Add(Microsoft.VisualStudio.Threading.JoinableTask! joinable) -> void
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.Context.get -> Microsoft.VisualStudio.Threading.JoinableTaskContext!
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.HangDetectionTimeout.get -> System.TimeSpan
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.HangDetectionTimeout.set -> void
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.IsWaitingOnLongRunningTask() -> bool
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.JoinableTaskFactory(Microsoft.VisualStudio.Threading.JoinableTaskCollection! collection) -> void
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.JoinableTaskFactory(Microsoft.VisualStudio.Threading.JoinableTaskContext! owner) -> void
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.MainThreadAwaitable
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.MainThreadAwaitable.GetAwaiter() -> Microsoft.VisualStudio.Threading.JoinableTaskFactory.MainThreadAwaiter
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.MainThreadAwaiter
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.MainThreadAwaiter.GetResult() -> void
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.MainThreadAwaiter.IsCompleted.get -> bool
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.MainThreadAwaiter.OnCompleted(System.Action! continuation) -> void
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.MainThreadAwaiter.UnsafeOnCompleted(System.Action! continuation) -> void
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.Run(System.Func<System.Threading.Tasks.Task!>! asyncMethod) -> void
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.Run(System.Func<System.Threading.Tasks.Task!>! asyncMethod, Microsoft.VisualStudio.Threading.JoinableTaskCreationOptions creationOptions) -> void
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.Run<T>(System.Func<System.Threading.Tasks.Task<T>!>! asyncMethod) -> T
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.Run<T>(System.Func<System.Threading.Tasks.Task<T>!>! asyncMethod, Microsoft.VisualStudio.Threading.JoinableTaskCreationOptions creationOptions) -> T
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.RunAsync(System.Func<System.Threading.Tasks.Task!>! asyncMethod) -> Microsoft.VisualStudio.Threading.JoinableTask!
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.RunAsync(System.Func<System.Threading.Tasks.Task!>! asyncMethod, Microsoft.VisualStudio.Threading.JoinableTaskCreationOptions creationOptions) -> Microsoft.VisualStudio.Threading.JoinableTask!
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.RunAsync<T>(System.Func<System.Threading.Tasks.Task<T>!>! asyncMethod) -> Microsoft.VisualStudio.Threading.JoinableTask<T>!
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.RunAsync<T>(System.Func<System.Threading.Tasks.Task<T>!>! asyncMethod, Microsoft.VisualStudio.Threading.JoinableTaskCreationOptions creationOptions) -> Microsoft.VisualStudio.Threading.JoinableTask<T>!
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.SwitchToMainThreadAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.VisualStudio.Threading.JoinableTaskFactory.MainThreadAwaitable
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.SwitchToMainThreadAsync(bool alwaysYield, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.VisualStudio.Threading.JoinableTaskFactory.MainThreadAwaitable
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.UnderlyingSynchronizationContext.get -> System.Threading.SynchronizationContext?
+Microsoft.VisualStudio.Threading.NoMessagePumpSyncContext
+Microsoft.VisualStudio.Threading.NoMessagePumpSyncContext.NoMessagePumpSyncContext() -> void
+Microsoft.VisualStudio.Threading.ProgressWithCompletion<T>
+Microsoft.VisualStudio.Threading.ProgressWithCompletion<T>.ProgressWithCompletion(System.Action<T>! handler) -> void
+Microsoft.VisualStudio.Threading.ProgressWithCompletion<T>.ProgressWithCompletion(System.Action<T>! handler, Microsoft.VisualStudio.Threading.JoinableTaskFactory? joinableTaskFactory) -> void
+Microsoft.VisualStudio.Threading.ProgressWithCompletion<T>.ProgressWithCompletion(System.Func<T, System.Threading.Tasks.Task!>! handler) -> void
+Microsoft.VisualStudio.Threading.ProgressWithCompletion<T>.ProgressWithCompletion(System.Func<T, System.Threading.Tasks.Task!>! handler, Microsoft.VisualStudio.Threading.JoinableTaskFactory? joinableTaskFactory) -> void
+Microsoft.VisualStudio.Threading.ProgressWithCompletion<T>.WaitAsync() -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Threading.ProgressWithCompletion<T>.WaitAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Threading.ReentrantSemaphore
+Microsoft.VisualStudio.Threading.ReentrantSemaphore.CurrentCount.get -> int
+Microsoft.VisualStudio.Threading.ReentrantSemaphore.Dispose() -> void
+Microsoft.VisualStudio.Threading.ReentrantSemaphore.ReentrancyMode
+Microsoft.VisualStudio.Threading.ReentrantSemaphore.ReentrancyMode.Freeform = 3 -> Microsoft.VisualStudio.Threading.ReentrantSemaphore.ReentrancyMode
+Microsoft.VisualStudio.Threading.ReentrantSemaphore.ReentrancyMode.NotAllowed = 0 -> Microsoft.VisualStudio.Threading.ReentrantSemaphore.ReentrancyMode
+Microsoft.VisualStudio.Threading.ReentrantSemaphore.ReentrancyMode.NotRecognized = 1 -> Microsoft.VisualStudio.Threading.ReentrantSemaphore.ReentrancyMode
+Microsoft.VisualStudio.Threading.ReentrantSemaphore.ReentrancyMode.Stack = 2 -> Microsoft.VisualStudio.Threading.ReentrantSemaphore.ReentrancyMode
+Microsoft.VisualStudio.Threading.ReentrantSemaphore.RevertRelevance
+Microsoft.VisualStudio.Threading.ReentrantSemaphore.RevertRelevance.Dispose() -> void
+Microsoft.VisualStudio.Threading.RegistryChangeNotificationFilters
+Microsoft.VisualStudio.Threading.RegistryChangeNotificationFilters.Attributes = 2 -> Microsoft.VisualStudio.Threading.RegistryChangeNotificationFilters
+Microsoft.VisualStudio.Threading.RegistryChangeNotificationFilters.Security = 8 -> Microsoft.VisualStudio.Threading.RegistryChangeNotificationFilters
+Microsoft.VisualStudio.Threading.RegistryChangeNotificationFilters.Subkey = 1 -> Microsoft.VisualStudio.Threading.RegistryChangeNotificationFilters
+Microsoft.VisualStudio.Threading.RegistryChangeNotificationFilters.Value = 4 -> Microsoft.VisualStudio.Threading.RegistryChangeNotificationFilters
+Microsoft.VisualStudio.Threading.SingleThreadedSynchronizationContext
+Microsoft.VisualStudio.Threading.SingleThreadedSynchronizationContext.Frame
+Microsoft.VisualStudio.Threading.SingleThreadedSynchronizationContext.Frame.Continue.get -> bool
+Microsoft.VisualStudio.Threading.SingleThreadedSynchronizationContext.Frame.Continue.set -> void
+Microsoft.VisualStudio.Threading.SingleThreadedSynchronizationContext.Frame.Frame() -> void
+Microsoft.VisualStudio.Threading.SingleThreadedSynchronizationContext.PushFrame(Microsoft.VisualStudio.Threading.SingleThreadedSynchronizationContext.Frame! frame) -> void
+Microsoft.VisualStudio.Threading.SingleThreadedSynchronizationContext.SingleThreadedSynchronizationContext() -> void
+Microsoft.VisualStudio.Threading.SpecializedSyncContext
+Microsoft.VisualStudio.Threading.SpecializedSyncContext.Dispose() -> void
+Microsoft.VisualStudio.Threading.ThreadingTools
+Microsoft.VisualStudio.Threading.TplExtensions
+Microsoft.VisualStudio.Threading.TplExtensions.NoThrowTaskAwaitable
+Microsoft.VisualStudio.Threading.TplExtensions.NoThrowTaskAwaitable.GetAwaiter() -> Microsoft.VisualStudio.Threading.TplExtensions.NoThrowTaskAwaiter
+Microsoft.VisualStudio.Threading.TplExtensions.NoThrowTaskAwaitable.NoThrowTaskAwaitable(System.Threading.Tasks.Task! task, bool captureContext) -> void
+Microsoft.VisualStudio.Threading.TplExtensions.NoThrowTaskAwaiter
+Microsoft.VisualStudio.Threading.TplExtensions.NoThrowTaskAwaiter.GetResult() -> void
+Microsoft.VisualStudio.Threading.TplExtensions.NoThrowTaskAwaiter.IsCompleted.get -> bool
+Microsoft.VisualStudio.Threading.TplExtensions.NoThrowTaskAwaiter.NoThrowTaskAwaiter(System.Threading.Tasks.Task! task, bool captureContext) -> void
+Microsoft.VisualStudio.Threading.TplExtensions.NoThrowTaskAwaiter.OnCompleted(System.Action! continuation) -> void
+Microsoft.VisualStudio.Threading.TplExtensions.NoThrowTaskAwaiter.UnsafeOnCompleted(System.Action! continuation) -> void
+abstract Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.GetResourceAsync(TMoniker resourceMoniker, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TResource!>!
+abstract Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.PrepareResourceForConcurrentAccessAsync(TResource! resource, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+abstract Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.PrepareResourceForExclusiveAccessAsync(TResource! resource, Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.LockFlags lockFlags, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+abstract Microsoft.VisualStudio.Threading.ReentrantSemaphore.ExecuteAsync(System.Func<System.Threading.Tasks.Task!>! operation, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+abstract Microsoft.VisualStudio.Threading.ReentrantSemaphore.ExecuteAsync<T>(System.Func<System.Threading.Tasks.ValueTask<T>>! operation, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<T>
+override Microsoft.VisualStudio.Threading.AsyncLazy<T>.ToString() -> string!
+override Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.OnExclusiveLockReleasedAsync() -> System.Threading.Tasks.Task!
+override Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.OnUpgradeableReadLockReleased() -> void
+override Microsoft.VisualStudio.Threading.CancellationTokenExtensions.CombinedCancellationToken.Equals(object? obj) -> bool
+override Microsoft.VisualStudio.Threading.CancellationTokenExtensions.CombinedCancellationToken.GetHashCode() -> int
+override Microsoft.VisualStudio.Threading.DelegatingJoinableTaskFactory.OnTransitionedToMainThread(Microsoft.VisualStudio.Threading.JoinableTask! joinableTask, bool canceled) -> void
+override Microsoft.VisualStudio.Threading.DelegatingJoinableTaskFactory.OnTransitioningToMainThread(Microsoft.VisualStudio.Threading.JoinableTask! joinableTask) -> void
+override Microsoft.VisualStudio.Threading.DelegatingJoinableTaskFactory.PostToUnderlyingSynchronizationContext(System.Threading.SendOrPostCallback! callback, object! state) -> void
+override Microsoft.VisualStudio.Threading.DelegatingJoinableTaskFactory.WaitSynchronously(System.Threading.Tasks.Task! task) -> void
+override Microsoft.VisualStudio.Threading.NoMessagePumpSyncContext.Wait(System.IntPtr[]! waitHandles, bool waitAll, int millisecondsTimeout) -> int
+override Microsoft.VisualStudio.Threading.SingleThreadedSynchronizationContext.CreateCopy() -> System.Threading.SynchronizationContext!
+override Microsoft.VisualStudio.Threading.SingleThreadedSynchronizationContext.Post(System.Threading.SendOrPostCallback! d, object? state) -> void
+override Microsoft.VisualStudio.Threading.SingleThreadedSynchronizationContext.Send(System.Threading.SendOrPostCallback! d, object? state) -> void
+static Microsoft.VisualStudio.Threading.AwaitExtensions.ConfigureAwait(this System.Runtime.CompilerServices.YieldAwaitable yieldAwaitable, bool continueOnCapturedContext) -> Microsoft.VisualStudio.Threading.AwaitExtensions.ConfiguredTaskYieldAwaitable
+static Microsoft.VisualStudio.Threading.AwaitExtensions.ConfigureAwaitRunInline(this System.Threading.Tasks.Task! antecedent) -> Microsoft.VisualStudio.Threading.AwaitExtensions.ExecuteContinuationSynchronouslyAwaitable
+static Microsoft.VisualStudio.Threading.AwaitExtensions.ConfigureAwaitRunInline<T>(this System.Threading.Tasks.Task<T>! antecedent) -> Microsoft.VisualStudio.Threading.AwaitExtensions.ExecuteContinuationSynchronouslyAwaitable<T>
+static Microsoft.VisualStudio.Threading.AwaitExtensions.GetAwaiter(this System.Threading.Tasks.TaskScheduler! scheduler) -> Microsoft.VisualStudio.Threading.AwaitExtensions.TaskSchedulerAwaiter
+static Microsoft.VisualStudio.Threading.AwaitExtensions.GetAwaiter(this System.Threading.WaitHandle! handle) -> System.Runtime.CompilerServices.TaskAwaiter
+static Microsoft.VisualStudio.Threading.AwaitExtensions.SwitchTo(this System.Threading.Tasks.TaskScheduler! scheduler, bool alwaysYield = false) -> Microsoft.VisualStudio.Threading.AwaitExtensions.TaskSchedulerAwaitable
+static Microsoft.VisualStudio.Threading.AwaitExtensions.WaitForChangeAsync(this Microsoft.Win32.RegistryKey! registryKey, bool watchSubtree = true, Microsoft.VisualStudio.Threading.RegistryChangeNotificationFilters change = Microsoft.VisualStudio.Threading.RegistryChangeNotificationFilters.Subkey | Microsoft.VisualStudio.Threading.RegistryChangeNotificationFilters.Value, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+static Microsoft.VisualStudio.Threading.AwaitExtensions.WaitForExitAsync(this System.Diagnostics.Process! process, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>!
+static Microsoft.VisualStudio.Threading.CancellationTokenExtensions.CombineWith(this System.Threading.CancellationToken original, System.Threading.CancellationToken other) -> Microsoft.VisualStudio.Threading.CancellationTokenExtensions.CombinedCancellationToken
+static Microsoft.VisualStudio.Threading.CancellationTokenExtensions.CombineWith(this System.Threading.CancellationToken original, params System.Threading.CancellationToken[]! others) -> Microsoft.VisualStudio.Threading.CancellationTokenExtensions.CombinedCancellationToken
+static Microsoft.VisualStudio.Threading.CancellationTokenExtensions.CombinedCancellationToken.operator !=(Microsoft.VisualStudio.Threading.CancellationTokenExtensions.CombinedCancellationToken left, Microsoft.VisualStudio.Threading.CancellationTokenExtensions.CombinedCancellationToken right) -> bool
+static Microsoft.VisualStudio.Threading.CancellationTokenExtensions.CombinedCancellationToken.operator ==(Microsoft.VisualStudio.Threading.CancellationTokenExtensions.CombinedCancellationToken left, Microsoft.VisualStudio.Threading.CancellationTokenExtensions.CombinedCancellationToken right) -> bool
+static Microsoft.VisualStudio.Threading.NoMessagePumpSyncContext.Default.get -> System.Threading.SynchronizationContext!
+static Microsoft.VisualStudio.Threading.ReentrantSemaphore.Create(int initialCount = 1, Microsoft.VisualStudio.Threading.JoinableTaskContext? joinableTaskContext = null, Microsoft.VisualStudio.Threading.ReentrantSemaphore.ReentrancyMode mode = Microsoft.VisualStudio.Threading.ReentrantSemaphore.ReentrancyMode.NotAllowed) -> Microsoft.VisualStudio.Threading.ReentrantSemaphore!
+static Microsoft.VisualStudio.Threading.SpecializedSyncContext.Apply(System.Threading.SynchronizationContext? syncContext, bool checkForChangesOnRevert = true) -> Microsoft.VisualStudio.Threading.SpecializedSyncContext
+static Microsoft.VisualStudio.Threading.ThreadingTools.Apply(this System.Threading.SynchronizationContext? syncContext, bool checkForChangesOnRevert = true) -> Microsoft.VisualStudio.Threading.SpecializedSyncContext
+static Microsoft.VisualStudio.Threading.ThreadingTools.ApplyChangeOptimistically<T, TArg>(ref T hotLocation, TArg applyChangeArgument, System.Func<T, TArg, T>! applyChange) -> bool
+static Microsoft.VisualStudio.Threading.ThreadingTools.ApplyChangeOptimistically<T>(ref T hotLocation, System.Func<T, T>! applyChange) -> bool
+static Microsoft.VisualStudio.Threading.ThreadingTools.WithCancellation(this System.Threading.Tasks.Task! task, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+static Microsoft.VisualStudio.Threading.ThreadingTools.WithCancellation<T>(this System.Threading.Tasks.Task<T>! task, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T>!
+static Microsoft.VisualStudio.Threading.TplExtensions.AppendAction(this System.Threading.Tasks.Task! task, System.Action! action, System.Threading.Tasks.TaskContinuationOptions options = System.Threading.Tasks.TaskContinuationOptions.None, System.Threading.CancellationToken cancellation = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+static Microsoft.VisualStudio.Threading.TplExtensions.ApplyResultTo<T>(this System.Threading.Tasks.Task! task, System.Threading.Tasks.TaskCompletionSource<T>! tcs) -> void
+static Microsoft.VisualStudio.Threading.TplExtensions.ApplyResultTo<T>(this System.Threading.Tasks.Task<T>! task, System.Threading.Tasks.TaskCompletionSource<T>! tcs) -> void
+static Microsoft.VisualStudio.Threading.TplExtensions.AttachToParent(this System.Threading.Tasks.Task! task) -> System.Threading.Tasks.Task!
+static Microsoft.VisualStudio.Threading.TplExtensions.AttachToParent<T>(this System.Threading.Tasks.Task<T>! task) -> System.Threading.Tasks.Task<T>!
+static Microsoft.VisualStudio.Threading.TplExtensions.FollowCancelableTaskToCompletion<T>(System.Func<System.Threading.Tasks.Task<T>!>! taskToFollow, System.Threading.CancellationToken ultimateCancellation, System.Threading.Tasks.TaskCompletionSource<T>? taskThatFollows = null) -> System.Threading.Tasks.Task<T>!
+static Microsoft.VisualStudio.Threading.TplExtensions.Forget(this System.Threading.Tasks.Task? task) -> void
+static Microsoft.VisualStudio.Threading.TplExtensions.InvokeAsync(this Microsoft.VisualStudio.Threading.AsyncEventHandler? handlers, object? sender, System.EventArgs! args) -> System.Threading.Tasks.Task!
+static Microsoft.VisualStudio.Threading.TplExtensions.InvokeAsync<TEventArgs>(this Microsoft.VisualStudio.Threading.AsyncEventHandler<TEventArgs>? handlers, object? sender, TEventArgs args) -> System.Threading.Tasks.Task!
+static Microsoft.VisualStudio.Threading.TplExtensions.NoThrowAwaitable(this System.Threading.Tasks.Task! task, bool captureContext = true) -> Microsoft.VisualStudio.Threading.TplExtensions.NoThrowTaskAwaitable
+static Microsoft.VisualStudio.Threading.TplExtensions.ToApm(this System.Threading.Tasks.Task! task, System.AsyncCallback? callback, object? state) -> System.Threading.Tasks.Task!
+static Microsoft.VisualStudio.Threading.TplExtensions.ToApm<TResult>(this System.Threading.Tasks.Task<TResult>! task, System.AsyncCallback? callback, object? state) -> System.Threading.Tasks.Task<TResult>!
+static Microsoft.VisualStudio.Threading.TplExtensions.ToTask(this System.Threading.WaitHandle! handle, int timeout = -1, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>!
+static Microsoft.VisualStudio.Threading.TplExtensions.WaitWithoutInlining(this System.Threading.Tasks.Task! task) -> void
+static Microsoft.VisualStudio.Threading.TplExtensions.WithTimeout(this System.Threading.Tasks.Task! task, System.TimeSpan timeout) -> System.Threading.Tasks.Task!
+static Microsoft.VisualStudio.Threading.TplExtensions.WithTimeout<T>(this System.Threading.Tasks.Task<T>! task, System.TimeSpan timeout) -> System.Threading.Tasks.Task<T>!
+static readonly Microsoft.VisualStudio.Threading.TplExtensions.CanceledTask -> System.Threading.Tasks.Task!
+static readonly Microsoft.VisualStudio.Threading.TplExtensions.CompletedTask -> System.Threading.Tasks.Task!
+static readonly Microsoft.VisualStudio.Threading.TplExtensions.FalseTask -> System.Threading.Tasks.Task<bool>!
+static readonly Microsoft.VisualStudio.Threading.TplExtensions.TrueTask -> System.Threading.Tasks.Task<bool>!
+virtual Microsoft.VisualStudio.Threading.AsyncQueue<T>.InitialCapacity.get -> int
+virtual Microsoft.VisualStudio.Threading.AsyncQueue<T>.OnCompleted() -> void
+virtual Microsoft.VisualStudio.Threading.AsyncQueue<T>.OnDequeued(T value) -> void
+virtual Microsoft.VisualStudio.Threading.AsyncQueue<T>.OnEnqueued(T value, bool alreadyDispatched) -> void
+virtual Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.CanCurrentThreadHoldActiveLock.get -> bool
+virtual Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Dispose(bool disposing) -> void
+virtual Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.GetHangReport() -> Microsoft.VisualStudio.Threading.HangReportContribution!
+virtual Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.GetTaskSchedulerForReadLockRequest() -> System.Threading.Tasks.TaskScheduler!
+virtual Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.IsUnsupportedSynchronizationContext.get -> bool
+virtual Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.NoMessagePumpSynchronizationContext.get -> System.Threading.SynchronizationContext!
+virtual Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.OnBeforeExclusiveLockReleasedAsync() -> System.Threading.Tasks.Task!
+virtual Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.OnBeforeLockReleasedAsync(bool exclusiveLockRelease, Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.LockHandle releasingLock) -> System.Threading.Tasks.Task!
+virtual Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.OnCriticalFailure(System.Exception! ex) -> System.Exception!
+virtual Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.OnExclusiveLockReleasedAsync() -> System.Threading.Tasks.Task!
+virtual Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.OnUpgradeableReadLockReleased() -> void
+virtual Microsoft.VisualStudio.Threading.AsyncSemaphore.Dispose(bool disposing) -> void
+virtual Microsoft.VisualStudio.Threading.JoinableTaskContext.CreateDefaultFactory() -> Microsoft.VisualStudio.Threading.JoinableTaskFactory!
+virtual Microsoft.VisualStudio.Threading.JoinableTaskContext.CreateFactory(Microsoft.VisualStudio.Threading.JoinableTaskCollection! collection) -> Microsoft.VisualStudio.Threading.JoinableTaskFactory!
+virtual Microsoft.VisualStudio.Threading.JoinableTaskContext.Dispose(bool disposing) -> void
+virtual Microsoft.VisualStudio.Threading.JoinableTaskContext.GetHangReport() -> Microsoft.VisualStudio.Threading.HangReportContribution!
+virtual Microsoft.VisualStudio.Threading.JoinableTaskContext.NoMessagePumpSynchronizationContext.get -> System.Threading.SynchronizationContext!
+virtual Microsoft.VisualStudio.Threading.JoinableTaskContext.OnFalseHangDetected(System.TimeSpan hangDuration, System.Guid hangId) -> void
+virtual Microsoft.VisualStudio.Threading.JoinableTaskContext.OnHangDetected(System.TimeSpan hangDuration, int notificationCount, System.Guid hangId) -> void
+virtual Microsoft.VisualStudio.Threading.JoinableTaskContextNode.CreateDefaultFactory() -> Microsoft.VisualStudio.Threading.JoinableTaskFactory!
+virtual Microsoft.VisualStudio.Threading.JoinableTaskContextNode.CreateFactory(Microsoft.VisualStudio.Threading.JoinableTaskCollection! collection) -> Microsoft.VisualStudio.Threading.JoinableTaskFactory!
+virtual Microsoft.VisualStudio.Threading.JoinableTaskContextNode.OnFalseHangDetected(System.TimeSpan hangDuration, System.Guid hangId) -> void
+virtual Microsoft.VisualStudio.Threading.JoinableTaskContextNode.OnHangDetected(Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails! details) -> void
+virtual Microsoft.VisualStudio.Threading.JoinableTaskContextNode.OnHangDetected(System.TimeSpan hangDuration, int notificationCount, System.Guid hangId) -> void
+virtual Microsoft.VisualStudio.Threading.JoinableTaskFactory.OnTransitionedToMainThread(Microsoft.VisualStudio.Threading.JoinableTask! joinableTask, bool canceled) -> void
+virtual Microsoft.VisualStudio.Threading.JoinableTaskFactory.OnTransitioningToMainThread(Microsoft.VisualStudio.Threading.JoinableTask! joinableTask) -> void
+virtual Microsoft.VisualStudio.Threading.JoinableTaskFactory.PostToUnderlyingSynchronizationContext(System.Threading.SendOrPostCallback! callback, object! state) -> void
+virtual Microsoft.VisualStudio.Threading.JoinableTaskFactory.WaitSynchronously(System.Threading.Tasks.Task! task) -> void
+virtual Microsoft.VisualStudio.Threading.JoinableTaskFactory.WaitSynchronouslyCore(System.Threading.Tasks.Task! task) -> void
+virtual Microsoft.VisualStudio.Threading.ProgressWithCompletion<T>.Report(T value) -> void
+virtual Microsoft.VisualStudio.Threading.ReentrantSemaphore.SuppressRelevance() -> Microsoft.VisualStudio.Threading.ReentrantSemaphore.RevertRelevance
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.Releaser.DisposeAsync() -> System.Threading.Tasks.ValueTask
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.ResourceReleaser.DisposeAsync() -> System.Threading.Tasks.ValueTask
+Microsoft.VisualStudio.Threading.NonConcurrentSynchronizationContext
+Microsoft.VisualStudio.Threading.NonConcurrentSynchronizationContext.NonConcurrentSynchronizationContext(bool sticky) -> void
+Microsoft.VisualStudio.Threading.NonConcurrentSynchronizationContext.UnhandledException -> System.EventHandler<System.Exception!>?
+override Microsoft.VisualStudio.Threading.NonConcurrentSynchronizationContext.CreateCopy() -> System.Threading.SynchronizationContext!
+override Microsoft.VisualStudio.Threading.NonConcurrentSynchronizationContext.Post(System.Threading.SendOrPostCallback! d, object? state) -> void
+override Microsoft.VisualStudio.Threading.NonConcurrentSynchronizationContext.Send(System.Threading.SendOrPostCallback! d, object? state) -> void
+static Microsoft.VisualStudio.Threading.TplExtensions.Forget(this System.Threading.Tasks.ValueTask task) -> void
+static Microsoft.VisualStudio.Threading.TplExtensions.Forget<T>(this System.Threading.Tasks.ValueTask<T> task) -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.AggregateExceptionAwaitable
+Microsoft.VisualStudio.Threading.AwaitExtensions.AggregateExceptionAwaitable.AggregateExceptionAwaitable(System.Threading.Tasks.Task! task, bool continueOnCapturedContext) -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.AggregateExceptionAwaitable.GetAwaiter() -> Microsoft.VisualStudio.Threading.AwaitExtensions.AggregateExceptionAwaiter
+Microsoft.VisualStudio.Threading.AwaitExtensions.AggregateExceptionAwaiter
+Microsoft.VisualStudio.Threading.AwaitExtensions.AggregateExceptionAwaiter.AggregateExceptionAwaiter(System.Threading.Tasks.Task! task, bool continueOnCapturedContext) -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.AggregateExceptionAwaiter.GetResult() -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.AggregateExceptionAwaiter.IsCompleted.get -> bool
+Microsoft.VisualStudio.Threading.AwaitExtensions.AggregateExceptionAwaiter.OnCompleted(System.Action! continuation) -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.AggregateExceptionAwaiter.UnsafeOnCompleted(System.Action! continuation) -> void
+static Microsoft.VisualStudio.Threading.AwaitExtensions.ConfigureAwaitForAggregateException(this System.Threading.Tasks.Task! task, bool continueOnCapturedContext = true) -> Microsoft.VisualStudio.Threading.AwaitExtensions.AggregateExceptionAwaitable
+Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.AsyncReaderWriterLock(Microsoft.VisualStudio.Threading.JoinableTaskContext? joinableTaskContext, bool captureDiagnostics = false) -> void
+Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.AsyncReaderWriterResourceLock(Microsoft.VisualStudio.Threading.JoinableTaskContext? joinableTaskContext, bool captureDiagnostics) -> void
+Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadMaybeBlocked() -> bool
+virtual Microsoft.VisualStudio.Threading.AsyncReaderWriterLock.DeadlockCheckTimeout.get -> System.TimeSpan

--- a/src/Microsoft.VisualStudio.Threading/net5.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/net5.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,12 @@
+Microsoft.VisualStudio.Threading.AsyncQueue<T>.ToArray() -> T[]!
+Microsoft.VisualStudio.Threading.AwaitExtensions.SynchronizationContextAwaiter
+Microsoft.VisualStudio.Threading.AwaitExtensions.SynchronizationContextAwaiter.GetResult() -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.SynchronizationContextAwaiter.IsCompleted.get -> bool
+Microsoft.VisualStudio.Threading.AwaitExtensions.SynchronizationContextAwaiter.OnCompleted(System.Action! continuation) -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.SynchronizationContextAwaiter.SynchronizationContextAwaiter(System.Threading.SynchronizationContext! syncContext) -> void
+Microsoft.VisualStudio.Threading.AwaitExtensions.SynchronizationContextAwaiter.UnsafeOnCompleted(System.Action! continuation) -> void
+Microsoft.VisualStudio.Threading.SemaphoreFaultedException
+Microsoft.VisualStudio.Threading.SemaphoreFaultedException.SemaphoreFaultedException() -> void
+Microsoft.VisualStudio.Threading.IllegalSemaphoreUsageException
+Microsoft.VisualStudio.Threading.IllegalSemaphoreUsageException.IllegalSemaphoreUsageException(string! message) -> void
+static Microsoft.VisualStudio.Threading.AwaitExtensions.GetAwaiter(this System.Threading.SynchronizationContext! synchronizationContext) -> Microsoft.VisualStudio.Threading.AwaitExtensions.SynchronizationContextAwaiter

--- a/test/Microsoft.VisualStudio.Threading.Tests/DispatcherExtensionsTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/DispatcherExtensionsTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if NETFRAMEWORK
+#if NETFRAMEWORK || WINDOWS
 
 using System;
 using System.Threading;

--- a/test/Microsoft.VisualStudio.Threading.Tests/Microsoft.VisualStudio.Threading.Tests.csproj
+++ b/test/Microsoft.VisualStudio.Threading.Tests/Microsoft.VisualStudio.Threading.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.1;net5.0;net5.0-windows</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsTestProject>true</IsTestProject>
 

--- a/test/Microsoft.VisualStudio.Threading.Tests/Microsoft.VisualStudio.Threading.Tests.csproj
+++ b/test/Microsoft.VisualStudio.Threading.Tests/Microsoft.VisualStudio.Threading.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net5.0;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.1;net5.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsTestProject>true</IsTestProject>
 
@@ -8,6 +8,9 @@
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
 
     <DefineConstants Condition=" '$(TargetFramework)' == 'net472' ">$(DefineConstants);ISOLATED_TEST_SUPPORT</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+    <TargetFrameworks>$(TargetFrameworks);net5.0-windows</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\src\Microsoft.VisualStudio.Threading\InternalUtilities.cs">

--- a/test/Microsoft.VisualStudio.Threading.Tests/SingleThreadedTestSynchronizationContext.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/SingleThreadedTestSynchronizationContext.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if NETFRAMEWORK
+#if NETFRAMEWORK || WINDOWS
 #define UseWpfContext
 #endif
 

--- a/tools/Install-DotNetSdk.ps1
+++ b/tools/Install-DotNetSdk.ps1
@@ -42,12 +42,12 @@ Get-ChildItem "$PSScriptRoot\..\src\*.*proj","$PSScriptRoot\..\test\*.*proj","$P
     $projXml = [xml](Get-Content -Path $_)
     $pg = $projXml.Project.PropertyGroup
     if ($pg) {
-        $targetFrameworks = $pg.TargetFramework
-        if (!$targetFrameworks) {
-            $targetFrameworks = $pg.TargetFrameworks
-            if ($targetFrameworks) {
-                $targetFrameworks = $targetFrameworks -Split ';'
-            }
+        $targetFrameworks = @()
+        $tf = $pg.TargetFramework
+        $targetFrameworks += $tf
+        $tfs = $pg.TargetFrameworks
+        if ($tfs) {
+            $targetFrameworks = $tfs -Split ';'
         }
     }
     $targetFrameworks |? { $_ -match 'net(?:coreapp)?(\d+\.\d+)' } |% {


### PR DESCRIPTION
This allows .NET 5.0 Windows targets to consume an assembly that includes WPF types such as `DispatcherExtensions`.

net5.0 contains all the same public APIs that netcoreapp3.1 does.
net5.0-windows contains all the same public APIs that net472 does.