### PR TITLE
Merge latest Library.Template

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    <MicroBuildVersion>2.0.130</MicroBuildVersion>
+    <MicroBuildVersion>2.0.131</MicroBuildVersion>
     <CodeAnalysisVersion>3.11.0</CodeAnalysisVersion>
     <CodeAnalysisVersion Condition="'$(IsTestProject)'=='true'">4.4.0</CodeAnalysisVersion>
     <CodefixTestingVersion>1.1.1</CodefixTestingVersion>
@@ -36,10 +36,10 @@
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="7.0.0" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
-    <PackageVersion Include="xunit" Version="2.4.2" />
+    <PackageVersion Include="xunit" Version="2.5.0" />
     <PackageVersion Include="xunit.abstractions" Version="2.0.3" />
     <PackageVersion Include="Xunit.Combinatorial" Version="1.5.25" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.0" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />
     <PackageVersion Include="Xunit.StaFact" Version="1.1.11" />
   </ItemGroup>

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -33,7 +33,7 @@ jobs:
 
   - template: install-dependencies.yml
 
-  - script: dotnet tool run nbgv cloud -ca
+  - script: dotnet nbgv cloud -ca
     displayName: ⚙ Set build number
 
   - ${{ if eq(variables['system.collectionId'], '011b8bdf-6d56-4f87-be0d-0092136884d9') }}:

--- a/test/IsolatedTestHost/App.config
+++ b/test/IsolatedTestHost/App.config
@@ -10,13 +10,13 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="xunit.core" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.4.2.0" newVersion="2.4.2.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.5.0.0" newVersion="2.5.0.0" />
       </dependentAssembly>
     </assemblyBinding>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="xunit.execution.desktop" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.4.2.0" newVersion="2.4.2.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.5.0.0" newVersion="2.5.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/test/Microsoft.VisualStudio.Threading.Tests/AssertEx.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/AssertEx.cs
@@ -10,7 +10,7 @@ internal static class AssertEx
     {
         if (!EqualityComparer<T>.Default.Equals(expected, actual))
         {
-            throw new Xunit.Sdk.AssertActualExpectedException(expected, actual, message);
+            throw Xunit.Sdk.EqualException.ForMismatchedValues(expected, actual, message);
         }
     }
 
@@ -18,7 +18,7 @@ internal static class AssertEx
     {
         if (!EqualityComparer<T>.Default.Equals(expected, actual))
         {
-            throw new Xunit.Sdk.AssertActualExpectedException(expected, actual, string.Format(CultureInfo.CurrentCulture, formattingMessage, formattingArgs));
+            throw Xunit.Sdk.EqualException.ForMismatchedValues(expected, actual, string.Format(CultureInfo.CurrentCulture, formattingMessage, formattingArgs));
         }
     }
 
@@ -26,7 +26,7 @@ internal static class AssertEx
     {
         if (EqualityComparer<T>.Default.Equals(expected, actual))
         {
-            throw new Xunit.Sdk.AssertActualExpectedException(expected, actual, message);
+            throw Xunit.Sdk.NotEqualException.ForEqualValues(expected?.ToString() ?? "<null>", actual?.ToString() ?? "<null>", message);
         }
     }
 
@@ -34,7 +34,7 @@ internal static class AssertEx
     {
         if (EqualityComparer<T>.Default.Equals(expected, actual))
         {
-            throw new Xunit.Sdk.AssertActualExpectedException(expected, actual, string.Format(CultureInfo.CurrentCulture, formattingMessage, formattingArgs));
+            throw Xunit.Sdk.NotEqualException.ForEqualValues(expected?.ToString() ?? "<null>", actual?.ToString() ?? "<null>", string.Format(CultureInfo.CurrentCulture, formattingMessage, formattingArgs));
         }
     }
 }

