### PR TITLE
Improve scalability in the JoinableTask dependency chain

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/JoinableTask+ExecutionQueue.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTask+ExecutionQueue.cs
@@ -69,7 +69,16 @@ namespace Microsoft.VisualStudio.Threading
             {
                 base.OnCompleted();
 
-                this.owningJob.OnQueueCompleted();
+                if ((this.owningJob.state & JoinableTaskFlags.CompleteFinalized) != JoinableTaskFlags.CompleteFinalized)
+                {
+                    using (this.owningJob.JoinableTaskContext.NoMessagePumpSynchronizationContext.Apply())
+                    {
+                        lock (this.owningJob.JoinableTaskContext.SyncContextLock)
+                        {
+                            this.owningJob.OnQueueCompleted();
+                        }
+                    }
+                }
             }
 
             private void Scavenge()

--- a/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
@@ -60,7 +60,7 @@ namespace Microsoft.VisualStudio.Threading
         /// The collections that this job is a member of.
         /// </summary>
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private ListOfOftenOne<IJoinableTaskDependent> dependencyParents;
+        private RarelyRemoveItemSet<IJoinableTaskDependent> dependencyParents;
 
         /// <summary>
         /// The <see cref="System.Threading.Tasks.Task"/> returned by the async delegate that this JoinableTask originally executed,
@@ -479,7 +479,7 @@ namespace Microsoft.VisualStudio.Threading
             get
             {
                 Assumes.True(Monitor.IsEntered(this.JoinableTaskContext.SyncContextLock));
-                return this.dependencyParents.OfType<JoinableTaskCollection>().ToList();
+                return this.dependencyParents.ToArray().OfType<JoinableTaskCollection>();
             }
         }
 
@@ -1022,7 +1022,7 @@ namespace Microsoft.VisualStudio.Threading
                 // notifications come in.
                 this.JoinableTaskContext.OnJoinableTaskCompleted(this);
 
-                foreach (IJoinableTaskDependent? collection in this.dependencyParents)
+                foreach (IJoinableTaskDependent collection in this.dependencyParents.EnumerateAndClear())
                 {
                     JoinableTaskDependencyGraph.RemoveDependency(collection, this, forceCleanup: true);
                 }

--- a/src/Microsoft.VisualStudio.Threading/RarelyRemoveItemSet`1.cs
+++ b/src/Microsoft.VisualStudio.Threading/RarelyRemoveItemSet`1.cs
@@ -138,7 +138,7 @@ namespace Microsoft.VisualStudio.Threading
             return results;
         }
 
