### PR TITLE
Cache boxed bool values to reduce allocation overhead

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/Boxed.cs
+++ b/src/Microsoft.VisualStudio.Threading/Boxed.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.Threading
+{
+    internal static class Boxed
+    {
+        /// <summary>
+        /// Returns an object containing <see langword="true"/>.
+        /// </summary>
+        public static readonly object True = true;
+
+        /// <summary>
+        /// Returns an object containing <see langword="false"/>.
+        /// </summary>
+        public static readonly object False = false;
+
+        /// <summary>
+        /// Returns an object containing specified value.
+        /// </summary>
+        public static object Box(bool value)
+        {
+            return value ? True : False;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Threading/ThreadingEventSource.cs
+++ b/src/Microsoft.VisualStudio.Threading/ThreadingEventSource.cs
@@ -106,7 +106,7 @@ namespace Microsoft.VisualStudio.Threading
         [Event(CompleteOnCurrentThreadStartEvent)]
         public void CompleteOnCurrentThreadStart(int taskId, bool isOnMainThread)
         {
-            this.WriteEvent(CompleteOnCurrentThreadStartEvent, taskId, isOnMainThread);
+            this.WriteEvent(CompleteOnCurrentThreadStartEvent, taskId, Boxed.Box(isOnMainThread));
         }
 
         /// <summary>
@@ -145,7 +145,7 @@ namespace Microsoft.VisualStudio.Threading
         [Event(PostExecutionStartEvent, Level = EventLevel.Verbose)]
         public void PostExecutionStart(int requestId, bool mainThreadAffinitized)
         {
-            this.WriteEvent(PostExecutionStartEvent, requestId, mainThreadAffinitized);
+            this.WriteEvent(PostExecutionStartEvent, requestId, Boxed.Box(mainThreadAffinitized));
         }
 
         /// <summary>


### PR DESCRIPTION
There are around 1MB of allocations caused by boxing boolean values when opening up Orchard Core which we can avoid by caching the values.