### PR TITLE
Dev/jialongcheng/main thread blocked by joinable task

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskContext.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskContext.cs
@@ -117,6 +117,11 @@ namespace Microsoft.VisualStudio.Threading
         private readonly int mainThreadManagedThreadId;
 
         /// <summary>
+        /// The count of <see cref="JoinableTaskFactory"/> blocking API calls on the main thread.
+        /// </summary>
+        private volatile int mainThreadJTFBlockingCount;
+
+        /// <summary>
         /// A single joinable task factory that itself cannot be joined.
         /// </summary>
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
@@ -199,6 +204,11 @@ namespace Microsoft.VisualStudio.Threading
         {
             get { return this.AmbientTask is object; }
         }
+
+        /// <summary>
+        /// Gets a value indicating whether the main thread is blocked by any joinable task.
+        /// </summary>
+        public bool IsMainThreadBlockedByAnyone => this.mainThreadJTFBlockingCount > 0;
 
         /// <summary>
         /// Gets the underlying <see cref="SynchronizationContext"/> that controls the main thread in the host.
@@ -474,6 +484,30 @@ namespace Microsoft.VisualStudio.Threading
             }
 
             return new HangNotificationRegistration(node);
+        }
+
+        /// <summary>
+        /// Increment the count of blocking API calls on the main thread.
+        /// </summary>
+        /// <remarks>
+        /// This method should only be called on the main thread.
+        /// </remarks>
+        internal void IncrementMainThreadBlockingCount()
+        {
+            Assumes.True(this.IsOnMainThread);
+            this.mainThreadJTFBlockingCount++;
+        }
+
+        /// <summary>
+        /// Decrement the count of blocking API calls on the main thread.
+        /// </summary>
+        /// <remarks>
+        /// This method should only be called on the main thread.
+        /// </remarks>
+        internal void DecrementMainThreadBlockingCount()
+        {
+            Assumes.True(this.IsOnMainThread);
+            this.mainThreadJTFBlockingCount--;
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskContext.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskContext.cs
@@ -117,9 +117,9 @@ namespace Microsoft.VisualStudio.Threading
         private readonly int mainThreadManagedThreadId;
 
         /// <summary>
-        /// The count of <see cref="JoinableTaskFactory"/> blocking API calls on the main thread.
+        /// The count of <see cref="JoinableTask"/>s blocking the main thread.
         /// </summary>
-        private volatile int mainThreadJTFBlockingCount;
+        private volatile int mainThreadBlockingJoinableTaskCount;
 
         /// <summary>
         /// A single joinable task factory that itself cannot be joined.
@@ -208,7 +208,7 @@ namespace Microsoft.VisualStudio.Threading
         /// <summary>
         /// Gets a value indicating whether the main thread is blocked by any joinable task.
         /// </summary>
-        public bool IsMainThreadBlockedByAnyone => this.mainThreadJTFBlockingCount > 0;
+        public bool IsMainThreadBlockedByAnyJoinableTask => this.mainThreadBlockingJoinableTaskCount > 0;
 
         /// <summary>
         /// Gets the underlying <see cref="SynchronizationContext"/> that controls the main thread in the host.
@@ -487,7 +487,7 @@ namespace Microsoft.VisualStudio.Threading
         }
 
         /// <summary>
-        /// Increment the count of blocking API calls on the main thread.
+        /// Increment the count of <see cref="JoinableTask"/>s blocking the main thread.
         /// </summary>
         /// <remarks>
         /// This method should only be called on the main thread.
@@ -495,11 +495,11 @@ namespace Microsoft.VisualStudio.Threading
         internal void IncrementMainThreadBlockingCount()
         {
             Assumes.True(this.IsOnMainThread);
-            this.mainThreadJTFBlockingCount++;
+            this.mainThreadBlockingJoinableTaskCount++;
         }
 
         /// <summary>
-        /// Decrement the count of blocking API calls on the main thread.
+        /// Decrement the count of <see cref="JoinableTask"/>s blocking the main thread.
         /// </summary>
         /// <remarks>
         /// This method should only be called on the main thread.
