### PR TITLE
Add `AsyncLazy<T>.SuppressRecursiveFactoryDetection` property

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/net472/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/net472/PublicAPI.Unshipped.txt
@@ -13,4 +13,6 @@ Microsoft.VisualStudio.Threading.AsyncLazy<T>.DisposeValueAsync() -> System.Thre
 Microsoft.VisualStudio.Threading.AsyncLazy<T>.IsValueDisposed.get -> bool
 Microsoft.VisualStudio.Threading.AsyncLazy<T>.RevertRelevance
 Microsoft.VisualStudio.Threading.AsyncLazy<T>.RevertRelevance.Dispose() -> void
+Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRecursiveFactoryDetection.get -> bool
+Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRecursiveFactoryDetection.init -> void
 Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRelevance() -> Microsoft.VisualStudio.Threading.AsyncLazy<T>.RevertRelevance

--- a/src/Microsoft.VisualStudio.Threading/net6.0-windows/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/net6.0-windows/PublicAPI.Unshipped.txt
@@ -13,4 +13,6 @@ Microsoft.VisualStudio.Threading.AsyncLazy<T>.DisposeValueAsync() -> System.Thre
 Microsoft.VisualStudio.Threading.AsyncLazy<T>.IsValueDisposed.get -> bool
 Microsoft.VisualStudio.Threading.AsyncLazy<T>.RevertRelevance
 Microsoft.VisualStudio.Threading.AsyncLazy<T>.RevertRelevance.Dispose() -> void
+Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRecursiveFactoryDetection.get -> bool
+Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRecursiveFactoryDetection.init -> void
 Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRelevance() -> Microsoft.VisualStudio.Threading.AsyncLazy<T>.RevertRelevance

--- a/src/Microsoft.VisualStudio.Threading/net6.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/net6.0/PublicAPI.Unshipped.txt
@@ -13,4 +13,6 @@ Microsoft.VisualStudio.Threading.AsyncLazy<T>.DisposeValueAsync() -> System.Thre
 Microsoft.VisualStudio.Threading.AsyncLazy<T>.IsValueDisposed.get -> bool
 Microsoft.VisualStudio.Threading.AsyncLazy<T>.RevertRelevance
 Microsoft.VisualStudio.Threading.AsyncLazy<T>.RevertRelevance.Dispose() -> void
+Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRecursiveFactoryDetection.get -> bool
+Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRecursiveFactoryDetection.init -> void
 Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRelevance() -> Microsoft.VisualStudio.Threading.AsyncLazy<T>.RevertRelevance

--- a/src/Microsoft.VisualStudio.Threading/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/netstandard2.0/PublicAPI.Unshipped.txt
@@ -13,4 +13,6 @@ Microsoft.VisualStudio.Threading.AsyncLazy<T>.DisposeValueAsync() -> System.Thre
 Microsoft.VisualStudio.Threading.AsyncLazy<T>.IsValueDisposed.get -> bool
 Microsoft.VisualStudio.Threading.AsyncLazy<T>.RevertRelevance
 Microsoft.VisualStudio.Threading.AsyncLazy<T>.RevertRelevance.Dispose() -> void
+Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRecursiveFactoryDetection.get -> bool
+Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRecursiveFactoryDetection.init -> void
 Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRelevance() -> Microsoft.VisualStudio.Threading.AsyncLazy<T>.RevertRelevance

--- a/test/Microsoft.VisualStudio.Threading.Tests/AsyncLazyTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/AsyncLazyTests.cs
@@ -6,10 +6,13 @@ using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Microsoft;
 using Microsoft.VisualStudio.Threading;
+
 using Xunit;
 using Xunit.Abstractions;
+
 using NamedSyncContext = AwaitExtensionsTests.NamedSyncContext;
 
 public class AsyncLazyTests : TestBase
@@ -711,6 +714,105 @@ public class AsyncLazyTests : TestBase
                 return 1;
             },
             jtf);
