### PR TITLE
Adding yml file for OptProf profiling workflow

### DIFF
--- a/azure-pipelines/OptProf_part2.yml
+++ b/azure-pipelines/OptProf_part2.yml
@@ -1,5 +1,3 @@
-# OptProf profiling workflow for VS-Threading repository
-
 trigger: none
 
 resources:

--- a/azure-pipelines/vs-threading_OptProf.yml
+++ b/azure-pipelines/vs-threading_OptProf.yml
@@ -1,0 +1,90 @@
+# OptProf profiling workflow for VS-Threading repository
+
+trigger: none
+
+resources:
+  pipelines:
+  - pipeline: VisualStudioBuildUnderTest
+    source: DD-CB-PR
+    trigger:
+      tags:
+      - vs-threading-insertion
+  - pipeline: DartLab
+    source: DartLab
+    branch: main
+  - pipeline: DartLab.OptProf
+    source: DartLab.OptProf
+    branch: main
+  repositories:
+  - repository: DartLabTemplates
+    type: git
+    name: DartLab.Templates
+    ref: refs/heads/main
+  - repository: DartLabOptProfTemplates
+    type: git
+    name: DartLab.OptProf
+    ref: refs/heads/main
+
+parameters:
+
+# The prefix naming of the OptimizationInputs drop
+- name: optimizationDropPrefix
+  type: string
+  default: OptimizationInputs/DevDiv/microsoft/vs-threading
+
+stages:
+- template: \templates\stages\visual-studio\single-runsettings.yml@DartLabOptProfTemplates
+  parameters:
+    ##### Required #####
+    runSettingsURI: $(Pipeline.Workspace)\VisualStudioBuildUnderTest\BuildArtifacts\runsettings\vs-threading.OptProf.runsettings
+    visualStudioBootstrapperURI: https://vsdrop.corp.microsoft.com/file/v1/$(VisualStudio.BuildUnderTest.ProductsDropName);bootstrappers/Enterprise/vs_enterprise.exe
+    ##### Optional #####
+    name: OptProfProfilingWorkflow
+    displayName: OptProf Profiling Workflow
+    optOptimizationInputsDropName: $(OptimizationInputsDropName)
+    previousOptimizationInputsDropName: $(PreviousOptimizationInputsDropName)
+    testLabPoolName: VS-Platform
+    ##### Step Hooks #####
+    preTestMachineConfigurationStepList:
+    - download: VisualStudioBuildUnderTest
+    - task: PowerShell@2
+      name: SetProductsDropName
+      displayName: Set 'VisualStudio.BuildUnderTest.ProductsDropName'
+      inputs:
+        filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-VisualStudioDropName.ps1
+        arguments: -DropNamePrefix 'Products' -VstsDropUrlsJson '$(Pipeline.Workspace)\VisualStudioBuildUnderTest\BuildArtifacts\VstsDropUrls.json' -OutVariableName 'VisualStudio.BuildUnderTest.ProductsDropName'
+    preDeployAndRunTestsStepList:
+    - download: VisualStudioBuildUnderTest
+    prePublishOptimizationInputsDropStepList:
+    # Set parameter for  PreviousOptimizationInputsDropName, MicroBuildCommitID, and OptimizationInputsDropName
+    - powershell: |
+        try {
+          $artifactName = 'InsertionOutputs'
+          $BuildID = $(resources.pipeline.VisualStudioBuildUnderTest.runID)
+          $artifact = Get-BuildArtifact -InstanceURL 'https://dev.azure.com/devdiv' -ProjectName 'DevDiv' -BuildID $BuildID -ArtifactName $artifactName -OAuthAccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force)
+          $containerName = $artifact.Resource.Data -Split '/' | Select-Object -Last 1
+          $fileName = Join-Path $containerName 'Metadata.json'
+          $jsonString = Read-BuildArtifactFile -InstanceURL 'https://dev.azure.com/devdiv' -ProjectName 'DevDiv' -BuildID $BuildID -ArtifactName $artifactName -FileName $fileName -OAuthAccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force)
+          $json = $jsonString | ConvertFrom-Json
+
+          Write-Host "The content of the metadata.json file was $json"
+
+          $dropname = $json.OptimizationData
+          $commitID = $json.CommitID
+          $OptimizationInputsDropName = "${{parameters.optimizationDropPrefix}}/$($commitID)/$(Build.BuildId)/$(System.StageId)/$(System.StageAttempt)"
+
+          Write-Host "PreviousOptimizationInputsDropName: $dropname"
+          Set-AzurePipelinesVariable 'PreviousOptimizationInputsDropName' $dropname
+
+          Write-Host "MicroBuildCommitID: $commitID"
+          Set-AzurePipelinesVariable 'MicroBuildCommitID' $commitID
+
+          Write-Host "OptimizationInputsDropName: $OptimizationInputsDropName"
+          Set-AzurePipelinesVariable 'OptimizationInputsDropName' $OptimizationInputsDropName
+        }
+        catch {
+          Write-Host $_
+          Write-Error "Failed to set OptimizationInputsDropName pipeline variable"
+          throw
+        }
+      displayName: Set MicroBuildCommitID, PreviousOptimizationInputsDropName, and OptimizationInputsDropName


### PR DESCRIPTION
OptProf profiling workflows are moving away from release pipeline over to DartLab (build) pipelines. The yml file added in the pull request setup the vs-threading repo for OptPorf profiling on DartLab.