### PR TITLE
Allow obtaining serializable tokens that represent JoinableTasks

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -48,6 +48,7 @@
   <ItemGroup>
     <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.1.329" />
     <GlobalPackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59" />
+    <GlobalPackageReference Include="IsExternalInit" Version="1.0.3" />
     <GlobalPackageReference Include="Microsoft.VisualStudio.Internal.MicroBuild.VisualStudio" Version="$(MicroBuildVersion)" />
     <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.5.119" />
     <GlobalPackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.435" />

--- a/src/Microsoft.VisualStudio.Threading/JoinableTask`1.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTask`1.cs
@@ -27,12 +27,13 @@ namespace Microsoft.VisualStudio.Threading
         /// <summary>
         /// Initializes a new instance of the <see cref="JoinableTask{T}"/> class.
         /// </summary>
-        /// <param name="owner">The instance that began the async operation.</param>
-        /// <param name="synchronouslyBlocking">A value indicating whether the launching thread will synchronously block for this job's completion.</param>
-        /// <param name="creationOptions">The <see cref="JoinableTaskCreationOptions"/> used to customize the task's behavior.</param>
-        /// <param name="initialDelegate">The entry method's info for diagnostics.</param>
-        internal JoinableTask(JoinableTaskFactory owner, bool synchronouslyBlocking, JoinableTaskCreationOptions creationOptions, Delegate initialDelegate)
-            : base(owner, synchronouslyBlocking, creationOptions, initialDelegate)
+        /// <param name="owner"><inheritdoc cref="JoinableTask(JoinableTaskFactory, bool, string?, JoinableTaskCreationOptions, Delegate)" path="/param[@name='owner']"/></param>
+        /// <param name="synchronouslyBlocking"><inheritdoc cref="JoinableTask(JoinableTaskFactory, bool, string?, JoinableTaskCreationOptions, Delegate)" path="/param[@name='synchronouslyBlocking']"/></param>
+        /// <param name="parentToken"><inheritdoc cref="JoinableTask(JoinableTaskFactory, bool, string?, JoinableTaskCreationOptions, Delegate)" path="/param[@name='parentToken']"/></param>
+        /// <param name="creationOptions"><inheritdoc cref="JoinableTask(JoinableTaskFactory, bool, string?, JoinableTaskCreationOptions, Delegate)" path="/param[@name='creationOptions']"/></param>
+        /// <param name="initialDelegate"><inheritdoc cref="JoinableTask(JoinableTaskFactory, bool, string?, JoinableTaskCreationOptions, Delegate)" path="/param[@name='initialDelegate']"/></param>
+        internal JoinableTask(JoinableTaskFactory owner, bool synchronouslyBlocking, string? parentToken, JoinableTaskCreationOptions creationOptions, Delegate initialDelegate)
+            : base(owner, synchronouslyBlocking, parentToken, creationOptions, initialDelegate)
         {
         }
 

--- a/src/Microsoft.VisualStudio.Threading/net472/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/net472/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+Microsoft.VisualStudio.Threading.JoinableTaskContext.Capture() -> string?
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.RunAsync(System.Func<System.Threading.Tasks.Task!>! asyncMethod, string? parentToken, Microsoft.VisualStudio.Threading.JoinableTaskCreationOptions creationOptions) -> Microsoft.VisualStudio.Threading.JoinableTask!
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.RunAsync<T>(System.Func<System.Threading.Tasks.Task<T>!>! asyncMethod, string? parentToken, Microsoft.VisualStudio.Threading.JoinableTaskCreationOptions creationOptions) -> Microsoft.VisualStudio.Threading.JoinableTask<T>!

--- a/src/Microsoft.VisualStudio.Threading/net6.0-windows/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/net6.0-windows/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+Microsoft.VisualStudio.Threading.JoinableTaskContext.Capture() -> string?
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.RunAsync(System.Func<System.Threading.Tasks.Task!>! asyncMethod, string? parentToken, Microsoft.VisualStudio.Threading.JoinableTaskCreationOptions creationOptions) -> Microsoft.VisualStudio.Threading.JoinableTask!
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.RunAsync<T>(System.Func<System.Threading.Tasks.Task<T>!>! asyncMethod, string? parentToken, Microsoft.VisualStudio.Threading.JoinableTaskCreationOptions creationOptions) -> Microsoft.VisualStudio.Threading.JoinableTask<T>!

