### PR TITLE
VSTHRD003 analyzer false positive fixes

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD003UseJtfRunAsyncAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD003UseJtfRunAsyncAnalyzer.cs
@@ -201,7 +201,7 @@ public class VSTHRD003UseJtfRunAsyncAnalyzer : DiagnosticAnalyzer
                         // Search for assignments to the local and see if it was to a new object.
                         containingFunc ??= CSharpUtils.GetContainingFunction(focusedExpression);
                         if (containingFunc.Value.BlockOrExpression is not null &&
-                            CSharpUtils.FindAssignedValuesWithin(containingFunc.Value.BlockOrExpression, semanticModel, local, cancellationToken).Any(v => v is ObjectCreationExpressionSyntax))
+                            CSharpUtils.FindAssignedValuesWithin(containingFunc.Value.BlockOrExpression, semanticModel, local, cancellationToken).Any(v => v is ObjectCreationExpressionSyntax or ImplicitObjectCreationExpressionSyntax))
                         {
                             return null;
                         }

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD003UseJtfRunAsyncAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD003UseJtfRunAsyncAnalyzer.cs
@@ -198,10 +198,11 @@ public class VSTHRD003UseJtfRunAsyncAnalyzer : DiagnosticAnalyzer
                     if (memberAccessExpression.Expression is IdentifierNameSyntax identifier &&
                         semanticModel.GetSymbolInfo(identifier, cancellationToken).Symbol is ILocalSymbol local)
                     {
-                        // Search for assignments to the local and see if it was to a new object.
+                        // Search for assignments to the local and see if it was to a new object or the result of an invocation.
                         containingFunc ??= CSharpUtils.GetContainingFunction(focusedExpression);
                         if (containingFunc.Value.BlockOrExpression is not null &&
-                            CSharpUtils.FindAssignedValuesWithin(containingFunc.Value.BlockOrExpression, semanticModel, local, cancellationToken).Any(v => v is ObjectCreationExpressionSyntax or ImplicitObjectCreationExpressionSyntax))
+                            CSharpUtils.FindAssignedValuesWithin(containingFunc.Value.BlockOrExpression, semanticModel, local, cancellationToken).Any(
+                                v => v is ObjectCreationExpressionSyntax or ImplicitObjectCreationExpressionSyntax or InvocationExpressionSyntax))
                         {
                             return null;
                         }

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD003UseJtfRunAsyncAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD003UseJtfRunAsyncAnalyzer.cs
@@ -195,16 +195,30 @@ public class VSTHRD003UseJtfRunAsyncAnalyzer : DiagnosticAnalyzer
                     }
 
                     // Do not report a warning if the task is a member of an object that was created in this method.
-                    if (memberAccessExpression.Expression is IdentifierNameSyntax identifier &&
-                        semanticModel.GetSymbolInfo(identifier, cancellationToken).Symbol is ILocalSymbol local)
+                    if (memberAccessExpression.Expression is IdentifierNameSyntax identifier)
                     {
-                        // Search for assignments to the local and see if it was to a new object or the result of an invocation.
-                        containingFunc ??= CSharpUtils.GetContainingFunction(focusedExpression);
-                        if (containingFunc.Value.BlockOrExpression is not null &&
-                            CSharpUtils.FindAssignedValuesWithin(containingFunc.Value.BlockOrExpression, semanticModel, local, cancellationToken).Any(
-                                v => v is ObjectCreationExpressionSyntax or ImplicitObjectCreationExpressionSyntax or InvocationExpressionSyntax))
+                        ISymbol? symbol = semanticModel.GetSymbolInfo(identifier, cancellationToken).Symbol;
+                        switch (symbol)
                         {
-                            return null;
+                            case ILocalSymbol local:
+                                // Search for assignments to the local and see if it was to a new object or the result of an invocation.
+                                containingFunc ??= CSharpUtils.GetContainingFunction(focusedExpression);
+                                if (containingFunc.Value.BlockOrExpression is not null &&
+                                    CSharpUtils.FindAssignedValuesWithin(containingFunc.Value.BlockOrExpression, semanticModel, local, cancellationToken).Any(
+                                        v => v is ObjectCreationExpressionSyntax or ImplicitObjectCreationExpressionSyntax or InvocationExpressionSyntax))
+                                {
+                                    return null;
+                                }
+
+                                break;
+                            case IParameterSymbol parameter:
+                                // We allow returning members of a parameter in a lambda, to support `.Select(x => x.Completion)` syntax.
+                                if (parameter.ContainingSymbol is IMethodSymbol method && method.MethodKind == MethodKind.AnonymousFunction)
+                                {
+                                    return null;
+                                }
+
+                                break;
                         }
                     }
                 }

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/Helpers/CSharpCodeFixVerifier`2+Test.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/Helpers/CSharpCodeFixVerifier`2+Test.cs
@@ -73,7 +73,7 @@ public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
 
         protected override ParseOptions CreateParseOptions()
         {
-            return ((CSharpParseOptions)base.CreateParseOptions()).WithLanguageVersion(LanguageVersion.CSharp8);
+            return ((CSharpParseOptions)base.CreateParseOptions()).WithLanguageVersion(LanguageVersion.CSharp11);
         }
 
         private static string ReadManifestResource(Assembly assembly, string resourceName)

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD003UseJtfRunAsyncAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD003UseJtfRunAsyncAnalyzerTests.cs
@@ -1402,6 +1402,32 @@ class Tests
         await CSVerify.VerifyAnalyzerAsync(test);
     }
 