--- a/test/Microsoft.VisualStudio.Threading.Tests/AsyncAutoResetEventTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/AsyncAutoResetEventTests.cs
@@ -121,7 +121,7 @@ public class AsyncAutoResetEventTests : TestBase
         try
         {
             waitTask.GetAwaiter().GetResult();
-            Assert.True(false, "Task was expected to transition to a canceled state.");
+            Assert.Fail("Task was expected to transition to a canceled state.");
         }
         catch (OperationCanceledException ex)
         {
@@ -148,7 +148,7 @@ public class AsyncAutoResetEventTests : TestBase
         try
         {
             this.evt.WaitAsync(token).GetAwaiter().GetResult();
-            Assert.True(false, "Task was expected to transition to a canceled state.");
+            Assert.Fail("Task was expected to transition to a canceled state.");
         }
         catch (OperationCanceledException ex)
         {

--- a/test/Microsoft.VisualStudio.Threading.Tests/AsyncReaderWriterLockTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/AsyncReaderWriterLockTests.cs
@@ -2652,7 +2652,7 @@ public class AsyncReaderWriterLockTests : TestBase, IDisposable
             try
             {
                 awaiter.GetResult();
-                Assert.True(false, "Expected OperationCanceledException not thrown.");
+                Assert.Fail("Expected OperationCanceledException not thrown.");
             }
             catch (OperationCanceledException)
             {
@@ -2670,7 +2670,7 @@ public class AsyncReaderWriterLockTests : TestBase, IDisposable
         try
         {
             awaiter.GetResult();
-            Assert.True(false, "Expected OperationCanceledException not thrown.");
+            Assert.Fail("Expected OperationCanceledException not thrown.");
         }
         catch (OperationCanceledException)
         {
@@ -2702,7 +2702,7 @@ public class AsyncReaderWriterLockTests : TestBase, IDisposable
                     try
                     {
                         awaiter.GetResult();
-                        cancellationTestConcluded.SetException(new ThrowsException(typeof(OperationCanceledException)));
+                        cancellationTestConcluded.SetException(ThrowsException.ForNoException(typeof(OperationCanceledException)));
                     }
                     catch (OperationCanceledException)
                     {
@@ -2740,7 +2740,7 @@ public class AsyncReaderWriterLockTests : TestBase, IDisposable
                     try
                     {
                         awaiter.GetResult();
-                        cancellationTestConcluded.SetException(new ThrowsException(typeof(OperationCanceledException)));
+                        cancellationTestConcluded.SetException(ThrowsException.ForNoException(typeof(OperationCanceledException)));
                     }
                     catch (OperationCanceledException)
                     {
@@ -3026,7 +3026,7 @@ public class AsyncReaderWriterLockTests : TestBase, IDisposable
         try
         {
             awaiter.GetResult();
-            Assert.True(false, "Expected exception not thrown.");
+            Assert.Fail("Expected exception not thrown.");
         }
         catch (InvalidOperationException)
         {
@@ -3047,7 +3047,7 @@ public class AsyncReaderWriterLockTests : TestBase, IDisposable
             try
             {
                 awaiter.GetResult();
-                Assert.True(false, "Expected exception not thrown.");
+                Assert.Fail("Expected exception not thrown.");
             }
             catch (InvalidOperationException)
             {
@@ -3448,7 +3448,7 @@ public class AsyncReaderWriterLockTests : TestBase, IDisposable
                 this.asyncLock.Complete();
             }
 
-            Assert.True(false, "Expected exception not thrown.");
+            Assert.Fail("Expected exception not thrown.");
         }
         catch (AggregateException ex)
         {
@@ -4184,7 +4184,7 @@ public class AsyncReaderWriterLockTests : TestBase, IDisposable
             try
             {
                 await completingTask; // observe any exception.
-                Assert.True(false, "Expected exception not thrown.");
+                Assert.Fail("Expected exception not thrown.");
             }
             catch (CriticalErrorException ex)
             {
@@ -4993,7 +4993,7 @@ public class AsyncReaderWriterLockTests : TestBase, IDisposable
                 bool dummy = this.asyncLock.IsReadLockHeld;
                 if (!successExpected)
                 {
-                    Assert.True(false, "Expected exception not thrown.");
+                    Assert.Fail("Expected exception not thrown.");
                 }
             }
             catch (Exception ex)
@@ -5009,7 +5009,7 @@ public class AsyncReaderWriterLockTests : TestBase, IDisposable
                 bool dummy = this.asyncLock.IsUpgradeableReadLockHeld;
                 if (!successExpected)
                 {
-                    Assert.True(false, "Expected exception not thrown.");
+                    Assert.Fail("Expected exception not thrown.");
                 }
             }
             catch (Exception ex)
@@ -5025,7 +5025,7 @@ public class AsyncReaderWriterLockTests : TestBase, IDisposable
                 bool dummy = this.asyncLock.IsWriteLockHeld;
                 if (!successExpected)
                 {
-                    Assert.True(false, "Expected exception not thrown.");
+                    Assert.Fail("Expected exception not thrown.");
                 }
             }
             catch (Exception ex)
@@ -5045,7 +5045,7 @@ public class AsyncReaderWriterLockTests : TestBase, IDisposable
             try
             {
                 releaser = await locker();
-                Assert.True(false, "Expected exception not thrown.");
+                Assert.Fail("Expected exception not thrown.");
             }
             catch (Exception ex)
             {

--- a/test/Microsoft.VisualStudio.Threading.Tests/AsyncReaderWriterResourceLockTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/AsyncReaderWriterResourceLockTests.cs
@@ -310,7 +310,7 @@ public class AsyncReaderWriterResourceLockTests : TestBase
                 try
                 {
                     await resourceTask;
-                    Assert.True(false, "Expected OperationCanceledException not thrown.");
+                    Assert.Fail("Expected OperationCanceledException not thrown.");
                 }
                 catch (OperationCanceledException)
                 {
@@ -461,7 +461,7 @@ public class AsyncReaderWriterResourceLockTests : TestBase
                 (resource, s) =>
                 {
                     Assert.Same(state, s);
-                    Assert.True(false, "Read locks should not invoke this.");
+                    Assert.Fail("Read locks should not invoke this.");
                     return false;
                 },
                 state);
@@ -1216,7 +1216,7 @@ public class AsyncReaderWriterResourceLockTests : TestBase
             try
             {
                 await access.GetResourceAsync(1);
-                Assert.True(false, "Expected exception not thrown.");
+                Assert.Fail("Expected exception not thrown.");
             }
             catch (ApplicationException)
             {
@@ -1242,7 +1242,7 @@ public class AsyncReaderWriterResourceLockTests : TestBase
             try
             {
                 Resource? resource = await access.GetResourceAsync(1);
-                Assert.True(false, "Expected exception not thrown.");
+                Assert.Fail("Expected exception not thrown.");
             }
             catch (ApplicationException)
             {
@@ -1275,7 +1275,7 @@ public class AsyncReaderWriterResourceLockTests : TestBase
                     try
                     {
                         await writeAccess.ReleaseAsync();
-                        Assert.True(false, "Expected exception not thrown.");
+                        Assert.Fail("Expected exception not thrown.");
                     }
                     catch (ApplicationException)
                     {
@@ -1285,7 +1285,7 @@ public class AsyncReaderWriterResourceLockTests : TestBase
                 }
 
                 // Exiting the using block should also throw.
-                Assert.True(false, "Expected exception not thrown.");
+                Assert.Fail("Expected exception not thrown.");
             }
             catch (ApplicationException)
             {
@@ -1308,7 +1308,7 @@ public class AsyncReaderWriterResourceLockTests : TestBase
                 try
                 {
                     await readAccess.GetResourceAsync(1);
-                    Assert.True(false, "Expected exception not thrown.");
+                    Assert.Fail("Expected exception not thrown.");
                 }
                 catch (ApplicationException)
                 {

--- a/test/Microsoft.VisualStudio.Threading.Tests/AsyncSemaphoreTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/AsyncSemaphoreTests.cs
@@ -158,7 +158,7 @@ public class AsyncSemaphoreTests : TestBase
         try
         {
             await second;
-            Assert.True(false, "Expected OperationCanceledException not thrown.");
+            Assert.Fail("Expected OperationCanceledException not thrown.");
         }
         catch (OperationCanceledException ex)
         {
@@ -176,7 +176,7 @@ public class AsyncSemaphoreTests : TestBase
         try
         {
             enterAsyncTask.GetAwaiter().GetResult();
-            Assert.True(false, "Expected exception not thrown.");
+            Assert.Fail("Expected exception not thrown.");
         }
         catch (OperationCanceledException ex)
         {

--- a/test/Microsoft.VisualStudio.Threading.Tests/AwaitExtensionsTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/AwaitExtensionsTests.cs
@@ -507,7 +507,7 @@ public partial class AwaitExtensionsTests : TestBase
         try
         {
             await joint.ConfigureAwaitForAggregateException();
-            Assert.False(true, "Exception was not thrown.");
+            Assert.Fail("Exception was not thrown.");
         }
         catch (AggregateException ex)
         {
@@ -523,7 +523,7 @@ public partial class AwaitExtensionsTests : TestBase
         try
         {
             await canceled.ConfigureAwaitForAggregateException();
-            Assert.False(true, "Exception was not thrown.");
+            Assert.Fail("Exception was not thrown.");
         }
         catch (OperationCanceledException)
         {
@@ -540,7 +540,7 @@ public partial class AwaitExtensionsTests : TestBase
         try
         {
             await joint.ConfigureAwaitForAggregateException();
-            Assert.False(true, "Exception was not thrown.");
+            Assert.Fail("Exception was not thrown.");
         }
         catch (OperationCanceledException)
         {
@@ -557,7 +557,7 @@ public partial class AwaitExtensionsTests : TestBase
         try
         {
             await joint.ConfigureAwaitForAggregateException();
-            Assert.False(true, "Exception was not thrown.");
+            Assert.Fail("Exception was not thrown.");
         }
         catch (AggregateException ex)
         {
@@ -718,7 +718,7 @@ public partial class AwaitExtensionsTests : TestBase
             try
             {
                 await changeWatcherTask;
-                Assert.True(false, "Expected exception not thrown.");
+                Assert.Fail("Expected exception not thrown.");
             }
             catch (OperationCanceledException ex)
             {
@@ -756,7 +756,7 @@ public partial class AwaitExtensionsTests : TestBase
         try
         {
             await watchingTask;
-            Assert.True(false, "Expected exception not thrown.");
+            Assert.Fail("Expected exception not thrown.");
         }
         catch (OperationCanceledException ex)
         {

--- a/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskAndAsyncReaderWriterLockTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskAndAsyncReaderWriterLockTests.cs
@@ -163,7 +163,7 @@ public class JoinableTaskAndAsyncReaderWriterLockTests : TestBase
                 try
                 {
                     this.asyncPump.Run(() => Task.CompletedTask);
-                    Assert.False(true, "Expected InvalidOperationException not thrown.");
+                    Assert.Fail("Expected InvalidOperationException not thrown.");
                 }
                 catch (InvalidOperationException)
                 {
@@ -190,7 +190,7 @@ public class JoinableTaskAndAsyncReaderWriterLockTests : TestBase
                 try
                 {
                     this.asyncPump.Run(() => Task.CompletedTask);
-                    Assert.True(false, "Expected InvalidOperationException not thrown.");
+                    Assert.Fail("Expected InvalidOperationException not thrown.");
                 }
                 catch (InvalidOperationException)
                 {

--- a/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskTests.cs
@@ -293,7 +293,7 @@ public class JoinableTaskTests : JoinableTaskTestBase
             try
             {
                 await this.asyncPump.SwitchToMainThreadAsync(cts.Token);
-                Assert.True(false, "Expected OperationCanceledException not thrown.");
+                Assert.Fail("Expected OperationCanceledException not thrown.");
             }
             catch (OperationCanceledException)
             {
@@ -337,7 +337,7 @@ public class JoinableTaskTests : JoinableTaskTestBase
                     });
                 }
             });
-            Assert.True(false, "Expected OperationCanceledException not thrown.");
+            Assert.Fail("Expected OperationCanceledException not thrown.");
         }
         catch (OperationCanceledException)
         {
@@ -2500,7 +2500,7 @@ public class JoinableTaskTests : JoinableTaskTestBase
 
             if (ex is object)
             {
-                Assert.True(false, $"Posted message threw an exception: {ex}");
+                Assert.Fail($"Posted message threw an exception: {ex}");
             }
 
             return Task.CompletedTask;
@@ -3491,7 +3491,7 @@ public class JoinableTaskTests : JoinableTaskTestBase
         try
         {
             awaiter.GetResult();
-            Assert.True(false, "Expected exception not rethrown.");
+            Assert.Fail("Expected exception not rethrown.");
         }
         catch (InvalidOperationException ex)
         {
@@ -3513,7 +3513,7 @@ public class JoinableTaskTests : JoinableTaskTestBase
         try
         {
             awaiter.GetResult();
-            Assert.True(false, "Expected exception not rethrown.");
+            Assert.Fail("Expected exception not rethrown.");
         }
         catch (InvalidOperationException ex)
         {

--- a/test/Microsoft.VisualStudio.Threading.Tests/ThreadingToolsTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/ThreadingToolsTests.cs
@@ -179,7 +179,7 @@ public class ThreadingToolsTests : TestBase
         try
         {
             tcs.Task.WithCancellation(cts.Token).Wait(TestTimeout);
-            Assert.True(false, "Expected OperationCanceledException not thrown.");
+            Assert.Fail("Expected OperationCanceledException not thrown.");
         }
         catch (AggregateException ex)
         {

--- a/test/Microsoft.VisualStudio.Threading.Tests/TplExtensionsTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/TplExtensionsTests.cs
@@ -299,7 +299,7 @@ public class TplExtensionsTests : TestBase
         try
         {
             tcs.Task.WaitWithoutInlining();
-            Assert.False(true, "Expected exception not thrown.");
+            Assert.Fail("Expected exception not thrown.");
         }
         catch (AggregateException ex)
         {
@@ -765,7 +765,7 @@ public class TplExtensionsTests : TestBase
         try
         {
             task.GetAwaiter().GetResult();
-            Assert.True(false, "Expected AggregateException not thrown.");
+            Assert.Fail("Expected AggregateException not thrown.");
         }
         catch (AggregateException ex)
         {
@@ -792,7 +792,7 @@ public class TplExtensionsTests : TestBase
         try
         {
             task.GetAwaiter().GetResult();
-            Assert.True(false, "Expected AggregateException not thrown.");
+            Assert.Fail("Expected AggregateException not thrown.");
         }
         catch (AggregateException ex)
         {


### PR DESCRIPTION
- Bump xunit.runner.visualstudio from 2.4.5 to 2.5.0 (#210)
- Bump MicroBuildVersion to 2.0.131
- Bump xunit from 2.4.2 to 2.5.0 (#209)
- Remove `tool run` from `dotnet nbgv` invocation
