### PR TITLE
Add `AsyncMutex` class

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/AsyncCrossProcessMutex.cs
+++ b/src/Microsoft.VisualStudio.Threading/AsyncCrossProcessMutex.cs
@@ -1,0 +1,202 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.Threading;
+
+/// <summary>
+/// A mutex that can be entered asynchronously.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This class utilizes the OS mutex synchronization primitive, which is fundamentally thread-affinitized and requires synchronously blocking the thread that will own the mutex.
+/// This makes a native mutex unsuitable for use in async methods, where the thread that enters the mutex may not be the same thread that exits it.
+/// This class solves that problem by using a private dedicated thread to enter and release the mutex, but otherwise allows its owner to execute async code, switch threads, etc.
+/// </para>
+/// </remarks>
+/// <example><![CDATA[
+/// using AsyncCrossProcessMutex mutex = new("Some-Unique Name");
+/// using (await mutex.EnterAsync())
+/// {
+///     // Code that must not execute in parallel with any other thread or process protected by the same named mutex.
+/// }
+/// ]]></example>
+public class AsyncCrossProcessMutex
+    : IDisposable
+{
+#pragma warning disable SA1310 // Field names should not contain underscore
+    private const int STATE_READY = 0;
+    private const int STATE_HELD_OR_WAITING = 1;
+    private const int STATE_DISPOSED = 2;
+#pragma warning restore SA1310 // Field names should not contain underscore
+
+    private static readonly Action ExitSentinel = new Action(() => { });
+    private readonly Thread namedMutexOwner;
+    private readonly BlockingCollection<Action> mutexWorkQueue = new();
+    private readonly Mutex mutex;
+    private int state;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AsyncCrossProcessMutex"/> class.
+    /// </summary>
+    /// <param name="name">
+    /// A non-empty name for the mutex, which follows standard mutex naming rules.
+    /// This name will share a namespace with other processes in the system and collisions will result in the processes sharing a single mutex across processes.
+    /// </param>
+    /// <remarks>
+    /// See the help docs on the underlying <see cref="Mutex"/> class for more information on the <paramref name="name"/> parameter.
+    /// Consider when reading that the <c>initiallyOwned</c> parameter for that constructor is always <see langword="false"/> for this class.
+    /// </remarks>
+    public AsyncCrossProcessMutex(string name)
+    {
+        Requires.NotNullOrEmpty(name);
+        this.namedMutexOwner = new Thread(this.MutexOwnerThread, 100 * 1024)
+        {
+            Name = $"{nameof(AsyncCrossProcessMutex)}-{name}",
+        };
+        this.mutex = new Mutex(false, name);
+        this.namedMutexOwner.Start();
+        this.Name = name;
+    }
+
+    /// <summary>
+    /// Gets the name of the mutex.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// Disposes of the underlying native objects.
+    /// </summary>
+    public void Dispose()
+    {
+        int priorState = Interlocked.Exchange(ref this.state, STATE_DISPOSED);
+        if (priorState != STATE_DISPOSED)
+        {
+            this.mutexWorkQueue.Add(ExitSentinel);
+            this.mutexWorkQueue.CompleteAdding();
+        }
+    }
+
+    /// <inheritdoc cref="EnterAsync(TimeSpan)"/>
+    public Task<LockReleaser> EnterAsync() => this.EnterAsync(Timeout.InfiniteTimeSpan);
+
+    /// <summary>
+    /// Acquires the mutex asynchronously.
+    /// </summary>
+    /// <param name="timeout">The maximum time to wait before timing out. Use <see cref="Timeout.InfiniteTimeSpan"/> for no timeout, or <see cref="TimeSpan.Zero"/> to acquire the mutex only if it is immediately available.</param>
+    /// <returns>A value whose disposal will release the mutex.</returns>
+    /// <exception cref="TimeoutException">Thrown from the awaited result if the mutex could not be acquired within the specified timeout.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown from the awaited result if the <paramref name="timeout"/> is a negative number other than -1 milliseconds, which represents an infinite timeout.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if called before a prior call to this method has completed, with its releaser disposed if the mutex was entered.</exception>
+    public async Task<LockReleaser> EnterAsync(TimeSpan timeout) => await this.TryEnterAsync(timeout) ?? throw new TimeoutException();
+
+    /// <summary>
+    /// Acquires the mutex asynchronously, allowing for timeouts without throwing exceptions.
+    /// </summary>
+    /// <param name="timeout">The maximum time to wait before timing out. Use <see cref="Timeout.InfiniteTimeSpan"/> for no timeout, or <see cref="TimeSpan.Zero"/> to acquire the mutex only if it is immediately available.</param>
+    /// <returns>
+    /// If the mutex was acquired, the result is a value whose disposal will release the mutex.
+    /// In the event of a timeout, the result in a <see langword="null" /> value.
+    /// </returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown from the awaited result if the <paramref name="timeout"/> is a negative number other than -1 milliseconds, which represents an infinite timeout.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if called before a prior call to this method has completed, with its releaser disposed if the mutex was entered.</exception>
+    public Task<LockReleaser?> TryEnterAsync(TimeSpan timeout)
+    {
+        int priorState = Interlocked.CompareExchange(ref this.state, STATE_HELD_OR_WAITING, STATE_READY);
+        switch (priorState)
+        {
+            case STATE_HELD_OR_WAITING:
+                throw new InvalidOperationException();
+            case STATE_DISPOSED:
+                throw new ObjectDisposedException(this.GetType().FullName);
+        }
+
+        // Pass `this` as the state simply to assist in debugging dumps.
+        TaskCompletionSource<LockReleaser?> tcs = new(this, TaskCreationOptions.RunContinuationsAsynchronously);
+        this.mutexWorkQueue.Add(delegate
+        {
+            try
+            {
+                if (this.mutex.WaitOne(timeout))
+                {
+                    tcs.SetResult(new LockReleaser(this));
+                }
+                else
+                {
+                    Assumes.True(Interlocked.CompareExchange(ref this.state, STATE_READY, STATE_HELD_OR_WAITING) == STATE_HELD_OR_WAITING);
+                    tcs.SetResult(null);
+                }
+            }
+            catch (AbandonedMutexException)
+            {
+                tcs.SetResult(new LockReleaser(this, abandoned: true));
+            }
+            catch (Exception ex)
+            {
+                Assumes.True(Interlocked.CompareExchange(ref this.state, STATE_READY, STATE_HELD_OR_WAITING) == STATE_HELD_OR_WAITING);
+                tcs.SetException(ex);
+            }
+        });
+
+        return tcs.Task;
+    }
+
+    private void Release()
+    {
+        Assumes.True(Interlocked.CompareExchange(ref this.state, STATE_READY, STATE_HELD_OR_WAITING) == STATE_HELD_OR_WAITING);
+        this.mutexWorkQueue.Add(this.mutex.ReleaseMutex);
+    }
+
+    private void MutexOwnerThread()
+    {
+        try
+        {
+            while (!this.mutexWorkQueue.IsCompleted)
+            {
+                Action work = this.mutexWorkQueue.Take();
+                if (work == ExitSentinel)
+                {
+                    // We use an exit sentinel to avoid an exception having to be thrown and caught on disposal when we call Take() and CompleteAdding() is called.
+                    break;
+                }
+
+                work();
+            }
+        }
+        finally
+        {
+            this.mutex.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// The value returned from <see cref="EnterAsync(TimeSpan)"/> that must be disposed to release the mutex.
+    /// </summary>
+    public struct LockReleaser : IDisposable
+    {
+        private AsyncCrossProcessMutex? owner;
+
+        internal LockReleaser(AsyncCrossProcessMutex mutex, bool abandoned = false)
+        {
+            this.owner = mutex;
+            this.IsAbandoned = abandoned;
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the mutex was abandoned by its previous owner.
+        /// </summary>
+        public bool IsAbandoned { get; }
+
+        /// <summary>
+        /// Releases the named mutex.
+        /// </summary>
+        public void Dispose()
+        {
+            Interlocked.Exchange(ref this.owner, null)?.Release();
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Threading/net472/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/net472/PublicAPI.Unshipped.txt
@@ -1,0 +1,10 @@
+Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex
+Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.AsyncCrossProcessMutex(string! name) -> void
+Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.Dispose() -> void
+Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.EnterAsync() -> System.Threading.Tasks.Task<Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.LockReleaser>!
+Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.EnterAsync(System.TimeSpan timeout) -> System.Threading.Tasks.Task<Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.LockReleaser>!
+Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.LockReleaser
+Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.LockReleaser.Dispose() -> void
+Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.LockReleaser.IsAbandoned.get -> bool
+Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.Name.get -> string!
+Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.TryEnterAsync(System.TimeSpan timeout) -> System.Threading.Tasks.Task<Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.LockReleaser?>!

--- a/src/Microsoft.VisualStudio.Threading/net6.0-windows/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/net6.0-windows/PublicAPI.Unshipped.txt
@@ -1,0 +1,10 @@
+Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex
+Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.AsyncCrossProcessMutex(string! name) -> void
+Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.Dispose() -> void
+Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.EnterAsync() -> System.Threading.Tasks.Task<Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.LockReleaser>!
+Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.EnterAsync(System.TimeSpan timeout) -> System.Threading.Tasks.Task<Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.LockReleaser>!
+Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.LockReleaser
+Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.LockReleaser.Dispose() -> void
+Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.LockReleaser.IsAbandoned.get -> bool
+Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.Name.get -> string!
+Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.TryEnterAsync(System.TimeSpan timeout) -> System.Threading.Tasks.Task<Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.LockReleaser?>!

--- a/src/Microsoft.VisualStudio.Threading/net6.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/net6.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,10 @@
+Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex
+Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.AsyncCrossProcessMutex(string! name) -> void
+Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.Dispose() -> void
+Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.EnterAsync() -> System.Threading.Tasks.Task<Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.LockReleaser>!
+Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.EnterAsync(System.TimeSpan timeout) -> System.Threading.Tasks.Task<Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.LockReleaser>!
+Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.LockReleaser
+Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.LockReleaser.Dispose() -> void
+Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.LockReleaser.IsAbandoned.get -> bool
+Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.Name.get -> string!
+Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.TryEnterAsync(System.TimeSpan timeout) -> System.Threading.Tasks.Task<Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.LockReleaser?>!

--- a/src/Microsoft.VisualStudio.Threading/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,10 @@
+Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex
+Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.AsyncCrossProcessMutex(string! name) -> void
+Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.Dispose() -> void
+Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.EnterAsync() -> System.Threading.Tasks.Task<Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.LockReleaser>!
+Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.EnterAsync(System.TimeSpan timeout) -> System.Threading.Tasks.Task<Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.LockReleaser>!
+Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.LockReleaser
+Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.LockReleaser.Dispose() -> void
+Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.LockReleaser.IsAbandoned.get -> bool
+Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.Name.get -> string!
+Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.TryEnterAsync(System.TimeSpan timeout) -> System.Threading.Tasks.Task<Microsoft.VisualStudio.Threading.AsyncCrossProcessMutex.LockReleaser?>!

--- a/test/Microsoft.VisualStudio.Threading.Tests/AsyncCrossProcessMutexTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/AsyncCrossProcessMutexTests.cs
@@ -1,0 +1,219 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
+using Xunit;
+using Xunit.Abstractions;
+
+public class AsyncCrossProcessMutexTests : TestBase, IDisposable
+{
+    private readonly AsyncCrossProcessMutex mutex = new($"test {Guid.NewGuid()}");
+
+    public AsyncCrossProcessMutexTests(ITestOutputHelper logger)
+        : base(logger)
+    {
+    }
+
+    public void Dispose()
+    {
+        this.mutex.Dispose();
+    }
+
+    [Fact]
+    public void DisposeWithoutUse()
+    {
+        // This test intentionally left blank. The tested functionality is in the constructor and Dispose method.
+    }
+
+    [Fact]
+    public void Dispose_Twice()
+    {
+        // The second disposal happens in the Dispose method of this class.
+        this.mutex.Dispose();
+    }
+
+    [Fact]
+    public async Task EnterAsync_Release_Uncontested()
+    {
+        await this.VerifyMutexEnterReleaseAsync();
+    }
+
+    [Fact]
+    public async Task EnterAsync_DoubleRelease()
+    {
+        AsyncCrossProcessMutex.LockReleaser releaser = await this.mutex.EnterAsync();
+        releaser.Dispose();
+        releaser.Dispose();
+    }
+
+    [Fact]
+    public async Task EnterAsync_Reentrancy()
+    {
+        using (AsyncCrossProcessMutex.LockReleaser releaser = await this.mutex.EnterAsync())
+        {
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await this.mutex.EnterAsync());
+        }
+
+        await this.VerifyMutexEnterReleaseAsync();
+    }
+
+    [Fact]
+    public async Task TryEnterAsync_Reentrancy()
+    {
+        using (AsyncCrossProcessMutex.LockReleaser releaser = await this.mutex.EnterAsync())
+        {
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await this.mutex.TryEnterAsync(Timeout.InfiniteTimeSpan));
+        }
+
+        await this.VerifyMutexEnterReleaseAsync();
+    }
+
+    [Fact]
+    public async Task EnterAsync_Contested()
+    {
+        // We don't allow attempted reentrancy, so create a new mutex object to use for the contested locks.
+        AsyncCrossProcessMutex mutex2 = new(this.mutex.Name);
+
+        // Acquire and hold the mutex so that we can test timeout behavior.
+        using (AsyncCrossProcessMutex.LockReleaser releaser = await this.mutex.EnterAsync())
+        {
+            // Verify that we can't acquire the mutex within a timeout.
+            await Assert.ThrowsAsync<TimeoutException>(async () => await mutex2.EnterAsync(TimeSpan.Zero));
+            await Assert.ThrowsAsync<TimeoutException>(async () => await mutex2.EnterAsync(TimeSpan.FromMilliseconds(1)));
+        }
+
+        // Verify that we can acquire the mutex after it is released.
+        using (AsyncCrossProcessMutex.LockReleaser releaser2 = await mutex2.EnterAsync())
+        {
+        }
+
+        // Verify that the main mutex still functions.
+        await this.VerifyMutexEnterReleaseAsync();
+    }
+
+    [Fact]
+    public async Task TryEnterAsync_Contested()
+    {
+        // We don't allow attempted reentrancy, so create a new mutex object to use for the contested locks.
+        AsyncCrossProcessMutex mutex2 = new(this.mutex.Name);
+
+        // Acquire and hold the mutex so that we can test timeout behavior.
+        using (AsyncCrossProcessMutex.LockReleaser? releaser = await this.mutex.TryEnterAsync(Timeout.InfiniteTimeSpan))
+        {
+            // Verify that we can't acquire the mutex within a timeout.
+            Assert.Null(await mutex2.TryEnterAsync(TimeSpan.Zero));
+            Assert.Null(await mutex2.TryEnterAsync(TimeSpan.FromMilliseconds(1)));
+
+            // Just verify that the syntax is nice.
+            using (AsyncCrossProcessMutex.LockReleaser? releaser2 = await mutex2.TryEnterAsync(TimeSpan.Zero))
+            {
+                Assert.Null(releaser2);
+            }
+        }
+
+        // Verify that we can acquire the mutex after it is released.
+        using (AsyncCrossProcessMutex.LockReleaser releaser2 = await mutex2.EnterAsync())
+        {
+        }
+
+        // Verify that the main mutex still functions.
+        await this.VerifyMutexEnterReleaseAsync();
+    }
+
+    [Fact]
+    public async Task EnterAsync_InvalidNegativeTimeout()
+    {
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await this.mutex.EnterAsync(TimeSpan.FromMilliseconds(-2)));
+        await this.VerifyMutexEnterReleaseAsync();
+    }
+
+    [Fact]
+    public async Task TryEnterAsync_InvalidNegativeTimeout()
+    {
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await this.mutex.TryEnterAsync(TimeSpan.FromMilliseconds(-2)));
+        await this.VerifyMutexEnterReleaseAsync();
+    }
+
+    [Fact]
+    public async Task EnterAsync_AbandonedMutex()
+    {
+        using AsyncCrossProcessMutex mutex2 = new(this.mutex.Name);
+
+        AsyncCrossProcessMutex.LockReleaser abandonedReleaser = await this.mutex.EnterAsync();
+        Assert.False(abandonedReleaser.IsAbandoned);
+
+        // Dispose the mutex WITHOUT first releasing it.
+        this.mutex.Dispose();
+
+        using (AsyncCrossProcessMutex.LockReleaser releaser2 = await mutex2.EnterAsync())
+        {
+            Assert.True(releaser2.IsAbandoned);
+        }
+    }
+
+    [Fact]
+    public async Task TryEnterAsync_AbandonedMutex()
+    {
+        using AsyncCrossProcessMutex mutex2 = new(this.mutex.Name);
+
+        AsyncCrossProcessMutex.LockReleaser? abandonedReleaser = await this.mutex.TryEnterAsync(Timeout.InfiniteTimeSpan);
+        Assert.False(abandonedReleaser.Value.IsAbandoned);
+
+        // Dispose the mutex WITHOUT first releasing it.
+        this.mutex.Dispose();
+
+        using (AsyncCrossProcessMutex.LockReleaser? releaser2 = await mutex2.TryEnterAsync(Timeout.InfiniteTimeSpan))
+        {
+            Assert.True(releaser2.Value.IsAbandoned);
+        }
+    }
+
+    [Fact]
+    public async Task EnterAsync_ThrowsObjectDisposedException()
+    {
+        this.mutex.Dispose();
+        await Assert.ThrowsAsync<ObjectDisposedException>(async () => await this.mutex.EnterAsync());
+    }
+
+    [Fact]
+    public async Task TryEnterAsync_ThrowsObjectDisposedException()
+    {
+        this.mutex.Dispose();
+        await Assert.ThrowsAsync<ObjectDisposedException>(async () => await this.mutex.TryEnterAsync(Timeout.InfiniteTimeSpan));
+    }
+
+    [Fact]
+    public async Task TryEnterAsync_Twice()
+    {
+        using (AsyncCrossProcessMutex.LockReleaser? releaser = await this.mutex.TryEnterAsync(TimeSpan.Zero))
+        {
+        }
+
+        using (AsyncCrossProcessMutex.LockReleaser? releaser = await this.mutex.TryEnterAsync(TimeSpan.Zero))
+        {
+        }
+    }
+
+    /// <summary>
+    /// Asserts behavior or the .NET Mutex class that we may be emulating in our <see cref="AsyncCrossProcessMutex"/> class.
+    /// </summary>
+    [Fact]
+    public void Mutex_BaselineBehaviors()
+    {
+        // Verify reentrant behavior.
+        using Mutex mutex = new(false, $"test {Guid.NewGuid()}");
+        mutex.WaitOne();
+        mutex.WaitOne();
+        mutex.ReleaseMutex();
+        mutex.ReleaseMutex();
+        Assert.Throws<ApplicationException>(mutex.ReleaseMutex);
+    }
+
+    private async Task VerifyMutexEnterReleaseAsync()
+    {
+        using AsyncCrossProcessMutex.LockReleaser releaser = await this.mutex.EnterAsync();
+    }
+}


### PR DESCRIPTION
This adds a more convenient way to execute async code while holding (or waiting for) a mutex.

Mutexes are traditionally very difficult to asynchronously wait for or do async work while holding because they are thread affinitized. This new class creates a dedicated thread to 'own' the mutex while allowing the `AsyncMutex` owner to await for the mutex and run async code on any thread while holding it.