### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "powershell": {
-      "version": "7.3.6",
+      "version": "7.3.8",
       "commands": [
         "pwsh"
       ]
@@ -15,7 +15,7 @@
       ]
     },
     "dotnet-coverage": {
-      "version": "17.8.4",
+      "version": "17.9.3",
       "commands": [
         "dotnet-coverage"
       ]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Refer to https://hub.docker.com/_/microsoft-dotnet-sdk for available versions
-FROM mcr.microsoft.com/dotnet/sdk:7.0.302-jammy
+FROM mcr.microsoft.com/dotnet/sdk:7.0.401-jammy
 
 # Installing mono makes `dotnet test` work without errors even for net472.
 # But installing it takes a long time, so it's excluded by default.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <BaseIntermediateOutputPath>$(RepoRootPath)obj\$([MSBuild]::MakeRelative($(RepoRootPath), $(MSBuildProjectDirectory)))\</BaseIntermediateOutputPath>
     <BaseOutputPath Condition=" '$(BaseOutputPath)' == '' ">$(RepoRootPath)bin\$(MSBuildProjectName)\</BaseOutputPath>
     <PackageOutputPath>$(RepoRootPath)bin\Packages\$(Configuration)\NuGet\</PackageOutputPath>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>11</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <AnalysisLevel>latest</AnalysisLevel>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    <MicroBuildVersion>2.0.137</MicroBuildVersion>
+    <MicroBuildVersion>2.0.146</MicroBuildVersion>
     <CodeAnalysisVersion>3.11.0</CodeAnalysisVersion>
     <CodeAnalysisVersion Condition="'$(IsTestProject)'=='true'">4.4.0</CodeAnalysisVersion>
     <CodefixTestingVersion>1.1.1</CodefixTestingVersion>
@@ -36,10 +36,10 @@
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="7.0.0" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
-    <PackageVersion Include="xunit" Version="2.5.0" />
+    <PackageVersion Include="xunit" Version="2.5.3" />
     <PackageVersion Include="xunit.abstractions" Version="2.0.3" />
     <PackageVersion Include="Xunit.Combinatorial" Version="1.5.25" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.3" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />
     <PackageVersion Include="Xunit.StaFact" Version="1.1.11" />
   </ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.302",
+    "version": "7.0.401",
     "rollForward": "patch",
     "allowPrerelease": false
   },

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
-  <!-- Include and reference README in nuge package, if a README is in the project directory. -->
+  <!-- Include and reference README in nuget package, if a README is in the project directory. -->
   <PropertyGroup>
     <PackageReadmeFile Condition="Exists('README.md')">README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/test/Microsoft.VisualStudio.Threading.Tests/.editorconfig
+++ b/test/Microsoft.VisualStudio.Threading.Tests/.editorconfig
@@ -1,0 +1,5 @@
+[*.cs]
+# xUnit1030: Test methods should not call ConfigureAwait(false)
+dotnet_diagnostic.xUnit1030.severity = none
+# xUnit1031: Test methods should not use blocking task operations
+dotnet_diagnostic.xUnit1031.severity = none


### PR DESCRIPTION
- Fix typo in comment
- Bump MicroBuildVersion to 2.0.146
- Bump dotnet-coverage to 17.8.6
- Bump xunit from 2.5.0 to 2.5.1 (#219)
- Bump xunit.runner.visualstudio from 2.5.0 to 2.5.1 (#220)
- Bump powershell to 7.3.7
- Fix LangVersion at 11
- Bump dotnet-coverage to 17.8.7
- Revert "Bump dotnet-coverage to 17.8.7"
- Bump .NET SDK to 7.0.401
- Bump xunit.runner.visualstudio from 2.5.1 to 2.5.3 (#224)
- Bump dotnet-coverage from 17.8.6 to 17.9.1 (#222)
- Bump powershell from 7.3.7 to 7.3.8 (#221)
- Bump xunit from 2.5.1 to 2.5.2 (#223)
- Bump xunit from 2.5.2 to 2.5.3 (#226)
- Bump dotnet-coverage from 17.9.1 to 17.9.3 (#225)
- Handle new warnings
