### PR TITLE
Explicitly include Newtonsoft.Json dependency

### DIFF
--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/Microsoft.VisualStudio.Threading.Analyzers.Tests.csproj
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/Microsoft.VisualStudio.Threading.Analyzers.Tests.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Interop" Version="17.3.32630.470" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="17.2.32531.470" IncludeAssets="runtime" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Framework" Version="17.2.32531.470" IncludeAssets="runtime" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="6.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />

--- a/test/Microsoft.VisualStudio.Threading.Tests/Microsoft.VisualStudio.Threading.Tests.csproj
+++ b/test/Microsoft.VisualStudio.Threading.Tests/Microsoft.VisualStudio.Threading.Tests.csproj
@@ -30,6 +30,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.msbuild" Version="3.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Nullable" Version="1.3.0" PrivateAssets="all" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
     <PackageReference Include="Xunit.Combinatorial" Version="1.4.1" />


### PR DESCRIPTION
Some packages in unit test projects still have references to Newtonsoft.Json 9.0.1 and those packages do not have updated versions yet. This change explicitly includes a reference to Newtonsoft.Json to ensure 13.0.1 version is used for unit test projects.