### PR TITLE
Retarget analyzers to the 3.11.0 version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,8 +4,8 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 
     <MicroBuildVersion>2.0.87</MicroBuildVersion>
-    <CodeAnalysisVersion>2.10.0</CodeAnalysisVersion>
-    <CodeAnalysisVersion Condition="'$(IsTestProject)'=='true'">3.11.0</CodeAnalysisVersion>
+    <CodeAnalysisVersion>3.11.0</CodeAnalysisVersion>
+    <CodeAnalysisVersion Condition="'$(IsTestProject)'=='true'">4.4.0</CodeAnalysisVersion>
     <CodefixTestingVersion>1.1.1</CodefixTestingVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/Microsoft.VisualStudio.Threading.sln
+++ b/Microsoft.VisualStudio.Threading.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28413.118
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.33116.440
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.VisualStudio.Threading.Analyzers", "src\Microsoft.VisualStudio.Threading.Analyzers\Microsoft.VisualStudio.Threading.Analyzers.csproj", "{536F3F9A-B457-43B8-BC93-CE1C16959037}"
 EndProject
@@ -12,6 +12,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 		azure-pipelines\build.yml = azure-pipelines\build.yml
 		Directory.Build.props = Directory.Build.props
+		Directory.Build.targets = Directory.Build.targets
+		Directory.Packages.props = Directory.Packages.props
 		global.json = global.json
 		nuget.config = nuget.config
 		stylecop.json = stylecop.json
@@ -33,6 +35,21 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.VisualStudio.Threading.Analyzers.CSharp", "src\Microsoft.VisualStudio.Threading.Analyzers.CSharp\Microsoft.VisualStudio.Threading.Analyzers.CSharp.csproj", "{D5A0D627-7853-43F5-9AF4-E23D062C6ABA}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.VisualStudio.Threading.Analyzers.VisualBasic", "src\Microsoft.VisualStudio.Threading.Analyzers.VisualBasic\Microsoft.VisualStudio.Threading.Analyzers.VisualBasic.csproj", "{8CDF7526-D625-4E16-A266-BAF654ABE181}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{96134B19-FB32-4FA0-A565-BD4247D1E5B2}"
+	ProjectSection(SolutionItems) = preProject
+		src\.editorconfig = src\.editorconfig
+		src\AssemblyInfo.cs = src\AssemblyInfo.cs
+		src\Directory.Build.props = src\Directory.Build.props
+		src\Directory.Build.targets = src\Directory.Build.targets
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{C1DAF484-769B-4C5E-9DD1-A4CFAA66E938}"
+	ProjectSection(SolutionItems) = preProject
+		test\.editorconfig = test\.editorconfig
+		test\Directory.Build.props = test\Directory.Build.props
+		test\Directory.Build.targets = test\Directory.Build.targets
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -123,6 +140,18 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{536F3F9A-B457-43B8-BC93-CE1C16959037} = {96134B19-FB32-4FA0-A565-BD4247D1E5B2}
+		{620ED702-B6DA-4454-BF3E-5494D3652724} = {C1DAF484-769B-4C5E-9DD1-A4CFAA66E938}
+		{4961AA84-088C-46C0-BAC0-F9E87A9F03A7} = {C1DAF484-769B-4C5E-9DD1-A4CFAA66E938}
+		{D9BB9FB6-3833-44E8-B7A7-DE729FCE214D} = {96134B19-FB32-4FA0-A565-BD4247D1E5B2}
+		{CBEDB102-ABAE-40B1-AF3F-A6226DB6713D} = {C1DAF484-769B-4C5E-9DD1-A4CFAA66E938}
+		{BA4643D8-E6B2-4DED-882F-4827F3AB6AB0} = {C1DAF484-769B-4C5E-9DD1-A4CFAA66E938}
+		{3BDB8F46-A39C-422B-8B0E-89E98B83073F} = {96134B19-FB32-4FA0-A565-BD4247D1E5B2}
+		{7177DEEE-D14D-4A4A-BF6E-8B0CDC26B624} = {96134B19-FB32-4FA0-A565-BD4247D1E5B2}
+		{D5A0D627-7853-43F5-9AF4-E23D062C6ABA} = {96134B19-FB32-4FA0-A565-BD4247D1E5B2}
+		{8CDF7526-D625-4E16-A266-BAF654ABE181} = {96134B19-FB32-4FA0-A565-BD4247D1E5B2}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E2124DFF-970E-4BA1-9E50-3ADB0AABF347}

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/CSharpCommonInterest.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/CSharpCommonInterest.cs
@@ -113,7 +113,7 @@ internal static class CSharpCommonInterest
         }
     }
 