@@ -507,7 +507,7 @@ namespace Microsoft.VisualStudio.Threading
         internal void DecrementMainThreadBlockingCount()
         {
             Assumes.True(this.IsOnMainThread);
-            this.mainThreadJTFBlockingCount--;
+            this.mainThreadBlockingJoinableTaskCount--;
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
@@ -545,6 +545,12 @@ namespace Microsoft.VisualStudio.Threading
         protected virtual void WaitSynchronouslyCore(Task task)
         {
             Requires.NotNull(task, nameof(task));
+
+            if (this.Context.IsOnMainThread)
+            {
+                this.Context.IncrementMainThreadBlockingCount();
+            }
+
             int hangTimeoutsCount = 0; // useful for debugging dump files to see how many times we looped.
             int hangNotificationCount = 0;
             Guid hangId = Guid.Empty;
@@ -587,6 +593,13 @@ namespace Microsoft.VisualStudio.Threading
                 // Swallow exceptions thrown by Task.Wait().
                 // Our caller just wants to know when the Task completes,
                 // whether successfully or not.
+            }
+            finally
+            {
+                if (this.Context.IsOnMainThread)
+                {
+                    this.Context.DecrementMainThreadBlockingCount();
+                }
             }
         }
 

--- a/src/Microsoft.VisualStudio.Threading/net472/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/net472/PublicAPI.Shipped.txt
@@ -244,6 +244,7 @@ Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.HangDuration.ge
 Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.HangId.get -> System.Guid
 Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.NotificationCount.get -> int
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadBlocked() -> bool
+Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadBlockedByAnyone.get -> bool
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsOnMainThread.get -> bool
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsWithinJoinableTask.get -> bool
 Microsoft.VisualStudio.Threading.JoinableTaskContext.JoinableTaskContext() -> void

--- a/src/Microsoft.VisualStudio.Threading/net472/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/net472/PublicAPI.Shipped.txt
@@ -244,7 +244,7 @@ Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.HangDuration.ge
 Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.HangId.get -> System.Guid
 Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.NotificationCount.get -> int
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadBlocked() -> bool
-Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadBlockedByAnyone.get -> bool
+Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadBlockedByAnyJoinableTask.get -> bool
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsOnMainThread.get -> bool
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsWithinJoinableTask.get -> bool
 Microsoft.VisualStudio.Threading.JoinableTaskContext.JoinableTaskContext() -> void

--- a/src/Microsoft.VisualStudio.Threading/net6.0-windows/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/net6.0-windows/PublicAPI.Shipped.txt
@@ -244,6 +244,7 @@ Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.HangDuration.ge
 Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.HangId.get -> System.Guid
 Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.NotificationCount.get -> int
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadBlocked() -> bool
+Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadBlockedByAnyone.get -> bool
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsOnMainThread.get -> bool
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsWithinJoinableTask.get -> bool
 Microsoft.VisualStudio.Threading.JoinableTaskContext.JoinableTaskContext() -> void

--- a/src/Microsoft.VisualStudio.Threading/net6.0-windows/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/net6.0-windows/PublicAPI.Shipped.txt
@@ -244,7 +244,7 @@ Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.HangDuration.ge
 Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.HangId.get -> System.Guid
 Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.NotificationCount.get -> int
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadBlocked() -> bool
-Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadBlockedByAnyone.get -> bool
+Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadBlockedByAnyJoinableTask.get -> bool
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsOnMainThread.get -> bool
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsWithinJoinableTask.get -> bool
 Microsoft.VisualStudio.Threading.JoinableTaskContext.JoinableTaskContext() -> void

--- a/src/Microsoft.VisualStudio.Threading/net6.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/net6.0/PublicAPI.Shipped.txt
@@ -243,7 +243,7 @@ Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.HangDuration.ge
 Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.HangId.get -> System.Guid
 Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.NotificationCount.get -> int
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadBlocked() -> bool
-Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadBlockedByAnyone.get -> bool
+Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadBlockedByAnyJoinableTask.get -> bool
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsOnMainThread.get -> bool
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsWithinJoinableTask.get -> bool
 Microsoft.VisualStudio.Threading.JoinableTaskContext.JoinableTaskContext() -> void

--- a/src/Microsoft.VisualStudio.Threading/net6.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/net6.0/PublicAPI.Shipped.txt
@@ -243,6 +243,7 @@ Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.HangDuration.ge
 Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.HangId.get -> System.Guid
 Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.NotificationCount.get -> int
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadBlocked() -> bool
+Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadBlockedByAnyone.get -> bool
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsOnMainThread.get -> bool
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsWithinJoinableTask.get -> bool
 Microsoft.VisualStudio.Threading.JoinableTaskContext.JoinableTaskContext() -> void

