### PR TITLE
Reduce unnecessary disposing JTF dependencies & task continuations

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
@@ -607,9 +607,16 @@ namespace Microsoft.VisualStudio.Threading
 
             static async Task JoinSlowAsync(JoinableTask me, CancellationToken cancellationToken)
             {
-                using (me.AmbientJobJoinsThis())
+                JoinRelease dependency = me.AmbientJobJoinsThis();
+
+                try
                 {
                     await me.Task.WithCancellation(continueOnCapturedContext: AwaitShouldCaptureSyncContext, cancellationToken).ConfigureAwait(AwaitShouldCaptureSyncContext);
+                }
+                catch
+                {
+                    dependency.Dispose();
+                    throw;
                 }
             }
         }

--- a/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
@@ -596,7 +596,7 @@ namespace Microsoft.VisualStudio.Threading
 
             if (!cancellationToken.CanBeCanceled)
             {
-                // if a completed or failed JoinableTask will remove itself from parent dependency chains, so we don't repeat it which requires the sync lock.
+                // A completed or failed JoinableTask will remove itself from parent dependency chains, so we don't repeat it which requires the sync lock.
                 _ = this.AmbientJobJoinsThis();
                 return this.Task;
             }
@@ -607,13 +607,14 @@ namespace Microsoft.VisualStudio.Threading
 
             static async Task JoinSlowAsync(JoinableTask me, CancellationToken cancellationToken)
             {
+                // No need to dispose of this except in cancellation case.
                 JoinRelease dependency = me.AmbientJobJoinsThis();
 
                 try
                 {
                     await me.Task.WithCancellation(continueOnCapturedContext: AwaitShouldCaptureSyncContext, cancellationToken).ConfigureAwait(AwaitShouldCaptureSyncContext);
                 }
-                catch
+                catch (OperationCanceledException)
                 {
                     dependency.Dispose();
                     throw;

--- a/src/Microsoft.VisualStudio.Threading/JoinableTask`1.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTask`1.cs
@@ -72,7 +72,7 @@ namespace Microsoft.VisualStudio.Threading
                     await me.Task.WithCancellation(continueOnCapturedContext: AwaitShouldCaptureSyncContext, cancellationToken).ConfigureAwait(AwaitShouldCaptureSyncContext);
                 }
 
-                return await me.Task.ConfigureAwaitRunInline();
+                return await me.Task.ConfigureAwait(AwaitShouldCaptureSyncContext);
             }
         }
 

--- a/src/Microsoft.VisualStudio.Threading/ThreadingTools.cs
+++ b/src/Microsoft.VisualStudio.Threading/ThreadingTools.cs
@@ -307,7 +307,7 @@ namespace Microsoft.VisualStudio.Threading
             // Rethrow any fault/cancellation exception, even if we awaited above.
             // But if we skipped the above if branch, this will actually yield
             // on an incompleted task.
-            await task.ConfigureAwaitRunInline();
+            await task.ConfigureAwait(continueOnCapturedContext);
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.Threading/ThreadingTools.cs
+++ b/src/Microsoft.VisualStudio.Threading/ThreadingTools.cs
@@ -307,7 +307,7 @@ namespace Microsoft.VisualStudio.Threading
             // Rethrow any fault/cancellation exception, even if we awaited above.
             // But if we skipped the above if branch, this will actually yield
             // on an incompleted task.
-            await task.ConfigureAwait(continueOnCapturedContext);
+            await task.ConfigureAwaitRunInline();
         }
 
         /// <summary>


### PR DESCRIPTION
This PR is to improve performance of JoinAsync when a cancellation token is not being used.

The reason behind this is JoinAsync will only complete when the task being waited is completed. A completed JoinableTask will remove itself from the graph, so we don't need chain the task inside JoinAsync to clean up the new dependency.

It is more efficiently to do that:
 1, removing dependency will need get into the global lock, which is a contention point of the product
 2, removing the completed task will cut all dependencies in one operation, which is much efficient than removing dependencies one by one.

This will allow us not to have any new async state machine in that case, and cut off some unnecessary task continuation in the AsyncLazy, when GetValueAsync is called without a cancellation token.
