### PR TITLE
Unhide fields from debugger

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
@@ -53,13 +53,11 @@ public partial class JoinableTask : IJoinableTaskDependent
     /// <summary>
     /// The <see cref="JoinableTaskDependencyGraph.JoinableTaskDependentData"/> to track dependencies between tasks.
     /// </summary>
-    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private JoinableTaskDependencyGraph.JoinableTaskDependentData dependentData;
 
     /// <summary>
     /// The collections that this job is a member of.
     /// </summary>
-    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private RarelyRemoveItemSet<IJoinableTaskDependent> dependencyParents;
 
     /// <summary>

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskCollection.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskCollection.cs
@@ -32,7 +32,6 @@ public class JoinableTaskCollection : IJoinableTaskDependent, IEnumerable<Joinab
     /// <summary>
     /// The <see cref="JoinableTaskDependencyGraph.JoinableTaskDependentData"/> to track dependencies between tasks.
     /// </summary>
-    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private JoinableTaskDependencyGraph.JoinableTaskDependentData dependentData;
 
     /// <summary>

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskDependencyGraph.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskDependencyGraph.cs
@@ -297,7 +297,6 @@ internal static class JoinableTaskDependencyGraph
         /// <remarks>
         /// When the value in an entry is decremented to 0, the entry is removed from the map.
         /// </remarks>
-        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private Dictionary<IJoinableTaskDependent, int> childDependentNodes;
 
         /// <summary>


### PR DESCRIPTION
These fields are important when looking at hangs/dumps to find relationships between the collection and the tasks they are blocked on. Unhide them so its easy to find them in Locals/Autos.