--- a/src/Microsoft.VisualStudio.Threading/netcoreapp3.1/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/netcoreapp3.1/PublicAPI.Shipped.txt
@@ -243,7 +243,7 @@ Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.HangDuration.ge
 Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.HangId.get -> System.Guid
 Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.NotificationCount.get -> int
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadBlocked() -> bool
-Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadBlockedByAnyone.get -> bool
+Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadBlockedByAnyJoinableTask.get -> bool
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsOnMainThread.get -> bool
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsWithinJoinableTask.get -> bool
 Microsoft.VisualStudio.Threading.JoinableTaskContext.JoinableTaskContext() -> void

--- a/src/Microsoft.VisualStudio.Threading/netcoreapp3.1/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/netcoreapp3.1/PublicAPI.Shipped.txt
@@ -243,6 +243,7 @@ Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.HangDuration.ge
 Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.HangId.get -> System.Guid
 Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.NotificationCount.get -> int
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadBlocked() -> bool
+Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadBlockedByAnyone.get -> bool
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsOnMainThread.get -> bool
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsWithinJoinableTask.get -> bool
 Microsoft.VisualStudio.Threading.JoinableTaskContext.JoinableTaskContext() -> void

--- a/src/Microsoft.VisualStudio.Threading/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/netstandard2.0/PublicAPI.Shipped.txt
@@ -243,7 +243,7 @@ Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.HangDuration.ge
 Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.HangId.get -> System.Guid
 Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.NotificationCount.get -> int
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadBlocked() -> bool
-Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadBlockedByAnyone.get -> bool
+Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadBlockedByAnyJoinableTask.get -> bool
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsOnMainThread.get -> bool
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsWithinJoinableTask.get -> bool
 Microsoft.VisualStudio.Threading.JoinableTaskContext.JoinableTaskContext() -> void

--- a/src/Microsoft.VisualStudio.Threading/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/netstandard2.0/PublicAPI.Shipped.txt
@@ -243,6 +243,7 @@ Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.HangDuration.ge
 Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.HangId.get -> System.Guid
 Microsoft.VisualStudio.Threading.JoinableTaskContext.HangDetails.NotificationCount.get -> int
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadBlocked() -> bool
+Microsoft.VisualStudio.Threading.JoinableTaskContext.IsMainThreadBlockedByAnyone.get -> bool
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsOnMainThread.get -> bool
 Microsoft.VisualStudio.Threading.JoinableTaskContext.IsWithinJoinableTask.get -> bool
 Microsoft.VisualStudio.Threading.JoinableTaskContext.JoinableTaskContext() -> void

--- a/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskContextTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskContextTests.cs
@@ -46,6 +46,85 @@ public class JoinableTaskContextTests : JoinableTaskTestBase
     }
 
     [Fact]