+
+        bool fireAndForgetCodeAsyncEntered = false;
+        bool fireAndForgetCodeAsyncReachedUIThread = false;
+        jtf.Run(async delegate
+        {
+            Task<int> lazyValue = asyncLazy.GetValueAsync();
+            Assert.True(fireAndForgetCodeAsyncEntered);
+            await Task.Delay(AsyncDelay);
+            Assert.False(fireAndForgetCodeAsyncReachedUIThread);
+            allowValueFactoryToFinish.Set();
+
+            // Assert that the value factory was allowed to finish.
+            Assert.Equal(1, await lazyValue.WithCancellation(this.TimeoutToken));
+        });
+
+        // Run a main thread pump so the fire-and-forget task can finish.
+        SingleThreadedTestSynchronizationContext.PushFrame(SynchronizationContext.Current!, frame);
+
+        // Assert that the fire-and-forget task was allowed to finish and did so without throwing.
+        Assert.Equal(1, await fireAndForgetTask!.WithCancellation(this.TimeoutToken));
+
+        async Task<int> FireAndForgetCodeAsync()
+        {
+            fireAndForgetCodeAsyncEntered = true;
+
+            // Yield the caller's thread.
+            // Resuming will require the main thread, since the caller was on the main thread.
+            await Task.Yield();
+
+            fireAndForgetCodeAsyncReachedUIThread = true;
+
+            int result = await asyncLazy.GetValueAsync();
+            frame.Continue = false;
+            return result;
+        }
+    }
+
+    [Fact]
+    public async Task SuppressRecursiveFactoryDetection_WithoutJTF()
+    {
+        AsyncManualResetEvent allowValueFactoryToFinish = new();
+        Task<int>? fireAndForgetTask = null;
+        AsyncLazy<int> asyncLazy = null!;
+        asyncLazy = new AsyncLazy<int>(
+            async delegate
+            {
+                fireAndForgetTask = FireAndForgetCodeAsync();
+                await allowValueFactoryToFinish;
+                return 1;
+            },
+            null)
+        {
+            SuppressRecursiveFactoryDetection = true,
+        };
+
+        bool fireAndForgetCodeAsyncEntered = false;
+        Task<int> lazyValue = asyncLazy.GetValueAsync();
+        Assert.True(fireAndForgetCodeAsyncEntered);
+        allowValueFactoryToFinish.Set();
+
+        // Assert that the value factory was allowed to finish.
+        Assert.Equal(1, await lazyValue.WithCancellation(this.TimeoutToken));
+
+        // Assert that the fire-and-forget task was allowed to finish and did so without throwing.
+        Assert.Equal(1, await fireAndForgetTask!.WithCancellation(this.TimeoutToken));
+
+        async Task<int> FireAndForgetCodeAsync()
+        {
+            fireAndForgetCodeAsyncEntered = true;
+            return await asyncLazy.GetValueAsync();
+        }
+    }
+
+    [Theory, PairwiseData]
+    public async Task SuppressRecursiveFactoryDetection_WithJTF(bool suppressWithJTF)
+    {
+        JoinableTaskContext? context = this.InitializeJTCAndSC();
+        SingleThreadedTestSynchronizationContext.IFrame frame = SingleThreadedTestSynchronizationContext.NewFrame();
+
+        JoinableTaskFactory? jtf = context.Factory;
+        AsyncManualResetEvent allowValueFactoryToFinish = new();
+        Task<int>? fireAndForgetTask = null;
+        AsyncLazy<int> asyncLazy = null!;
+        asyncLazy = new AsyncLazy<int>(
+            async delegate
+            {
+                using (suppressWithJTF ? jtf.Context.SuppressRelevance() : default)
+                using (suppressWithJTF ? default : asyncLazy.SuppressRelevance())
+                {
+                    fireAndForgetTask = FireAndForgetCodeAsync();
+                }
+
+                await allowValueFactoryToFinish;
+                return 1;
+            },
+            jtf)
+        {
+            SuppressRecursiveFactoryDetection = true,
+        };
 
         bool fireAndForgetCodeAsyncEntered = false;
         bool fireAndForgetCodeAsyncReachedUIThread = false;


### PR DESCRIPTION
This allows folks to opt-out of the recursive detection altogether, such that `AsyncLazy<T>.SuppressRelevance()` isn't required (though that call would still carry out the JTF suppression function).