### PR TITLE
Fix IsMainThreadMaybeBlocked to return false value after the main task completed

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskContext.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskContext.cs
@@ -359,6 +359,11 @@ namespace Microsoft.VisualStudio.Threading
             JoinableTask? ambientTask = this.AmbientTask;
             if (ambientTask is object)
             {
+                if ((ambientTask.State & JoinableTask.JoinableTaskFlags.CompleteFinalized) == JoinableTask.JoinableTaskFlags.CompleteFinalized)
+                {
+                    return false;
+                }
+
                 if ((ambientTask.State & JoinableTask.JoinableTaskFlags.SynchronouslyBlockingMainThread) == JoinableTask.JoinableTaskFlags.SynchronouslyBlockingMainThread)
                 {
                     return true;


### PR DESCRIPTION
IsMainThreadMaybeBlocked return true after the current main thread blocking JTF is completed.

This is a wrong behavior, and leads the method to return wrong value for spin-off tasks, and makes it less usable to detect performance issues.