--- a/src/Microsoft.VisualStudio.Threading/net6.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/net6.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+Microsoft.VisualStudio.Threading.JoinableTaskContext.Capture() -> string?
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.RunAsync(System.Func<System.Threading.Tasks.Task!>! asyncMethod, string? parentToken, Microsoft.VisualStudio.Threading.JoinableTaskCreationOptions creationOptions) -> Microsoft.VisualStudio.Threading.JoinableTask!
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.RunAsync<T>(System.Func<System.Threading.Tasks.Task<T>!>! asyncMethod, string? parentToken, Microsoft.VisualStudio.Threading.JoinableTaskCreationOptions creationOptions) -> Microsoft.VisualStudio.Threading.JoinableTask<T>!

--- a/src/Microsoft.VisualStudio.Threading/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+Microsoft.VisualStudio.Threading.JoinableTaskContext.Capture() -> string?
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.RunAsync(System.Func<System.Threading.Tasks.Task!>! asyncMethod, string? parentToken, Microsoft.VisualStudio.Threading.JoinableTaskCreationOptions creationOptions) -> Microsoft.VisualStudio.Threading.JoinableTask!
+Microsoft.VisualStudio.Threading.JoinableTaskFactory.RunAsync<T>(System.Func<System.Threading.Tasks.Task<T>!>! asyncMethod, string? parentToken, Microsoft.VisualStudio.Threading.JoinableTaskCreationOptions creationOptions) -> Microsoft.VisualStudio.Threading.JoinableTask<T>!