+    [Fact]
+    public async Task DoNotReportWarningWhenReturningTaskFromLambdaArgument()
+    {
+        var test = """
+            using System.Linq;
+            using System.Threading.Tasks;
+            
+            class JsonRpc
+            {
+                internal static JsonRpc Attach() => throw new System.NotImplementedException();
+            
+                internal Task Completion { get; }
+            }
+            
+            class Tests
+            {
+                static async Task ListenAndWait()
+                {
+                    JsonRpc[] rpcs = new [] { JsonRpc.Attach(), JsonRpc.Attach() };
+                    await Task.WhenAll(rpcs.Select(r => r.Completion));
+                }
+            }
+            """;
+        await CSVerify.VerifyAnalyzerAsync(test);
+    }
+
     private DiagnosticResult CreateDiagnostic(int line, int column, int length) =>
         CSVerify.Diagnostic().WithSpan(line, column, line, column + length);
 }

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD003UseJtfRunAsyncAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD003UseJtfRunAsyncAnalyzerTests.cs
@@ -1358,6 +1358,31 @@ class Tests
     }
 
     [Fact]
+    public async Task DoNotReportWarningWhenAwaitingTaskPropertyOfObjectReturnedFromMethodViaLocal()
+    {
+        var test = """
+            using System.Threading.Tasks;
+
+            class JsonRpc
+            {
+                internal static JsonRpc Attach() => throw new System.NotImplementedException();
+
+                internal Task Completion { get; }
+            }
+
+            class Tests
+            {
+                static async Task ListenAndWait()
+                {
+                    var jsonRpc = JsonRpc.Attach();
+                    await jsonRpc.Completion;
+                }
+            }
+            """;
+        await CSVerify.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
     public async Task ReportWarningWhenAwaitingTaskPropertyThatWasNotSetInContext()
     {
         var test = @"

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD003UseJtfRunAsyncAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD003UseJtfRunAsyncAnalyzerTests.cs
@@ -1310,6 +1310,29 @@ class Tests
         await CSVerify.VerifyAnalyzerAsync(test);
     }
 
+    [Fact]
+    public async Task DoNotReportWarningWhenAwaitingTaskPropertyOfObjectCreatedInContext_TargetTypeCreation()
+    {
+        string test = """
+            using System.Threading.Tasks;
+
+            class Test
+            {
+                static Task Exec2Async(string executable, params string[] args)
+                {
+                    Process p = new();
+                    return p.Task;
+                }
+            }
+
+            class Process
+            {
+                public Task Task { get; }
+            }
+            """;
+        await CSVerify.VerifyAnalyzerAsync(test);
+    }
+
     /// <summary>
     /// This is important to allow folks to return jtf.RunAsync(...).Task from a method.
     /// </summary>


### PR DESCRIPTION
This pull request to the Microsoft.VisualStudio.Threading.Analyzers.CSharp codebase includes modifications to the `AnalyzeAwaitExpression` method to support returning members of a parameter in a lambda, as well as new tests to verify that warnings are not reported in specific scenarios involving awaiting task properties and returning tasks from lambda arguments.

Main changes:

* <a href="diffhunk://#diff-301533a39b07cca182e799e5029a05ff29ba4d28833d62c1eda305aa223a7e94L198-R222">`src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD003UseJtfRunAsyncAnalyzer.cs`</a>: Modified the `AnalyzeAwaitExpression` method to allow returning members of a parameter in a lambda.
* <a href="diffhunk://#diff-14f9e94958e14aa9b5e8f1a2b716634569ad207fdba2fc53d28d6102532ce9bdR1313-R1335">`test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD003UseJtfRunAsyncAnalyzerTests.cs`</a>: Added three new tests to verify that warnings are not reported in specific scenarios involving awaiting task properties and returning tasks from lambda arguments. <a href="diffhunk://#diff-14f9e94958e14aa9b5e8f1a2b716634569ad207fdba2fc53d28d6102532ce9bdR1313-R1335">[1]</a> <a href="diffhunk://#diff-14f9e94958e14aa9b5e8f1a2b716634569ad207fdba2fc53d28d6102532ce9bdR1360-R1384">[2]</a> <a href="diffhunk://#diff-14f9e94958e14aa9b5e8f1a2b716634569ad207fdba2fc53d28d6102532ce9bdR1405-R1430">[3]</a>

Testing improvements:

* <a href="diffhunk://#diff-2160270e484cba1902abef19c782f9ee2515b5042338bf0a6dcd56efc8b20d9eL76-R76">`test/Microsoft.VisualStudio.Threading.Analyzers.Tests/Helpers/CSharpCodeFixVerifier``2+Test.cs`</a>: Updated `CreateParseOptions` method in `CSharpCodeFixVerifier` to set language version to CSharp11.