-    private static SyntaxNode? GetEnclosingBlock(SyntaxNode node)
+    private static SyntaxNode? GetEnclosingBlock(SyntaxNode? node)
     {
         while (node is not null)
         {
@@ -186,7 +186,7 @@ internal static class CSharpCommonInterest
 
         // Is this `Task.WhenAll` invocation from the System.Threading.Tasks.Task type?
         ITypeSymbol? classType = context.SemanticModel.GetTypeInfo(memberAccess.Expression).Type;
-        var correctType = classType.Name == Types.Task.TypeName && classType.BelongsToNamespace(Types.Task.Namespace);
+        var correctType = classType?.Name == Types.Task.TypeName && classType.BelongsToNamespace(Types.Task.Namespace);
         if (!correctType)
         {
             return false;

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/CSharpUtils.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/CSharpUtils.cs
@@ -40,7 +40,7 @@ internal sealed class CSharpUtils : LanguageUtils
     /// </summary>
     /// <param name="syntaxNode">The syntax node to begin the search from.</param>
     /// <returns>The containing function, and metadata for it.</returns>
-    internal static ContainingFunctionData GetContainingFunction(CSharpSyntaxNode syntaxNode)
+    internal static ContainingFunctionData GetContainingFunction(CSharpSyntaxNode? syntaxNode)
     {
         while (syntaxNode is object)
         {
@@ -103,7 +103,7 @@ internal sealed class CSharpUtils : LanguageUtils
                 return new ContainingFunctionData(method, method.Modifiers.Any(SyntaxKind.AsyncKeyword), method.ParameterList, method.Body, bodyReplacement);
             }
 
-            syntaxNode = (CSharpSyntaxNode)syntaxNode.Parent;
+            syntaxNode = (CSharpSyntaxNode?)syntaxNode.Parent;
         }
 
         return default(ContainingFunctionData);
@@ -147,7 +147,7 @@ internal sealed class CSharpUtils : LanguageUtils
             if (node is AssignmentExpressionSyntax assignment)
             {
                 ISymbol? assignedSymbol = semanticModel.GetSymbolInfo(assignment.Left, cancellationToken).Symbol;
-                if (variable.Equals(assignedSymbol))
+                if (variable.Equals(assignedSymbol, SymbolEqualityComparer.Default))
                 {
                     return true;
                 }
@@ -207,7 +207,7 @@ internal sealed class CSharpUtils : LanguageUtils
                     foreach (BaseTypeSyntax? baseTypeSyntax in typeDeclarationSyntax.BaseList.Types)
                     {
                         SymbolInfo baseTypeSymbolInfo = semanticModel.GetSymbolInfo(baseTypeSyntax.Type, cancellationToken);
-                        if (Equals(baseTypeSymbolInfo.Symbol, baseType))
+                        if (SymbolEqualityComparer.Default.Equals(baseTypeSymbolInfo.Symbol, baseType))
                         {
                             return baseTypeSyntax.GetLocation();
                         }
@@ -264,7 +264,7 @@ internal sealed class CSharpUtils : LanguageUtils
 
     internal readonly struct ContainingFunctionData
     {
-        internal ContainingFunctionData(CSharpSyntaxNode function, bool isAsync, ParameterListSyntax parameterList, CSharpSyntaxNode blockOrExpression, Func<CSharpSyntaxNode, CSharpSyntaxNode> bodyReplacement)
+        internal ContainingFunctionData(CSharpSyntaxNode function, bool isAsync, ParameterListSyntax? parameterList, CSharpSyntaxNode? blockOrExpression, Func<CSharpSyntaxNode, CSharpSyntaxNode> bodyReplacement)
         {
             this.Function = function;
             this.IsAsync = isAsync;
@@ -277,9 +277,9 @@ internal sealed class CSharpUtils : LanguageUtils
 
         internal bool IsAsync { get; }
 
-        internal ParameterListSyntax ParameterList { get; }
+        internal ParameterListSyntax? ParameterList { get; }
 
-        internal CSharpSyntaxNode BlockOrExpression { get; }
+        internal CSharpSyntaxNode? BlockOrExpression { get; }
 
         internal Func<CSharpSyntaxNode, CSharpSyntaxNode> BodyReplacement { get; }
     }

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/Microsoft.VisualStudio.Threading.Analyzers.CSharp.csproj
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/Microsoft.VisualStudio.Threading.Analyzers.CSharp.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Microsoft.VisualStudio.Threading.Analyzers</RootNamespace>
 
     <IsPackable>false</IsPackable>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD002UseJtfRunAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD002UseJtfRunAnalyzer.cs
@@ -122,9 +122,9 @@ public class VSTHRD002UseJtfRunAnalyzer : DiagnosticAnalyzer
                 if (firstParameter is object)
                 {
                     // Are we accessing a member of the completed task?
-                    ISymbol invokedObjectSymbol = context.SemanticModel.GetSymbolInfo(memberAccessSyntax.Expression, context.CancellationToken).Symbol;
-                    IParameterSymbol completedTask = context.SemanticModel.GetDeclaredSymbol(firstParameter);
-                    if (EqualityComparer<ISymbol>.Default.Equals(invokedObjectSymbol, completedTask))
+                    ISymbol? invokedObjectSymbol = context.SemanticModel.GetSymbolInfo(memberAccessSyntax.Expression, context.CancellationToken).Symbol;
+                    IParameterSymbol? completedTask = context.SemanticModel.GetDeclaredSymbol(firstParameter);
+                    if (EqualityComparer<ISymbol?>.Default.Equals(invokedObjectSymbol, completedTask))
                     {
                         // Skip analysis since Task.Result (et. al) of a completed Task is fair game.
                         return;

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD010MainThreadUsageAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD010MainThreadUsageAnalyzer.cs
@@ -120,13 +120,13 @@ public class VSTHRD010MainThreadUsageAnalyzer : DiagnosticAnalyzer
             var mainThreadAssertingMethods = CommonInterest.ReadMethods(compilationStartContext.Options, CommonInterest.FileNamePatternForMethodsThatAssertMainThread, compilationStartContext.CancellationToken).ToImmutableArray();
             var mainThreadSwitchingMethods = CommonInterest.ReadMethods(compilationStartContext.Options, CommonInterest.FileNamePatternForMethodsThatSwitchToMainThread, compilationStartContext.CancellationToken).ToImmutableArray();
             var membersRequiringMainThread = CommonInterest.ReadTypesAndMembers(compilationStartContext.Options, CommonInterest.FileNamePatternForMembersRequiringMainThread, compilationStartContext.CancellationToken).ToImmutableArray();
-            ImmutableDictionary<string, string>? diagnosticProperties = ImmutableDictionary<string, string>.Empty
+            ImmutableDictionary<string, string?>? diagnosticProperties = ImmutableDictionary<string, string?>.Empty
                 .Add(CommonInterest.FileNamePatternForMethodsThatAssertMainThread.ToString(), string.Join("\n", mainThreadAssertingMethods))
                 .Add(CommonInterest.FileNamePatternForMethodsThatSwitchToMainThread.ToString(), string.Join("\n", mainThreadSwitchingMethods));
 
-            var methodsDeclaringUIThreadRequirement = new HashSet<IMethodSymbol>();
-            var methodsAssertingUIThreadRequirement = new HashSet<IMethodSymbol>();
-            var callerToCalleeMap = new Dictionary<IMethodSymbol, List<CallInfo>>();
+            var methodsDeclaringUIThreadRequirement = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
+            var methodsAssertingUIThreadRequirement = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
+            var callerToCalleeMap = new Dictionary<IMethodSymbol, List<CallInfo>>(SymbolEqualityComparer.Default);
 
             compilationStartContext.RegisterCodeBlockStartAction<SyntaxKind>(codeBlockStartContext =>
             {
@@ -157,10 +157,10 @@ public class VSTHRD010MainThreadUsageAnalyzer : DiagnosticAnalyzer
                 HashSet<IMethodSymbol>? transitiveClosureOfMainThreadRequiringMethods = GetTransitiveClosureOfMainThreadRequiringMethods(methodsAssertingUIThreadRequirement, calleeToCallerMap);
                 foreach (IMethodSymbol? implicitUserMethod in transitiveClosureOfMainThreadRequiringMethods.Except(methodsDeclaringUIThreadRequirement))
                 {
-                    var reportSites = from info in callerToCalleeMap[implicitUserMethod]
-                                      where transitiveClosureOfMainThreadRequiringMethods.Contains(info.MethodSymbol)
-                                      group info by info.MethodSymbol into bySymbol
-                                      select new { Location = bySymbol.First().InvocationSyntax.GetLocation(), CalleeMethod = bySymbol.Key };
+                    var reportSites = callerToCalleeMap[implicitUserMethod]
+                        .Where(info => transitiveClosureOfMainThreadRequiringMethods.Contains(info.MethodSymbol))
+                        .GroupBy<CallInfo, ISymbol>(info => info.MethodSymbol, SymbolEqualityComparer.Default)
+                        .Select(bySymbol => new { Location = bySymbol.First().InvocationSyntax.GetLocation(), CalleeMethod = bySymbol.Key });
                     foreach (var site in reportSites)
                     {
                         bool isAsync = Utils.IsAsyncReady(implicitUserMethod);
@@ -181,7 +181,7 @@ public class VSTHRD010MainThreadUsageAnalyzer : DiagnosticAnalyzer
 
     private static HashSet<IMethodSymbol> GetTransitiveClosureOfMainThreadRequiringMethods(HashSet<IMethodSymbol> methodsRequiringUIThread, Dictionary<IMethodSymbol, List<CallInfo>> calleeToCallerMap)
     {
-        var result = new HashSet<IMethodSymbol>();
+        var result = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
 
         void MarkMethod(IMethodSymbol method)
         {
@@ -208,7 +208,7 @@ public class VSTHRD010MainThreadUsageAnalyzer : DiagnosticAnalyzer
 
     private static Dictionary<IMethodSymbol, List<CallInfo>> CreateCalleeToCallerMap(Dictionary<IMethodSymbol, List<CallInfo>> callerToCalleeMap)
     {
-        var result = new Dictionary<IMethodSymbol, List<CallInfo>>();
+        var result = new Dictionary<IMethodSymbol, List<CallInfo>>(SymbolEqualityComparer.Default);
 
         foreach (KeyValuePair<IMethodSymbol, List<CallInfo>> item in callerToCalleeMap)
         {
@@ -307,7 +307,7 @@ public class VSTHRD010MainThreadUsageAnalyzer : DiagnosticAnalyzer
             ImmutableArray<CommonInterest.TypeMatchSpec> membersRequiringMainThread,
             HashSet<IMethodSymbol> methodsDeclaringUIThreadRequirement,
             HashSet<IMethodSymbol> methodsAssertingUIThreadRequirement,
-            ImmutableDictionary<string, string> diagnosticProperties)
+            ImmutableDictionary<string, string?> diagnosticProperties)
         {
             this.MainThreadAssertingMethods = mainThreadAssertingMethods;
             this.MainThreadSwitchingMethods = mainThreadSwitchingMethods;
@@ -327,7 +327,7 @@ public class VSTHRD010MainThreadUsageAnalyzer : DiagnosticAnalyzer
 
         internal HashSet<IMethodSymbol> MethodsAssertingUIThreadRequirement { get; }
 
-        internal ImmutableDictionary<string, string> DiagnosticProperties { get; }
+        internal ImmutableDictionary<string, string?> DiagnosticProperties { get; }
 
         internal void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
         {
@@ -452,10 +452,10 @@ public class VSTHRD010MainThreadUsageAnalyzer : DiagnosticAnalyzer
             }
 
             return typeSymbol.GetAttributes().Any(ad =>
-                (ad.AttributeClass.Name == Types.CoClassAttribute.TypeName && ad.AttributeClass.BelongsToNamespace(Types.CoClassAttribute.Namespace)) ||
-                (ad.AttributeClass.Name == Types.ComImportAttribute.TypeName && ad.AttributeClass.BelongsToNamespace(Types.ComImportAttribute.Namespace)) ||
-                (ad.AttributeClass.Name == Types.InterfaceTypeAttribute.TypeName && ad.AttributeClass.BelongsToNamespace(Types.InterfaceTypeAttribute.Namespace)) ||
-                (ad.AttributeClass.Name == Types.TypeLibTypeAttribute.TypeName && ad.AttributeClass.BelongsToNamespace(Types.TypeLibTypeAttribute.Namespace)));
+                (ad.AttributeClass?.Name == Types.CoClassAttribute.TypeName && ad.AttributeClass.BelongsToNamespace(Types.CoClassAttribute.Namespace)) ||
+                (ad.AttributeClass?.Name == Types.ComImportAttribute.TypeName && ad.AttributeClass.BelongsToNamespace(Types.ComImportAttribute.Namespace)) ||
+                (ad.AttributeClass?.Name == Types.InterfaceTypeAttribute.TypeName && ad.AttributeClass.BelongsToNamespace(Types.InterfaceTypeAttribute.Namespace)) ||
+                (ad.AttributeClass?.Name == Types.TypeLibTypeAttribute.TypeName && ad.AttributeClass.BelongsToNamespace(Types.TypeLibTypeAttribute.Namespace)));
         }
 
         private bool AnalyzeMemberWithinContext(ITypeSymbol type, ISymbol? symbol, SyntaxNodeAnalysisContext context, Location? focusDiagnosticOn = null)

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD103UseAsyncOptionAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD103UseAsyncOptionAnalyzer.cs
@@ -110,7 +110,7 @@ public class VSTHRD103UseAsyncOptionAnalyzer : DiagnosticAnalyzer
                         asyncMethodName,
                         includeReducedExtensionMethods: true);
 
-                    MethodDeclarationSyntax invocationDeclaringMethod = invocationExpressionSyntax.FirstAncestorOrSelf<MethodDeclarationSyntax>();
+                    MethodDeclarationSyntax? invocationDeclaringMethod = invocationExpressionSyntax.FirstAncestorOrSelf<MethodDeclarationSyntax>();
                     ExpressionSyntax invokedMethodName = CSharpUtils.IsolateMethodName(invocationExpressionSyntax);
                     foreach (IMethodSymbol m in symbols.OfType<IMethodSymbol>())
                     {
@@ -120,7 +120,7 @@ public class VSTHRD103UseAsyncOptionAnalyzer : DiagnosticAnalyzer
                             && m.HasAsyncCompatibleReturnType())
                         {
                             // An async alternative exists.
-                            ImmutableDictionary<string, string>? properties = ImmutableDictionary<string, string>.Empty
+                            ImmutableDictionary<string, string?>? properties = ImmutableDictionary<string, string?>.Empty
                                 .Add(AsyncMethodKeyName, asyncMethodName);
 
                             Diagnostic diagnostic = Diagnostic.Create(
@@ -148,7 +148,7 @@ public class VSTHRD103UseAsyncOptionAnalyzer : DiagnosticAnalyzer
         /// </returns>
         private static bool HasSupersetOfParameterTypes(IMethodSymbol candidateMethod, IMethodSymbol baselineMethod)
         {
-            return candidateMethod.Parameters.All(candidateParameter => baselineMethod.Parameters.Any(baselineParameter => baselineParameter.Type?.Equals(candidateParameter.Type) ?? false));
+            return candidateMethod.Parameters.All(candidateParameter => baselineMethod.Parameters.Any(baselineParameter => baselineParameter.Type?.Equals(candidateParameter.Type, SymbolEqualityComparer.Default) ?? false));
         }
 
         private static bool IsInTaskReturningMethodOrDelegate(SyntaxNodeAnalysisContext context)
@@ -189,7 +189,7 @@ public class VSTHRD103UseAsyncOptionAnalyzer : DiagnosticAnalyzer
                     if (item.Method.IsMatch(memberSymbol))
                     {
                         Location? location = memberAccessSyntax.Name.GetLocation();
-                        ImmutableDictionary<string, string>? properties = ImmutableDictionary<string, string>.Empty
+                        ImmutableDictionary<string, string?>? properties = ImmutableDictionary<string, string?>.Empty
                             .Add(ExtensionMethodNamespaceKeyName, item.ExtensionMethodNamespace is object ? string.Join(".", item.ExtensionMethodNamespace) : string.Empty);
                         DiagnosticDescriptor descriptor;
                         var messageArgs = new List<object>(2);

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD107AwaitTaskWithinUsingExpressionAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD107AwaitTaskWithinUsingExpressionAnalyzer.cs
@@ -63,7 +63,7 @@ public class VSTHRD107AwaitTaskWithinUsingExpressionAnalyzer : DiagnosticAnalyze
         if (usingStatement.Expression is object)
         {
             TypeInfo expressionTypeInfo = context.SemanticModel.GetTypeInfo(usingStatement.Expression, context.CancellationToken);
-            ITypeSymbol expressionType = expressionTypeInfo.Type;
+            ITypeSymbol? expressionType = expressionTypeInfo.Type;
             if (expressionType?.Name == nameof(Task) &&
                 expressionType.BelongsToNamespace(Namespaces.SystemThreadingTasks))
             {

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes.csproj
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Microsoft.VisualStudio.Threading.Analyzers</RootNamespace>
 
     <Description>Static code analyzer to detect common mistakes or potential issues regarding threading and async coding.</Description>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/VSTHRD100AsyncVoidMethodCodeFix.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/VSTHRD100AsyncVoidMethodCodeFix.cs
@@ -76,8 +76,8 @@ public class VSTHRD100AsyncVoidMethodCodeFix : CodeFixProvider
 
         protected override async Task<Document> GetChangedDocumentAsync(CancellationToken cancellationToken)
         {
-            SyntaxNode? root = await this.document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-            MethodDeclarationSyntax? methodDeclaration = root.FindNode(this.diagnostic.Location.SourceSpan).FirstAncestorOrSelf<MethodDeclarationSyntax>();
+            SyntaxNode? root = await this.document.GetSyntaxRootOrThrowAsync(cancellationToken).ConfigureAwait(false);
+            MethodDeclarationSyntax methodDeclaration = root.FindNode(this.diagnostic.Location.SourceSpan).FirstAncestorOrSelf<MethodDeclarationSyntax>() ?? throw new InvalidOperationException("Unable to find MethodDeclaration");
             TypeSyntax? taskType = SyntaxFactory.ParseTypeName(typeof(Task).FullName)
                 .WithAdditionalAnnotations(Simplifier.Annotation)
                 .WithTrailingTrivia(methodDeclaration.ReturnType.GetTrailingTrivia());

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/VSTHRD107AwaitTaskWithinUsingExpressionCodeFix.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/VSTHRD107AwaitTaskWithinUsingExpressionCodeFix.cs
@@ -55,8 +55,8 @@ public class VSTHRD107AwaitTaskWithinUsingExpressionCodeFix : CodeFixProvider
                 async ct =>
                 {
                     Document? document = context.Document;
-                    SyntaxNode? root = await document.GetSyntaxRootAsync(ct).ConfigureAwait(false);
-                    MethodDeclarationSyntax? method = root.FindNode(diagnostic.Location.SourceSpan).FirstAncestorOrSelf<MethodDeclarationSyntax>();
+                    SyntaxNode? root = await document.GetSyntaxRootOrThrowAsync(ct).ConfigureAwait(false);
+                    MethodDeclarationSyntax method = root.FindNode(diagnostic.Location.SourceSpan).FirstAncestorOrSelf<MethodDeclarationSyntax>() ?? throw new InvalidOperationException("Unable to find MethodDeclaration.");
 
                     (document, method, _) = await FixUtils.UpdateDocumentAsync(
                         document,
@@ -64,9 +64,9 @@ public class VSTHRD107AwaitTaskWithinUsingExpressionCodeFix : CodeFixProvider
                         m =>
                         {
                             root = m.SyntaxTree.GetRoot(ct);
-                            UsingStatementSyntax usingStatement = root.FindNode(diagnostic.Location.SourceSpan).FirstAncestorOrSelf<UsingStatementSyntax>();
+                            UsingStatementSyntax? usingStatement = root.FindNode(diagnostic.Location.SourceSpan).FirstAncestorOrSelf<UsingStatementSyntax>() ?? throw new InvalidOperationException("Unable to find using statement.");
                             AwaitExpressionSyntax awaitExpression = SyntaxFactory.AwaitExpression(
-                                SyntaxFactory.ParenthesizedExpression(usingStatement.Expression));
+                                SyntaxFactory.ParenthesizedExpression(usingStatement.Expression!));
                             UsingStatementSyntax modifiedUsingStatement = usingStatement.WithExpression(awaitExpression)
                                 .WithAdditionalAnnotations(Simplifier.Annotation);
                             return m.ReplaceNode(usingStatement, modifiedUsingStatement);

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/VSTHRD111UseConfigureAwaitCodeFix.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/VSTHRD111UseConfigureAwaitCodeFix.cs
@@ -36,8 +36,12 @@ public class VSTHRD111UseConfigureAwaitCodeFix : CodeFixProvider
         foreach (Diagnostic? diagnostic in context.Diagnostics)
         {
             SemanticModel? semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
-            SyntaxNode? syntaxRoot = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+            SyntaxNode syntaxRoot = await context.Document.GetSyntaxRootOrThrowAsync(context.CancellationToken).ConfigureAwait(false);
             var awaitedExpression = syntaxRoot.FindNode(diagnostic.Location.SourceSpan) as ExpressionSyntax;
+            if (awaitedExpression is null)
+            {
+                return;
+            }
 
             Task<Document> ApplyFix(bool captureContext)
             {

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/VSTHRD114AvoidReturningNullTaskCodeFix.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/VSTHRD114AvoidReturningNullTaskCodeFix.cs
@@ -29,9 +29,9 @@ public class VSTHRD114AvoidReturningNullTaskCodeFix : CodeFixProvider
         foreach (Diagnostic? diagnostic in context.Diagnostics)
         {
             SemanticModel? semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
-            SyntaxNode? syntaxRoot = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+            SyntaxNode syntaxRoot = await context.Document.GetSyntaxRootOrThrowAsync(context.CancellationToken).ConfigureAwait(false);
             SyntaxNode? nullLiteral = syntaxRoot.FindNode(diagnostic.Location.SourceSpan);
-            if (semanticModel.GetOperation(nullLiteral, context.CancellationToken) is ILiteralOperation { ConstantValue: { HasValue: true, Value: null } })
+            if (semanticModel?.GetOperation(nullLiteral, context.CancellationToken) is ILiteralOperation { ConstantValue: { HasValue: true, Value: null } })
             {
                 TypeInfo typeInfo = semanticModel.GetTypeInfo(nullLiteral, context.CancellationToken);
                 if (typeInfo.ConvertedType is INamedTypeSymbol returnType)
@@ -61,7 +61,7 @@ public class VSTHRD114AvoidReturningNullTaskCodeFix : CodeFixProvider
                     var generator = SyntaxGenerator.GetGenerator(context.Document);
                     SyntaxNode taskFromResultExpression = generator.InvocationExpression(
                         generator.MemberAccessExpression(
-                            generator.TypeExpressionForStaticMemberAccess(returnType.BaseType),
+                            generator.TypeExpressionForStaticMemberAccess(returnType.BaseType!),
                             generator.GenericName(nameof(Task.FromResult), returnType.TypeArguments[0])),
                         generator.NullLiteralExpression());
 

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.VisualBasic/Microsoft.VisualStudio.Threading.Analyzers.VisualBasic.csproj
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.VisualBasic/Microsoft.VisualStudio.Threading.Analyzers.VisualBasic.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Microsoft.VisualStudio.Threading.Analyzers</RootNamespace>
 
     <IsPackable>false</IsPackable>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.VisualBasic/VisualBasicUtils.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.VisualBasic/VisualBasicUtils.cs
@@ -31,7 +31,7 @@ internal sealed class VisualBasicUtils : LanguageUtils
                         foreach (TypeSyntax? typeSyntax in inheritStatement.Types)
                         {
                             SymbolInfo baseTypeSymbolInfo = semanticModel.GetSymbolInfo(typeSyntax, cancellationToken);
-                            if (Equals(baseTypeSymbolInfo.Symbol, baseType))
+                            if (SymbolEqualityComparer.Default.Equals(baseTypeSymbolInfo.Symbol, baseType))
                             {
                                 return typeSyntax.GetLocation();
                             }
@@ -48,7 +48,7 @@ internal sealed class VisualBasicUtils : LanguageUtils
                         foreach (TypeSyntax? typeSyntax in implementStatement.Types)
                         {
                             SymbolInfo baseTypeSymbolInfo = semanticModel.GetSymbolInfo(typeSyntax, cancellationToken);
-                            if (Equals(baseTypeSymbolInfo.Symbol, baseType))
+                            if (SymbolEqualityComparer.Default.Equals(baseTypeSymbolInfo.Symbol, baseType))
                             {
                                 return typeSyntax.GetLocation();
                             }
@@ -65,7 +65,7 @@ internal sealed class VisualBasicUtils : LanguageUtils
                         foreach (TypeSyntax? typeSyntax in implementStatement.Types)
                         {
                             SymbolInfo baseTypeSymbolInfo = semanticModel.GetSymbolInfo(typeSyntax, cancellationToken);
-                            if (Equals(baseTypeSymbolInfo.Symbol, baseType))
+                            if (SymbolEqualityComparer.Default.Equals(baseTypeSymbolInfo.Symbol, baseType))
                             {
                                 return typeSyntax.GetLocation();
                             }

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/AbstractVSTHRD108AssertThreadRequirementUnconditionally.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/AbstractVSTHRD108AssertThreadRequirementUnconditionally.cs
@@ -80,7 +80,7 @@ public abstract class AbstractVSTHRD108AssertThreadRequirementUnconditionally : 
 
     private static IEnumerable<IOperation> GetAncestorsWithinMethod(IOperation operation)
     {
-        for (IOperation current = operation; current is object; current = current.Parent)
+        for (IOperation? current = operation; current is object; current = current.Parent)
         {
             if (current is ILocalFunctionOperation || current is IAnonymousFunctionOperation)
             {
@@ -99,7 +99,7 @@ public abstract class AbstractVSTHRD108AssertThreadRequirementUnconditionally : 
         {
             IMethodSymbol? symbolOfContainingMethodInvocation = containingInvocation.TargetMethod;
             return symbolOfContainingMethodInvocation?.GetAttributes().Any(a =>
-                a.AttributeClass.BelongsToNamespace(Namespaces.SystemDiagnostics) &&
+                a.AttributeClass?.BelongsToNamespace(Namespaces.SystemDiagnostics) is true &&
                 a.AttributeClass.Name == nameof(System.Diagnostics.ConditionalAttribute)) ?? false;
         }
 

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/AbstractVSTHRD112ImplementSystemIAsyncDisposableAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/AbstractVSTHRD112ImplementSystemIAsyncDisposableAnalyzer.cs
@@ -45,7 +45,7 @@ public abstract class AbstractVSTHRD112ImplementSystemIAsyncDisposableAnalyzer :
         });
     }
 
-    private void AnalyzeType(SymbolAnalysisContext context, INamedTypeSymbol vsThreadingAsyncDisposableType, INamedTypeSymbol bclAsyncDisposableType)
+    private void AnalyzeType(SymbolAnalysisContext context, INamedTypeSymbol vsThreadingAsyncDisposableType, INamedTypeSymbol? bclAsyncDisposableType)
     {
         var symbol = (INamedTypeSymbol)context.Symbol;
         if (symbol.Interfaces.Contains(vsThreadingAsyncDisposableType))

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/CommonInterest.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/CommonInterest.cs
@@ -314,7 +314,7 @@ internal static class CommonInterest
 
         public string Name { get; }
 
-        public bool IsMatch(ISymbol symbol)
+        public bool IsMatch(ISymbol? symbol)
         {
             return symbol?.Name == this.Name
                 && this.ContainingType.IsMatch(symbol.ContainingType);

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/DiagnosticAnalyzerState.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/DiagnosticAnalyzerState.cs
@@ -21,7 +21,7 @@ internal abstract class DiagnosticAnalyzerState
 {
     private const string GetAwaiterMethodName = nameof(Task.GetAwaiter);
 
-    private readonly ConcurrentDictionary<ITypeSymbol, bool> customAwaitableTypes = new ConcurrentDictionary<ITypeSymbol, bool>();
+    private readonly ConcurrentDictionary<ITypeSymbol, bool> customAwaitableTypes = new ConcurrentDictionary<ITypeSymbol, bool>(SymbolEqualityComparer.Default);
 
     internal bool IsAwaitableType(ITypeSymbol? typeSymbol, Compilation compilation, CancellationToken cancellationToken)
     {
@@ -46,7 +46,7 @@ internal abstract class DiagnosticAnalyzerState
                 IEnumerable<ITypeSymbol>? awaitableTypesPerAssembly = from assembly in compilation.Assembly.Modules.First().ReferencedAssemblySymbols
                                                 from awaitableType in GetAwaitableTypes(assembly)
                                                 select awaitableType;
-                isAwaitable = awaitableTypesFromThisAssembly.Concat(awaitableTypesPerAssembly).Contains(typeSymbol);
+                isAwaitable = awaitableTypesFromThisAssembly.Concat(awaitableTypesPerAssembly).Contains(typeSymbol, SymbolEqualityComparer.Default);
             }
 
             this.customAwaitableTypes.TryAdd(typeSymbol, isAwaitable);

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Microsoft.VisualStudio.Threading.Analyzers.csproj
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Microsoft.VisualStudio.Threading.Analyzers.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Microsoft.VisualStudio.Threading.Analyzers.Only</PackageId>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD113CheckForSystemIAsyncDisposableAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD113CheckForSystemIAsyncDisposableAnalyzer.cs
@@ -52,7 +52,7 @@ public class VSTHRD113CheckForSystemIAsyncDisposableAnalyzer : DiagnosticAnalyze
         });
     }
 
-    private static void AnalyzeTypeCheck(OperationAnalysisContext context, INamedTypeSymbol vsThreadingAsyncDisposableType, INamedTypeSymbol bclAsyncDisposableType)
+    private static void AnalyzeTypeCheck(OperationAnalysisContext context, INamedTypeSymbol vsThreadingAsyncDisposableType, INamedTypeSymbol? bclAsyncDisposableType)
     {
         switch (context.Operation)
         {
@@ -67,9 +67,9 @@ public class VSTHRD113CheckForSystemIAsyncDisposableAnalyzer : DiagnosticAnalyze
                 break;
         }
 
-        static void ConsiderTypeCheck(OperationAnalysisContext context, ITypeSymbol operand, INamedTypeSymbol vsThreadingAsyncDisposableType, INamedTypeSymbol bclAsyncDisposableType)
+        static void ConsiderTypeCheck(OperationAnalysisContext context, ITypeSymbol operand, INamedTypeSymbol vsThreadingAsyncDisposableType, INamedTypeSymbol? bclAsyncDisposableType)
         {
-            if (Equals(vsThreadingAsyncDisposableType, operand))
+            if (SymbolEqualityComparer.Default.Equals(vsThreadingAsyncDisposableType, operand))
             {
                 // If the System.IAsyncDisposable type is defined, search for a check for that type and skip the diagnostic if we find one.
                 if (bclAsyncDisposableType is object)
@@ -91,11 +91,11 @@ public class VSTHRD113CheckForSystemIAsyncDisposableAnalyzer : DiagnosticAnalyze
             switch (operation)
             {
                 case IIsTypeOperation { TypeOperand: { } operand }:
-                    return Equals(typeChecked, operand);
+                    return SymbolEqualityComparer.Default.Equals(typeChecked, operand);
                 case IDeclarationPatternOperation { DeclaredSymbol: ILocalSymbol { Type: { } operand } }:
-                    return Equals(typeChecked, operand);
+                    return SymbolEqualityComparer.Default.Equals(typeChecked, operand);
                 case IConversionOperation { Type: { } operand }:
-                    return Equals(typeChecked, operand);
+                    return SymbolEqualityComparer.Default.Equals(typeChecked, operand);
                 default:
                     return false;
             }

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD200UseAsyncNamingConventionAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD200UseAsyncNamingConventionAnalyzer.cs
@@ -84,7 +84,7 @@ public class VSTHRD200UseAsyncNamingConventionAnalyzer : DiagnosticAnalyzer
                 {
                     // We actively encourage folks to use the Async keyword only for clearly async-focused types.
                     // Not just any awaitable, since some stray extension method shouldn't change the world for everyone.
-                    ImmutableDictionary<string, string>? properties = ImmutableDictionary<string, string>.Empty
+                    ImmutableDictionary<string, string?>? properties = ImmutableDictionary<string, string?>.Empty
                         .Add(NewNameKey, methodSymbol.Name + MandatoryAsyncSuffix);
                     context.ReportDiagnostic(Diagnostic.Create(
                         AddAsyncDescriptor,
@@ -94,7 +94,7 @@ public class VSTHRD200UseAsyncNamingConventionAnalyzer : DiagnosticAnalyzer
                 else if (!this.IsAwaitableType(methodSymbol.ReturnType, context.Compilation, context.CancellationToken))
                 {
                     // Only warn about abusing the Async suffix if the return type is not awaitable.
-                    ImmutableDictionary<string, string>? properties = ImmutableDictionary<string, string>.Empty
+                    ImmutableDictionary<string, string?>? properties = ImmutableDictionary<string, string?>.Empty
                         .Add(NewNameKey, methodSymbol.Name.Substring(0, methodSymbol.Name.Length - MandatoryAsyncSuffix.Length));
                     context.ReportDiagnostic(Diagnostic.Create(
                         RemoveAsyncDescriptor,

--- a/src/Microsoft.VisualStudio.Threading/Microsoft.VisualStudio.Threading.csproj
+++ b/src/Microsoft.VisualStudio.Threading/Microsoft.VisualStudio.Threading.csproj
@@ -7,6 +7,9 @@
     <PackageTags>Threading Async Lock Synchronization Threadsafe</PackageTags>
 
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+
+    <!-- Version conflicts are reported because of our reference to the analyzers project, which we don't even use. -->
+    <NoWarn>$(NoWarn);MSB3277</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
     <TargetFrameworks>$(TargetFrameworks);net6.0-windows</TargetFrameworks>

--- a/test/Microsoft.VisualStudio.Threading.Tests/Microsoft.VisualStudio.Threading.Tests.csproj
+++ b/test/Microsoft.VisualStudio.Threading.Tests/Microsoft.VisualStudio.Threading.Tests.csproj
@@ -8,6 +8,9 @@
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
 
     <DefineConstants Condition=" '$(TargetFramework)' == 'net472' ">$(DefineConstants);ISOLATED_TEST_SUPPORT</DefineConstants>
+
+    <!-- Version conflicts are reported because of our reference to the analyzers project, which we don't even use. -->
+    <NoWarn>$(NoWarn);MSB3277</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
     <TargetFrameworks>$(TargetFrameworks);net472;net6.0-windows</TargetFrameworks>


### PR DESCRIPTION
This means the analyzers will now require at least Dev16.11.

This took a _lot_ of null ref annotation fixes.