### PR TITLE
Make `VSTHRD200` ignore `DisposeAsyncCore`

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD200UseAsyncNamingConventionAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD200UseAsyncNamingConventionAnalyzer.cs
@@ -72,6 +72,12 @@ public class VSTHRD200UseAsyncNamingConventionAnalyzer : DiagnosticAnalyzer
             return;
         }
 
+        // Skip the method of the recommended dispose pattern.
+        if (methodSymbol.Name == "DisposeAsyncCore")
+        {
+            return;
+        }
+
         bool hasAsyncFocusedReturnType = Utils.HasAsyncCompatibleReturnType(methodSymbol);
 
         bool actuallyEndsWithAsync = methodSymbol.Name.EndsWith(MandatoryAsyncSuffix, StringComparison.CurrentCulture);

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD200UseAsyncNamingConventionAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD200UseAsyncNamingConventionAnalyzerTests.cs
@@ -561,4 +561,27 @@ class Test {
 ";
         await CSVerify.VerifyAnalyzerAsync(test);
     }
+
+    [Fact]
+    public async Task MethodDisposeAsyncCore_GeneratesNoWarning()
+    {
+        var test = @"
+using System;
+using System.Threading.Tasks;
+
+class Test : IAsyncDisposable
+{
+    public async ValueTask DisposeAsync()
+    {
+        await DisposeAsyncCore().ConfigureAwait(false);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual async ValueTask DisposeAsyncCore()
+    {
+    }
+}
+";
+        await CSVerify.VerifyAnalyzerAsync(test);
+    }
 }


### PR DESCRIPTION
Fixes #805

`DisposeAsyncCore` is recommended in https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-disposeasync#the-disposeasynccore-method and as such I believe there should be no warning for the special case.

Though @sharwell mentioned that the name might not be final [here](https://github.com/microsoft/vs-threading/issues/805#issuecomment-800553086). But it's been 2.5 years so my guess is that the topic is not especially hot since nothing has seemingly happened since then.