### PR TITLE
Try to fix a problem that hardcoded thread schedule defeats the effort to prioritize UI blocking tasks.

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/AsyncReaderWriterResourceLock`2.cs
+++ b/src/Microsoft.VisualStudio.Threading/AsyncReaderWriterResourceLock`2.cs
@@ -214,6 +214,16 @@ public abstract class AsyncReaderWriterResourceLock<TMoniker, TResource> : Async
     }
 
     /// <summary>
+    /// Gets a task scheduler to prepare a resource for concurrent access.
+    /// </summary>
+    /// <param name="resource">The resource to prepare.</param>
+    /// <returns>A <see cref="TaskScheduler"/>.</returns>
+    protected virtual TaskScheduler GetTaskSchedulerToPrepareResourcesForConcurrentAccess(TResource resource)
+    {
+        return TaskScheduler.Default;
+    }
+
+    /// <summary>
     /// Prepares a resource for concurrent access.
     /// </summary>
     /// <param name="resource">The resource to prepare.</param>
@@ -769,7 +779,7 @@ public abstract class AsyncReaderWriterResourceLock<TMoniker, TResource> : Async
             AsyncReaderWriterResourceLock<TMoniker, TResource>.Helper.ResourceState finalState = forConcurrentUse ? ResourceState.Concurrent : ResourceState.Exclusive;
 
             Task? preparationTask = null;
-            TaskScheduler taskScheduler = TaskScheduler.Current.MaximumConcurrencyLevel > 1 ? TaskScheduler.Current : TaskScheduler.Default;
+            TaskScheduler taskScheduler = this.service.GetTaskSchedulerToPrepareResourcesForConcurrentAccess(resource);
 
             if (!this.resourcePreparationStates.TryGetValue(resource, out ResourcePreparationTaskState? preparationState))
             {

--- a/src/Microsoft.VisualStudio.Threading/InternalUtilities.cs
+++ b/src/Microsoft.VisualStudio.Threading/InternalUtilities.cs
@@ -62,7 +62,7 @@ internal static class InternalUtilities
     }
 
     /// <summary>
-    /// Walk the continuation objects inside "async state machines" to generate the return callstack.
+    /// Walk the continuation objects inside "async state machines" to generate the return call stack.
     /// FOR DIAGNOSTIC PURPOSES ONLY.
     /// </summary>
     /// <param name="continuationDelegate">The delegate that represents the head of an async continuation chain.</param>
@@ -85,7 +85,7 @@ internal static class InternalUtilities
                 stateMachine.GetType().FullName,
                 state,
                 AsyncReturnStackPrefix,
-                (int)GetAddress(stateMachine)); // the int cast allows hex formatting
+                (long)GetAddress(stateMachine)); // the int cast allows hex formatting
 
             Delegate[]? continuationDelegates = FindContinuationDelegates(stateMachine).ToArray();
             if (continuationDelegates.Length == 0)

--- a/src/Microsoft.VisualStudio.Threading/net472/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/net472/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+virtual Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.GetTaskSchedulerToPrepareResourcesForConcurrentAccess(TResource! resource) -> System.Threading.Tasks.TaskScheduler!

--- a/src/Microsoft.VisualStudio.Threading/net6.0-windows/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/net6.0-windows/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+virtual Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.GetTaskSchedulerToPrepareResourcesForConcurrentAccess(TResource! resource) -> System.Threading.Tasks.TaskScheduler!

--- a/src/Microsoft.VisualStudio.Threading/net6.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/net6.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+virtual Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.GetTaskSchedulerToPrepareResourcesForConcurrentAccess(TResource! resource) -> System.Threading.Tasks.TaskScheduler!

--- a/src/Microsoft.VisualStudio.Threading/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+virtual Microsoft.VisualStudio.Threading.AsyncReaderWriterResourceLock<TMoniker, TResource>.GetTaskSchedulerToPrepareResourcesForConcurrentAccess(TResource! resource) -> System.Threading.Tasks.TaskScheduler!

--- a/test/Microsoft.VisualStudio.Threading.Tests/AsyncReaderWriterResourceLockTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/AsyncReaderWriterResourceLockTests.cs
@@ -1617,6 +1617,11 @@ public class AsyncReaderWriterResourceLockTests : TestBase
             return Task.FromResult(this.resources[resourceMoniker]);
         }
 
+        protected override TaskScheduler GetTaskSchedulerToPrepareResourcesForConcurrentAccess(Resource resource)
+        {
+            return TaskScheduler.Current.MaximumConcurrencyLevel > 1 ? TaskScheduler.Current : TaskScheduler.Default;
+        }
+
         protected override async Task PrepareResourceForConcurrentAccessAsync(Resource resource, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();

--- a/test/Microsoft.VisualStudio.Threading.Tests/AsyncReaderWriterResourceLockTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/AsyncReaderWriterResourceLockTests.cs
@@ -763,7 +763,7 @@ public class AsyncReaderWriterResourceLockTests : TestBase
     }
 
     [Fact]
-    public async Task PreparationPreservesThrottlingScheduler()
+    public async Task LockServiceMayPreservesThrottlingScheduler()
     {
         var resourceTask = new TaskCompletionSource<TaskScheduler>();
 


### PR DESCRIPTION
The reader/writer lock implementation always spin off a new task with hardcoded task scheduler to call PrepareResources. It happens in the critical path to access a project in the project system implementation. Most of the time, when evaluation is up to date, this is expected to be a quick check, but the extra thread pool scheduling leads it to be sensitive to thread pool issues. Because of this hardcoded scheduler usage, it defeats the effort to use a priority queue to finish UI blocking tasks when thread pool has been scheduled for many background works. 

The change is to prevent changing the behavior when GetResourceAsync is called on the UI thread, as it may lead new kind of deadlocks.

This is considered to be the reason (at least one reason) why priority queue doesn't seem to work in a 15s UI delay trace provided by David.