+    public void IsMainThreadBlockedByAnyone_True()
+    {
+        Assert.False(this.Context.IsMainThreadBlockedByAnyone);
+        AsyncManualResetEvent mainThreadBlockerEvent = new AsyncManualResetEvent(false);
+        AsyncManualResetEvent backgroundThreadMonitorEvent = new AsyncManualResetEvent(false);
+
+        // Start task to monitor IsMainThreadBlockedByAnyone
+        Task monitorTask = Task.Run(async () =>
+        {
+            await mainThreadBlockerEvent.WaitAsync(this.TimeoutToken);
+
+            while (!this.Context.IsMainThreadBlockedByAnyone)
+            {
+                // Give the main thread time to enter a blocking state, if the test hasn't already timed out.
+                await Task.Delay(50, this.TimeoutToken);
+            }
+
+            backgroundThreadMonitorEvent.Set();
+        });
+
+        JoinableTask? joinable = this.Factory.RunAsync(async delegate
+        {
+            Assert.False(this.Context.IsMainThreadBlockedByAnyone);
+            await this.Factory.SwitchToMainThreadAsync(this.TimeoutToken);
+
+            this.Factory.Run(async () =>
+            {
+                await TaskScheduler.Default.SwitchTo(alwaysYield: true);
+                mainThreadBlockerEvent.Set();
+                await backgroundThreadMonitorEvent.WaitAsync(this.TimeoutToken);
+            });
+        });
+
+        joinable.Join();
+        monitorTask.WaitWithoutInlining(throwOriginalException: true);
+
+        Assert.False(this.Context.IsMainThreadBlockedByAnyone);
+    }
+
+    [Fact]
+    public void IsMainThreadBlockedByAnyone_False()
+    {
+        Assert.False(this.Context.IsMainThreadBlockedByAnyone);
+        ManualResetEventSlim backgroundThreadBlockerEvent = new();
+
+        JoinableTask? joinable = this.Factory.RunAsync(async delegate
+        {
+            Assert.False(this.Context.IsMainThreadBlockedByAnyone);
+            await TaskScheduler.Default.SwitchTo(alwaysYield: true);
+
+            this.Factory.Run(async () =>
+            {
+                backgroundThreadBlockerEvent.Set();
+
+                // Set a delay sufficient for the other thread to have noticed if IsMainThreadBlockedByAnyone is true
+                // while we're suspended.
+                await Task.Delay(AsyncDelay);
+            });
+        });
+
+        backgroundThreadBlockerEvent.Wait(UnexpectedTimeout);
+
+        do
+        {
+            // Give the background thread time to enter a blocking state, if the test hasn't already timed out.
+            this.TimeoutToken.ThrowIfCancellationRequested();
+
+            // IsMainThreadBlockedByAnyone should be false when a background thread is blocked.
+            Assert.False(this.Context.IsMainThreadBlockedByAnyone);
+            Thread.Sleep(10);
+        }
+        while (!joinable.IsCompleted);
+
+        joinable.Join();
+
+        Assert.False(this.Context.IsMainThreadBlockedByAnyone);
+    }
+
+    [Fact]
     public void ReportHangOnRun()
     {
         this.Factory.HangDetectionTimeout = TimeSpan.FromMilliseconds(10);
@@ -410,8 +489,8 @@ public class JoinableTaskContextTests : JoinableTaskTestBase
             this.Logger.WriteLine(report.Content);
             var dgml = XDocument.Parse(report.Content);
             IEnumerable<string>? collectionLabels = from node in dgml.Root!.Element(XName.Get("Nodes", DgmlNamespace))!.Elements()
-                                    where node.Attribute(XName.Get("Category"))?.Value == "Collection"
-                                    select node.Attribute(XName.Get("Label"))?.Value;
+                                                    where node.Attribute(XName.Get("Category"))?.Value == "Collection"
+                                                    select node.Attribute(XName.Get("Label"))?.Value;
             Assert.Contains(collectionLabels, label => label == jtcName);
             return Task.CompletedTask;
         });
@@ -433,8 +512,8 @@ public class JoinableTaskContextTests : JoinableTaskTestBase
         this.Logger.WriteLine(report.Content);
         var dgml = XDocument.Parse(report.Content);
         IEnumerable<string>? collectionLabels = from node in dgml.Root!.Element(XName.Get("Nodes", DgmlNamespace))!.Elements()
-                                where node.Attribute(XName.Get("Category"))?.Value == "Task"
-                                select node.Attribute(XName.Get("Label"))?.Value;
+                                                where node.Attribute(XName.Get("Category"))?.Value == "Task"
+                                                select node.Attribute(XName.Get("Label"))?.Value;
         Assert.Contains(collectionLabels, label => label.Contains(nameof(this.GetHangReportProducesDgmlWithMethodNameRequestingMainThread)));
     }
 
@@ -456,8 +535,8 @@ public class JoinableTaskContextTests : JoinableTaskTestBase
             this.Logger.WriteLine(report.Content);
             var dgml = XDocument.Parse(report.Content);
             IEnumerable<string>? collectionLabels = from node in dgml.Root!.Element(XName.Get("Nodes", DgmlNamespace))!.Elements()
-                                    where node.Attribute(XName.Get("Category"))?.Value == "Task"
-                                    select node.Attribute(XName.Get("Label"))?.Value;
+                                                    where node.Attribute(XName.Get("Category"))?.Value == "Task"
+                                                    select node.Attribute(XName.Get("Label"))?.Value;
             Assert.Contains(collectionLabels, label => label.Contains(nameof(this.YieldingMethodAsync)));
         });
     }


### PR DESCRIPTION
We still need a property to check whether the main thread is blocked by any joinableTask inside WaitSynchronouslyCore. This reintroduces previous commit 553c404a46e916c2ca3a4afe69ce2f642c502c77