--- a/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskTokenTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskTokenTests.cs
@@ -1,0 +1,218 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
+using Xunit;
+using Xunit.Abstractions;
+
+public class JoinableTaskTokenTests : JoinableTaskTestBase
+{
+    public JoinableTaskTokenTests(ITestOutputHelper logger)
+        : base(logger)
+    {
+    }
+
+    [Fact]
+    public void Capture_NoContext()
+    {
+        Assert.Null(this.context.Capture());
+    }
+
+    [Fact]
+    public void Capture_InsideRunContext()
+    {
+        string? token = null;
+        this.asyncPump.Run(delegate
+        {
+            token = this.context.Capture();
+            return Task.CompletedTask;
+        });
+        Assert.NotNull(token);
+        this.Logger.WriteLine($"Token {token}");
+    }
+
+    [Fact]
+    public void Capture_InsideRunContextWithoutSyncContext()
+    {
+        SynchronizationContext.SetSynchronizationContext(null);
+        JoinableTaskContext asyncPump = new();
+        asyncPump.Factory.Run(delegate
+        {
+            Assert.Null(asyncPump.Capture());
+            return Task.CompletedTask;
+        });
+    }
+
+    [Fact]
+    public void Capture_InheritsFromParent()
+    {
+        const string UnknownParent = "97f67c3ce2c74dc6bdb1d8a58edb9176:13";
+        string? token = null;
+        this.asyncPump.RunAsync(
+            delegate
+            {
+                token = this.context.Capture();
+                return Task.CompletedTask;
+            },
+            UnknownParent,
+            JoinableTaskCreationOptions.None).Join();
+        Assert.NotNull(token);
+        this.Logger.WriteLine($"Token {token}");
+        Assert.Contains(UnknownParent, token);
+        Assert.True(token.Length > UnknownParent.Length);
+    }
+
+    [Fact]
+    public void Capture_ReplacesParent()
+    {
+        AsyncManualResetEvent unblockParent = new();
+        string? parentToken = null;
+        JoinableTask parent = this.asyncPump.RunAsync(
+            async delegate
+            {
+                parentToken = this.context.Capture();
+                await unblockParent;
+            });
+        Assert.NotNull(parentToken);
+        this.Logger.WriteLine($"Parent: {parentToken}");
+
+        string? childToken = null;
+        this.asyncPump.RunAsync(
+            delegate
+            {
+                childToken = this.context.Capture();
+                unblockParent.Set();
+                return Task.CompletedTask;
+            },
+            parentToken,
+            JoinableTaskCreationOptions.None).Join();
+        Assert.NotNull(childToken);
+        this.Logger.WriteLine($"Child: {childToken}");
+
+        // Assert that the child token *replaced* the parent token since they both came from the same context.
+        Assert.Equal(parentToken.Length, childToken.Length);
+        Assert.NotEqual(parentToken, childToken);
+    }
+
+    [Fact]
+    public void RunAsync_AfterParentCompletes()
+    {
+        string? token = null;
+        this.asyncPump.Run(delegate
+        {
+            token = this.context.Capture();
+            return Task.CompletedTask;
+        });
+        Assert.NotNull(token);
+        this.Logger.WriteLine($"Token: {token}");
+
+        this.asyncPump.RunAsync(
+            () => Task.CompletedTask,
+            token,
+            JoinableTaskCreationOptions.None).Join();
+    }
+
+    [Theory, PairwiseData]
+    public async Task RunAsync_AvoidsDeadlockWithParent(bool includeOtherContexts)
+    {
+        string? parentToken = includeOtherContexts ? "abc:dead;ghi:coffee" : null;
+        TaskCompletionSource<string?> tokenSource = new();
+        AsyncManualResetEvent releaseOuterTask = new();
+
+        JoinableTask outerTask = this.asyncPump.RunAsync(
+            async delegate
+            {
+                try
+                {
+                    tokenSource.SetResult(this.context.Capture());
+                    await releaseOuterTask;
+                }
+                catch (Exception ex)
+                {
+                    tokenSource.SetException(ex);
+                }
+            },
+            parentToken,
+            JoinableTaskCreationOptions.None);
+
+        string? token = await tokenSource.Task;
+        Assert.NotNull(token);
+        this.Logger.WriteLine($"Token: {token}");
+        if (parentToken is not null)
+        {
+            Assert.Contains(parentToken, token);
+            token += ";even=feed";
+            this.Logger.WriteLine($"Token (modified): {token}");
+        }
+
+        JoinableTask innerTask = this.asyncPump.RunAsync(
+            async delegate
+            {
+                await Task.Yield();
+                releaseOuterTask.Set();
+            },
+            token,
+            JoinableTaskCreationOptions.None);
+
+        // Sync block the main thread using the outer task.
+        // No discernable dependency chain exists from outer to inner task,
+        // yet one subtly exists. Only the serialized context should allow inner
+        // to complete and thus unblock outer and avoid a deadlock.
+        outerTask.Join(this.TimeoutToken);
+    }
+
+    [Theory, PairwiseData]
+    public async Task RunAsyncOfT_AvoidsDeadlockWithParent(bool includeOtherContexts)
+    {
+        string? parentToken = includeOtherContexts ? "abc:dead;ghi:coffee" : null;
+        TaskCompletionSource<string?> tokenSource = new();
+        AsyncManualResetEvent releaseOuterTask = new();
+
+        JoinableTask outerTask = this.asyncPump.RunAsync<bool>(
+            async delegate
+            {
+                try
+                {
+                    tokenSource.SetResult(this.context.Capture());
+                    await releaseOuterTask;
+                }
+                catch (Exception ex)
+                {
+                    tokenSource.SetException(ex);
+                }
+
+                return true;
+            },
+            parentToken,
+            JoinableTaskCreationOptions.None);
+
+        string? token = await tokenSource.Task;
+        Assert.NotNull(token);
+        this.Logger.WriteLine($"Token: {token}");
+        if (parentToken is not null)
+        {
+            Assert.Contains(parentToken, token);
+            token += ";even=feed";
+            this.Logger.WriteLine($"Token (modified): {token}");
+        }
+
+        JoinableTask innerTask = this.asyncPump.RunAsync<bool>(
+            async delegate
+            {
+                await Task.Yield();
+                releaseOuterTask.Set();
+                return true;
+            },
+            token,
+            JoinableTaskCreationOptions.None);
+
+        // Sync block the main thread using the outer task.
+        // No discernable dependency chain exists from outer to inner task,
+        // yet one subtly exists. Only the serialized context should allow inner
+        // to complete and thus unblock outer and avoid a deadlock.
+        outerTask.Join(this.TimeoutToken);
+    }
+}


### PR DESCRIPTION
To enable RPC calls (e.g. JSON-RPC -- not COM calls), we add two new APIs:

1. `string? JoinableTaskContext.Capture()` - returns a token that represents the `JoinableTask` that is currently running, and its tokenized parents.
2. `JoinableTask JoinableTaskFactory.RunAsync(Func<Task>, string?, JoinableTaskCreationOptions)` - applies a token previously obtained from _any_ `Capture()` call (even from another process) so that any `JoinableTask` context that matches _this_ `JoinableTaskContext` object will be applied as a parent to the new `JoinableTask`.

Together, this allows RPC infrastructure to utilize `JoinableTaskFactory` to mitigate deadlocks due to requirements on the same UI thread that would otherwise be undetectable as dependencies due to how RPC runs its own queues, and may weave in and out of the process.

Prior to merging:
- [x] Prepare [changes to StreamJsonRpc that consumes these new APIs](https://github.com/microsoft/vs-streamjsonrpc/pull/886) to validate that the E2E works.
- [x] Add more xml doc comments, and any more code comments that are appropriate.
- [x] Return `null` from `Capture()` when the `JoinableTaskContext` is in 'no main thread' mode.