### PR TITLE
Update VSTHRD100.md

### DIFF
--- a/doc/analyzers/VSTHRD100.md
+++ b/doc/analyzers/VSTHRD100.md
@@ -26,4 +26,15 @@ async Task DoSomethingAsync()
 
 A code fix is offered that automatically changes the return type of the method. 
 
+For event handlers, avoid `async void` by using `RunAsync`:
+```csharp
+obj.Event += (s, e) => joinableTaskFactory.RunAsync(() => OnEventAsync(s, e));
+}
+
+private async Task OnEventAsync(object sender, EventArgs e)
+{
+   // async code here.
+}
+```
+
 Refer to [Async/Await - Best Practices in Asynchronous Programming](https://msdn.microsoft.com/en-us/magazine/jj991977.aspx) for more info.


### PR DESCRIPTION
There have been previous discussions (#447)  about whether `async void` event handlers should raise VSTHRD100 warnings, and the recommended approach in previous issues is to avoid `async void` for event handlers and use `RunAsync` instead.

The documentation for VSTHRD100 doesn't address the event handler edge case, and refers to an article that recommends using `async void` for event handlers. This change addresses it.

This code example has been suggested in this issue by @AArnott :
https://github.com/microsoft/vs-threading/issues/447#issuecomment-481068451