### PR TITLE
Analyzer fixes

### DIFF
--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD103UseAsyncOptionAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD103UseAsyncOptionAnalyzerTests.cs
@@ -1314,6 +1314,31 @@ class Test {
         await CSVerify.VerifyAnalyzerAsync(test);
     }
 
+    [Fact]
+    public async Task DoNotRaiseInSyncLocalFunctionInsideAsyncMethod()
+    {
+        string test = """
+            using System.Threading.Tasks;
+
+            class SomeClass {
+                Task Foo()
+                {
+                    return Task.CompletedTask;
+
+                    void CompletionHandler()
+                    {
+                        this.Bar();
+                    }
+                }
+
+                void Bar() {}
+                Task BarAsync() => Task.CompletedTask;
+            }
+            """;
+
+        await CSVerify.VerifyAnalyzerAsync(test);
+    }
+
     private DiagnosticResult CreateDiagnostic(int line, int column, int length, string methodName)
         => CSVerify.Diagnostic(DescriptorNoAlternativeMethod).WithSpan(line, column, line, column + length).WithArguments(methodName);
 

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD110ObserveResultOfAsyncCallsAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD110ObserveResultOfAsyncCallsAnalyzerTests.cs
@@ -430,6 +430,21 @@ class Test {
     }
 
     [Fact]
+    public async Task NullCoalescing_ProducesNoDiagnostic()
+    {
+        string test = """
+            using System.Threading.Tasks;
+
+            class Tree {
+                static Task ShakeTreeAsync(Tree? tree) => tree?.ShakeAsync() ?? Task.CompletedTask;
+                Task ShakeAsync() => Task.CompletedTask;
+            }
+            """;
+
+        await CSVerify.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
     public async Task TaskInFinalizer()
     {
         string test = @"
@@ -470,7 +485,4 @@ public async ValueTask DisposeAsync()
 
         await CSVerify.VerifyAnalyzerAsync(test);
     }
-
-    private DiagnosticResult CreateDiagnostic(int line, int column, int length)
-        => CSVerify.Diagnostic().WithSpan(line, column, line, column + length);
 }


### PR DESCRIPTION
##  Recognize local functions in VSTHRD103

This prevents false positives in synchronous local functions that appear within async methods.

Fixes #1003

## Add test to demonstrate that #881 no longer repros

Closes #881