### PR TITLE
Don't package reference inbox assemblies on .NETCoreApp

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes.csproj
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes.csproj
@@ -35,8 +35,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" />
-    <PackageReference Include="System.ValueTuple" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Microsoft.VisualStudio.Threading.Analyzers.csproj
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Microsoft.VisualStudio.Threading.Analyzers.csproj
@@ -25,7 +25,5 @@
     <PackageReference Include="Nullable" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" />
-    <PackageReference Include="System.ValueTuple" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.VisualStudio.Threading/Microsoft.VisualStudio.Threading.csproj
+++ b/src/Microsoft.VisualStudio.Threading/Microsoft.VisualStudio.Threading.csproj
@@ -42,10 +42,10 @@
   <ItemGroup>
     <PackageReference Include="Nullable" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="all" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
     <PackageReference Include="Microsoft.VisualStudio.Validation" />
-    <PackageReference Include="Microsoft.Win32.Registry" />
+    <PackageReference Include="Microsoft.Win32.Registry" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
     <PackageReference Include="Microsoft.Windows.CsWin32" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
- Microsoft.Win32.Registry got added to the .NETCoreApp shared framework with .NET 5.
- System.Threading.Tasks.Extensions has been part of the shared framework since I believe .NET Core 2.0.
- Microsoft.Bcl.AsyncInterfaces since .NET Core 2.1.

Don't reference these packages on .NETCoreApp to reduce the dependency graph and with that potential CVEs / CG warnings.