-        public struct Enumerator : IEnumerator<T>
+        internal struct Enumerator : IEnumerator<T>
         {
             private const int IndexBeforeFirstArrayElement = -1;
             private const int IndexSingleElement = -2;

--- a/src/Microsoft.VisualStudio.Threading/RarelyRemoveItemSet`1.cs
+++ b/src/Microsoft.VisualStudio.Threading/RarelyRemoveItemSet`1.cs
@@ -1,0 +1,242 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.Threading
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// A collection optimized for usually small number of elements, and items are rarely removed.
+    /// Note: this implementation is not thread-safe. It must be protected to prevent race conditions.
+    /// </summary>
+    /// <typeparam name="T">The type of elements to be stored.</typeparam>
+    internal struct RarelyRemoveItemSet<T>
+        where T : class
+    {
+        private const int MaxExpansionSize = 16 * 1024;
+
+        /// <summary>
+        /// The single value or array of values stored by this collection. Null if empty.
+        /// </summary>
+        private object? value;
+
+        /// <summary>
+        /// The number of items.
+        /// </summary>
+        private int count;
+
+        /// <summary>
+        /// Adds an element to the collection.
+        /// </summary>
+        public void Add(T value)
+        {
+            if (this.value is T[] valueArray)
+            {
+                if (valueArray.Length > this.count)
+                {
+                    valueArray[this.count] = value;
+                }
+                else
+                {
+                    int nextSize = valueArray.Length > MaxExpansionSize ? (valueArray.Length + MaxExpansionSize) : valueArray.Length * 2;
+
+                    Array.Resize(ref valueArray, nextSize);
+                    valueArray[this.count] = value;
+                    this.value = valueArray;
+                }
+            }
+            else
+            {
+                if (this.count == 0)
+                {
+                    this.value = value;
+                }
+                else
+                {
+                    Assumes.Equals(1, this.count);
+                    valueArray = new T[2] { (T)this.value!, value };
+                    this.value = valueArray;
+                }
+            }
+
+            this.count++;
+        }
+
+        /// <summary>
+        /// Removes an element from the collection.
+        /// </summary>
+        public void Remove(T value)
+        {
+            if (this.count == 0)
+            {
+                return;
+            }
+
+            if (this.value is T[] valueArray)
+            {
+                for (int i = 0; i < this.count; i++)
+                {
+                    if (valueArray[i] == value)
+                    {
+                        // found matched item
+                        --this.count;
+
+                        if (i < this.count)
+                        {
+                            valueArray[i] = valueArray[this.count];
+                        }
+
+                        // prevent holding reference
+                        valueArray[this.count] = null!;
+                    }
+                }
+            }
+            else if (this.value == value)
+            {
+                this.value = null;
+                this.count = 0;
+            }
+        }
+
+        /// <summary>
+        /// Gets the result out of the current list, and reset it to empty.
+        /// </summary>
+        public Enumerable EnumerateAndClear()
+        {
+            var copy = new Enumerable(this.value, this.count);
+
+            this.value = null;
+            this.count = 0;
+
+            return copy;
+        }
+
+        /// <summary>
+        /// Make a thread safe copy of the content of this list.
+        /// </summary>
+        public T[] ToArray()
+        {
+            if (this.count == 0)
+            {
+                return Array.Empty<T>();
+            }
+
+            var results = new T[this.count];
+            if (this.value is T[] valueArray)
+            {
+                Array.Copy(valueArray, results, this.count);
+            }
+            else
+            {
+                results[0] = (T)this.value!;
+            }
+
+            return results;
+        }
+
+        public struct Enumerable
+        {
+            private readonly object? value;
+
+            /// <summary>
+            /// The number of items.
+            /// </summary>
+            private readonly int count;
+
+            public Enumerable(object? value, int count)
+            {
+                this.value = value;
+                this.count = count;
+            }
+
+            /// <summary>
+            /// Returns an enumerator for a current snapshot of the collection.
+            /// </summary>
+            public Enumerator GetEnumerator()
+            {
+                return new Enumerator(this.value, this.count);
+            }
+        }
+
+        public struct Enumerator : IEnumerator<T>
+        {
+            private const int IndexBeforeFirstArrayElement = -1;
+            private const int IndexSingleElement = -2;
+            private const int IndexBeforeSingleElement = -3;
+
+            private readonly object? enumeratedValue;
+            private readonly int count;
+
+            private int currentIndex;
+
+            internal Enumerator(object? enumeratedValue, int count)
+            {
+                this.enumeratedValue = enumeratedValue;
+                this.count = count;
+                this.currentIndex = 0;
+                this.Reset();
+            }
+
+            public T Current
+            {
+                get
+                {
+                    if (this.currentIndex == IndexBeforeFirstArrayElement || this.currentIndex == IndexBeforeSingleElement)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    // enumeratedValue cannot be null here following a call to `MoveNext` that returns true (required
+                    // for correct usage of IEnumerator).
+                    return this.currentIndex == IndexSingleElement
+                        ? (T)this.enumeratedValue!
+                        : ((T[])this.enumeratedValue!)[this.currentIndex];
+                }
+            }
+
+            object System.Collections.IEnumerator.Current
+            {
+                get { return this.Current; }
+            }
+
+            public void Dispose()
+            {
+            }
+
+            public bool MoveNext()
+            {
+                if (this.currentIndex == IndexBeforeSingleElement && this.count > 0)
+                {
+                    this.currentIndex = IndexSingleElement;
+                    return true;
+                }
+
+                if (this.currentIndex == IndexSingleElement)
+                {
+                    return false;
+                }
+
+                if (this.currentIndex == IndexBeforeFirstArrayElement)
+                {
+                    this.currentIndex = 0;
+                    return true;
+                }
+
+                var array = (T[]?)this.enumeratedValue;
+                if (this.currentIndex >= 0 && this.currentIndex < this.count)
+                {
+                    this.currentIndex++;
+                    return this.currentIndex < this.count;
+                }
+
+                return false;
+            }
+
+            public void Reset()
+            {
+                this.currentIndex = this.enumeratedValue is T[] ? IndexBeforeFirstArrayElement : IndexBeforeSingleElement;
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Threading/RarelyRemoveItemSet`1.cs
+++ b/src/Microsoft.VisualStudio.Threading/RarelyRemoveItemSet`1.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Threading

--- a/src/Microsoft.VisualStudio.Threading/RarelyRemoveItemSet`1.cs
+++ b/src/Microsoft.VisualStudio.Threading/RarelyRemoveItemSet`1.cs
@@ -118,21 +118,21 @@ namespace Microsoft.VisualStudio.Threading
         /// <summary>
         /// Make a thread safe copy of the content of this list.
         /// </summary>
-        internal T?[] ToArray()
+        internal T[] ToArray()
         {
             if (this.count == 0)
             {
                 return Array.Empty<T>();
             }
 
-            var results = new T?[this.count];
+            var results = new T[this.count];
             if (this.value is T?[] valueArray)
             {
                 Array.Copy(valueArray, results, this.count);
             }
             else
             {
-                results[0] = (T?)this.value;
+                results[0] = (T)this.value!;
             }
 
             return results;

--- a/test/Microsoft.VisualStudio.Threading.Tests/Microsoft.VisualStudio.Threading.Tests.csproj
+++ b/test/Microsoft.VisualStudio.Threading.Tests/Microsoft.VisualStudio.Threading.Tests.csproj
@@ -19,6 +19,9 @@
     <Compile Include="..\..\src\Microsoft.VisualStudio.Threading\ListOfOftenOne`1.cs">
       <Link>ListOfOftenOne`1.cs</Link>
     </Compile>
+    <Compile Include="..\..\src\Microsoft.VisualStudio.Threading\RarelyRemoveItemSet`1.cs">
+      <Link>RarelyRemoveItemSet`1.cs</Link>
+    </Compile>
     <Compile Include="..\..\src\Microsoft.VisualStudio.Threading\RoslynDebug.cs" Link="RoslynDebug.cs" />
     <Compile Include="..\..\src\Microsoft.VisualStudio.Threading\WeakKeyDictionary`2.cs">
       <Link>WeakKeyDictionary`2.cs</Link>

--- a/test/Microsoft.VisualStudio.Threading.Tests/RarelyRemoveItemSetTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/RarelyRemoveItemSetTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using Microsoft.VisualStudio.Threading;
 using Xunit;
@@ -138,17 +139,25 @@ public class RarelyRemoveItemSetTests : TestBase
 
         this.list.Remove(values[2]);
         Assert.Equal(4, this.list.ToArray().Length);
+        AssertContains(0, 1, 3, 4);
 
         this.list.Remove(values[4]);
         Assert.Equal(3, this.list.ToArray().Length);
+        AssertContains(0, 1, 3);
 
         this.list.Remove(values[0]);
         Assert.Equal(2, this.list.ToArray().Length);
+        AssertContains(1, 3);
 
         this.list.Remove(values[3]);
         Assert.Single(this.list.ToArray());
+        AssertContains(1);
 
-        Assert.Equal(1, this.list.ToArray()[0].Data);
+        void AssertContains(params int[] values)
+        {
+            // We specifically do not care about order of elements.
+            Assert.Equal(values.OrderBy(k => k), this.list.ToArray().Select(v => v.Data).OrderBy(k => k));
+        }
     }
 
     /// <summary>

--- a/test/Microsoft.VisualStudio.Threading.Tests/RarelyRemoveItemSetTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/RarelyRemoveItemSetTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Linq;
 using Microsoft.VisualStudio.Threading;
 using Xunit;
 using Xunit.Abstractions;
@@ -123,6 +122,31 @@ public class RarelyRemoveItemSetTests : TestBase
         Assert.Equal(2, this.list.ToArray()[0].Data);
         this.list.Remove(value2);
         Assert.Empty(this.list.ToArray());
+    }
+
+    [Fact]
+    public void RemoveFromMultiple()
+    {
+        var values = new GenericParameterHelper[5];
+        for (int i = 0; i < 5; i++)
+        {
+            values[i] = new GenericParameterHelper(i);
+            this.list.Add(values[i]);
+        }
+
+        this.list.Remove(values[2]);
+        Assert.Equal(4, this.list.ToArray().Length);
+
+        this.list.Remove(values[4]);
+        Assert.Equal(3, this.list.ToArray().Length);
+
+        this.list.Remove(values[0]);
+        Assert.Equal(2, this.list.ToArray().Length);
+
+        this.list.Remove(values[3]);
+        Assert.Single(this.list.ToArray());
+
+        Assert.Equal(1, this.list.ToArray()[0].Data);
     }
 
     [Fact]

--- a/test/Microsoft.VisualStudio.Threading.Tests/RarelyRemoveItemSetTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/RarelyRemoveItemSetTests.cs
@@ -1,0 +1,141 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Linq;
+using Microsoft.VisualStudio.Threading;
+using Xunit;
+using Xunit.Abstractions;
+
+public class RarelyRemoveItemSetTests : TestBase
+{
+    private RarelyRemoveItemSet<GenericParameterHelper> list;
+
+    public RarelyRemoveItemSetTests(ITestOutputHelper logger)
+        : base(logger)
+    {
+        this.list = default(RarelyRemoveItemSet<GenericParameterHelper>);
+    }
+
+    [Fact]
+    public void EnumerationOfEmpty()
+    {
+        using (RarelyRemoveItemSet<GenericParameterHelper>.Enumerator enumerator = this.list.EnumerateAndClear().GetEnumerator())
+        {
+            Assert.False(enumerator.MoveNext());
+            enumerator.Reset();
+            Assert.False(enumerator.MoveNext());
+        }
+    }
+
+    [Fact]
+    public void EnumerationOfOne()
+    {
+        this.list.Add(new GenericParameterHelper(1));
+        using (RarelyRemoveItemSet<GenericParameterHelper>.Enumerator enumerator = this.list.EnumerateAndClear().GetEnumerator())
+        {
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal<int>(1, enumerator.Current.Data);
+            Assert.False(enumerator.MoveNext());
+            enumerator.Reset();
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal<int>(1, enumerator.Current.Data);
+            Assert.False(enumerator.MoveNext());
+        }
+    }
+
+    [Fact]
+    public void EnumerationOfTwo()
+    {
+        this.list.Add(new GenericParameterHelper(1));
+        this.list.Add(new GenericParameterHelper(2));
+        using (RarelyRemoveItemSet<GenericParameterHelper>.Enumerator enumerator = this.list.EnumerateAndClear().GetEnumerator())
+        {
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal<int>(1, enumerator.Current.Data);
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal<int>(2, enumerator.Current.Data);
+            Assert.False(enumerator.MoveNext());
+            enumerator.Reset();
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal<int>(1, enumerator.Current.Data);
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal<int>(2, enumerator.Current.Data);
+            Assert.False(enumerator.MoveNext());
+        }
+    }
+
+    [Fact]
+    public void RemoveFromEmpty()
+    {
+        this.list.Remove(null!);
+        Assert.Empty(this.list.ToArray());
+        this.list.Remove(new GenericParameterHelper(5));
+        Assert.Empty(this.list.ToArray());
+    }
+
+    [Fact]
+    public void RemoveFromOne()
+    {
+        var value = new GenericParameterHelper(1);
+        this.list.Add(value);
+
+        this.list.Remove(null!);
+        Assert.Single(this.list.ToArray());
+        this.list.Remove(new GenericParameterHelper(5));
+        Assert.Single(this.list.ToArray());
+        this.list.Remove(value);
+        Assert.Empty(this.list.ToArray());
+    }
+
+    [Fact]
+    public void RemoveFromTwoLIFO()
+    {
+        var value1 = new GenericParameterHelper(1);
+        var value2 = new GenericParameterHelper(2);
+        this.list.Add(value1);
+        this.list.Add(value2);
+
+        this.list.Remove(null!);
+        Assert.Equal(2, this.list.ToArray().Length);
+        this.list.Remove(new GenericParameterHelper(5));
+        Assert.Equal(2, this.list.ToArray().Length);
+        this.list.Remove(value2);
+        Assert.Single(this.list.ToArray());
+        Assert.Equal(1, this.list.ToArray()[0].Data);
+        this.list.Remove(value1);
+        Assert.Empty(this.list.ToArray());
+    }
+
+    [Fact]
+    public void RemoveFromTwoFIFO()
+    {
+        var value1 = new GenericParameterHelper(1);
+        var value2 = new GenericParameterHelper(2);
+        this.list.Add(value1);
+        this.list.Add(value2);
+
+        this.list.Remove(null!);
+        Assert.Equal(2, this.list.ToArray().Length);
+        this.list.Remove(new GenericParameterHelper(5));
+        Assert.Equal(2, this.list.ToArray().Length);
+        this.list.Remove(value1);
+        Assert.Single(this.list.ToArray());
+        Assert.Equal(2, this.list.ToArray()[0].Data);
+        this.list.Remove(value2);
+        Assert.Empty(this.list.ToArray());
+    }
+
+    [Fact]
+    public void EnumerateAndClear()
+    {
+        this.list.Add(new GenericParameterHelper(1));
+
+        using (RarelyRemoveItemSet<GenericParameterHelper>.Enumerator enumerator = this.list.EnumerateAndClear().GetEnumerator())
+        {
+            Assert.Empty(this.list.ToArray()); // The collection should have been cleared.
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal(1, enumerator.Current.Data);
+            Assert.False(enumerator.MoveNext());
+        }
+    }
+}

--- a/test/Microsoft.VisualStudio.Threading.Tests/RarelyRemoveItemSetTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/RarelyRemoveItemSetTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/test/Microsoft.VisualStudio.Threading.Tests/RarelyRemoveItemSetTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/RarelyRemoveItemSetTests.cs
@@ -151,6 +151,9 @@ public class RarelyRemoveItemSetTests : TestBase
         Assert.Equal(1, this.list.ToArray()[0].Data);
     }
 
+    /// <summary>
+    /// Test to make sure the list does not reference deleted items.
+    /// </summary>
     [Fact]
     public void RemoveFromMultipleGCTest()
     {


### PR DESCRIPTION
It was found during recently memory Watson bug investigation. When product code creates lots of dependent tasks of AsyncLazy, it can lead huge amounts of arrays to be allocated in the memory, although almost of them are released, they lead GC pressure or gets into LOH in this case.

Although this usage case has its own problem, it appears that the original data structure to hold child->parent relationship by using ListOfOftenOne was no longer suitable after many design changes in this area. It creates a new array when each item is added or removed was the primary reason behind this issue.

I replaced this with a new slightly different data structure, which tries to retain some advantage of the original data structure to be memory efficient when it holds a small amount of data (which is the majority of the time). However, the new data structure works more like List<T>, so it retains a buffer larger than number of items it holds.  I didn't switch to List<T>, because the overhead of another layer of objects, and also List has extra data structure to prevent thread-safe/reentry problems. In our usage scenario, we don't need thread-safe as JTF is using it inside a sync lock, and reentry was prevented by not exposing any enumeration directly.

As our analysis and a previous change to JoinAsync, removing item from the list is a rare operation, so i leave it to O(n) (to find the item, then we fill the hole with the last item in the list). But adding item is mostly O(1), and enumeration will be done by resetting the original collection clear. It is used only when JTF is completed.  I added ToArray, which is used by both unit tests and also a diagnostic code in JTF (not in common time).