### PR TITLE
Revert "Prevent creating two task waiting chains when joins AsyncLazy."

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/AsyncLazy`1.cs
+++ b/src/Microsoft.VisualStudio.Threading/AsyncLazy`1.cs
@@ -183,7 +183,12 @@ namespace Microsoft.VisualStudio.Threading
                 resumableAwaiter?.Resume();
             }
 
-            return this.joinableTask?.JoinAsync(cancellationToken) ?? this.value.WithCancellation(cancellationToken);
+            if (!this.value.IsCompleted)
+            {
+                this.joinableTask?.JoinAsync(cancellationToken).Forget();
+            }
+
+            return this.value.WithCancellation(cancellationToken);
         }
 
         /// <summary>


### PR DESCRIPTION
Reverts microsoft/vs-threading#999

I have concern on this PR to have potential impact to the performance of the product.  The reason:

when this code is executed on UI thread context:
await asyncLazy.GetValueAsync().ConfigureAwait(false)

and the inner task of the async lazy completes on a thread pool. Before this code, this continuation doesn't need back to the UI thread, but joinableTask.JoinAsync would need back to the UI thread to complete.  I think it is unnecessary in JoinAsync code, but it will require further changes to get this more complicated.