### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "powershell": {
-      "version": "7.3.5",
+      "version": "7.3.6",
       "commands": [
         "pwsh"
       ]
@@ -15,7 +15,7 @@
       ]
     },
     "dotnet-coverage": {
-      "version": "17.7.3",
+      "version": "17.8.4",
       "commands": [
         "dotnet-coverage"
       ]

--- a/.editorconfig
+++ b/.editorconfig
@@ -32,6 +32,10 @@ indent_size = 2
 indent_size = 2
 indent_style = space
 
+[*.ps1]
+indent_style = space
+indent_size = 4
+
 # Dotnet code style settings:
 [*.{cs,vb}]
 # Sort using and Import directives with System.* appearing first

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,7 @@ updates:
   schedule:
     interval: weekly
   ignore:
+  # This package has unlisted versions on nuget.org that are not supported. Avoid them.
+  - dependency-name: dotnet-format
+    versions: ["6.x", "7.x", "8.x"]
   - dependency-name: Microsoft.CodeAnalysis* # We intentionally target older VS versions.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    <MicroBuildVersion>2.0.131</MicroBuildVersion>
+    <MicroBuildVersion>2.0.137</MicroBuildVersion>
     <CodeAnalysisVersion>3.11.0</CodeAnalysisVersion>
     <CodeAnalysisVersion Condition="'$(IsTestProject)'=='true'">4.4.0</CodeAnalysisVersion>
     <CodefixTestingVersion>1.1.1</CodefixTestingVersion>
@@ -22,7 +22,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.XUnit" Version="$(CodefixTestingVersion)" />
     <PackageVersion Include="Microsoft.Diagnostics.Runtime.Utilities" Version="$(MicrosoftDiagnosticsRuntimeVersion)" />
     <PackageVersion Include="Microsoft.Diagnostics.Runtime" Version="$(MicrosoftDiagnosticsRuntimeVersion)" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Internal.MicroBuild.NonShipping" Version="$(MicroBuildVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Interop" Version="17.4.33103.184" />
     <PackageVersion Include="Microsoft.VisualStudio.Shell.15.0" Version="17.4.33103.184" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,7 +22,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.XUnit" Version="$(CodefixTestingVersion)" />
     <PackageVersion Include="Microsoft.Diagnostics.Runtime.Utilities" Version="$(MicrosoftDiagnosticsRuntimeVersion)" />
     <PackageVersion Include="Microsoft.Diagnostics.Runtime" Version="$(MicrosoftDiagnosticsRuntimeVersion)" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageVersion Include="Microsoft.VisualStudio.Internal.MicroBuild.NonShipping" Version="$(MicroBuildVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Interop" Version="17.4.33103.184" />
     <PackageVersion Include="Microsoft.VisualStudio.Shell.15.0" Version="17.4.33103.184" />

--- a/azure-pipelines/microbuild.before.yml
+++ b/azure-pipelines/microbuild.before.yml
@@ -11,6 +11,7 @@ steps:
     outputfile: $(System.DefaultWorkingDirectory)/obj/NOTICE
     outputformat: text
   condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+  retryCountOnTaskFailure: 3 # fails when the cloud service is overloaded
 
 - task: MicroBuildOptProfPlugin@6
   inputs:


### PR DESCRIPTION
- Dependabot to ignore dotnet-format
- Set tab settings for .ps1 files
- Bump powershell from 7.3.5 to 7.3.6 (#212)
- Bump dotnet-coverage from 17.7.3 to 17.8.0 (#211)
- Bump dotnet-coverage to 17.8.2
- Bump MicroBuild version to 2.0.134
- Bump Microsoft.NET.Test.Sdk from 17.6.3 to 17.7.0 (#213)
- Bump Microbuild version to 2.0.137
- Tolerate NOTICE file task network failures
- Bump Microsoft.NET.Test.Sdk from 17.7.0 to 17.7.1 (#214)
- Bump dotnet-coverage from 17.8.2 to 17.8.4 (#215)
