### PR TITLE
Expose a property on whether JoinableTaskContext has any JTF blocking calls on the main thread

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskContext.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskContext.cs
@@ -117,6 +117,11 @@ namespace Microsoft.VisualStudio.Threading
         private readonly int mainThreadManagedThreadId;
 
         /// <summary>
+        /// The count of <see cref="JoinableTaskFactory"/> blocking API calls on the main thread.
+        /// </summary>
+        private int mainThreadJTFBlockingCount;
+
+        /// <summary>
         /// A single joinable task factory that itself cannot be joined.
         /// </summary>
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
@@ -199,6 +204,11 @@ namespace Microsoft.VisualStudio.Threading
         {
             get { return this.AmbientTask is object; }
         }
+
+        /// <summary>
+        /// Gets a value indicating whether the main thread is blocked by any joinable task.
+        /// </summary>
+        public bool IsMainThreadBlockedByAnyone => this.mainThreadJTFBlockingCount > 0;
 
         /// <summary>
         /// Gets the underlying <see cref="SynchronizationContext"/> that controls the main thread in the host.
@@ -469,6 +479,30 @@ namespace Microsoft.VisualStudio.Threading
             }
 
             return new HangNotificationRegistration(node);
+        }
+
+        /// <summary>
+        /// Increment the count of blocking API calls on the main thread.
+        /// </summary>
+        /// <remarks>
+        /// This method should only be called on the main thread.
+        /// </remarks>
+        internal void IncrementMainThreadBlockingCount()
+        {
+            Assumes.True(this.IsOnMainThread);
+            this.mainThreadJTFBlockingCount++;
+        }
+
+        /// <summary>
+        /// Decrement the count of blocking API calls on the main thread.
+        /// </summary>
+        /// <remarks>
+        /// This method should only be called on the main thread.
+        /// </remarks>
+        internal void DecrementMainThreadBlockingCount()
+        {
+            Assumes.True(this.IsOnMainThread);
+            this.mainThreadJTFBlockingCount--;
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskContext.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskContext.cs
@@ -119,7 +119,7 @@ namespace Microsoft.VisualStudio.Threading
         /// <summary>
         /// The count of <see cref="JoinableTaskFactory"/> blocking API calls on the main thread.
         /// </summary>
-        private int mainThreadJTFBlockingCount;
+        private volatile int mainThreadJTFBlockingCount;
 
         /// <summary>
         /// A single joinable task factory that itself cannot be joined.

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
@@ -545,6 +545,12 @@ namespace Microsoft.VisualStudio.Threading
         protected virtual void WaitSynchronouslyCore(Task task)
         {
             Requires.NotNull(task, nameof(task));
+
+            if (this.Context.IsOnMainThread)
+            {
+                this.Context.IncrementMainThreadBlockingCount();
+            }
+
             int hangTimeoutsCount = 0; // useful for debugging dump files to see how many times we looped.
             int hangNotificationCount = 0;
             Guid hangId = Guid.Empty;
@@ -587,6 +593,13 @@ namespace Microsoft.VisualStudio.Threading
                 // Swallow exceptions thrown by Task.Wait().
                 // Our caller just wants to know when the Task completes,
                 // whether successfully or not.
+            }
+            finally
+            {
+                if (this.Context.IsOnMainThread)
+                {
+                    this.Context.DecrementMainThreadBlockingCount();
+                }
             }
         }
 

--- a/src/Microsoft.VisualStudio.Threading/net472/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/net472/PublicAPI.Shipped.txt
@@ -244,6 +244,7 @@ Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.HangDuration.ge
 Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.HangId.get -> System.Guid
 Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.NotificationCount.get -> int
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadBlocked() -> bool
+Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadBlockedByAnyone.get -> bool
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsOnMainThread.get -> bool
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsWithinJoinableTask.get -> bool
 Microsoft.VisualStudio.Threading.JoinableTaskContext.JoinableTaskContext() -> void

--- a/src/Microsoft.VisualStudio.Threading/net5.0-windows/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/net5.0-windows/PublicAPI.Shipped.txt
@@ -244,6 +244,7 @@ Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.HangDuration.ge
 Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.HangId.get -> System.Guid
 Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.NotificationCount.get -> int
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadBlocked() -> bool
+Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadBlockedByAnyone.get -> bool
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsOnMainThread.get -> bool
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsWithinJoinableTask.get -> bool
 Microsoft.VisualStudio.Threading.JoinableTaskContext.JoinableTaskContext() -> void

--- a/src/Microsoft.VisualStudio.Threading/net5.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/net5.0/PublicAPI.Shipped.txt
@@ -243,6 +243,7 @@ Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.HangDuration.ge
 Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.HangId.get -> System.Guid
 Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.NotificationCount.get -> int
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadBlocked() -> bool
+Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadBlockedByAnyone.get -> bool
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsOnMainThread.get -> bool
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsWithinJoinableTask.get -> bool
 Microsoft.VisualStudio.Threading.JoinableTaskContext.JoinableTaskContext() -> void

--- a/src/Microsoft.VisualStudio.Threading/netcoreapp3.1/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/netcoreapp3.1/PublicAPI.Shipped.txt
@@ -243,6 +243,7 @@ Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.HangDuration.ge
 Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.HangId.get -> System.Guid
 Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.NotificationCount.get -> int
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadBlocked() -> bool
+Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadBlockedByAnyone.get -> bool
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsOnMainThread.get -> bool
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsWithinJoinableTask.get -> bool
 Microsoft.VisualStudio.Threading.JoinableTaskContext.JoinableTaskContext() -> void

--- a/src/Microsoft.VisualStudio.Threading/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/netstandard2.0/PublicAPI.Shipped.txt
@@ -243,6 +243,7 @@ Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.HangDuration.ge
 Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.HangId.get -> System.Guid
 Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.NotificationCount.get -> int
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadBlocked() -> bool
+Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadBlockedByAnyone.get -> bool
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsOnMainThread.get -> bool
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsWithinJoinableTask.get -> bool
 Microsoft.VisualStudio.Threading.JoinableTaskContext.JoinableTaskContext() -> void


### PR DESCRIPTION
We already have IsMainThreadBlocked and IsMainThreadMaybeBlocked. Both APIs indicate whether the main thread is blocked by the caller. 

Sometimes we need to know whether the main thread is blocked by anyone using JoinableTaskFactory's several blocked APIs. This change exposes that property.