### PR TITLE
Implements OnMainThreadBlocked.

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskContext.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskContext.cs
@@ -158,7 +158,6 @@ public partial class JoinableTaskContext : IDisposable
     public JoinableTaskContext()
         : this(Thread.CurrentThread, SynchronizationContext.Current)
     {
-        this.nonPostJoinableTaskFactory = new NonPostJoinableTaskFactory(this);
     }
 
     /// <summary>
@@ -176,6 +175,7 @@ public partial class JoinableTaskContext : IDisposable
         this.MainThread = mainThread ?? Thread.CurrentThread;
         this.mainThreadManagedThreadId = this.MainThread.ManagedThreadId;
         this.UnderlyingSynchronizationContext = synchronizationContext ?? SynchronizationContext.Current; // may still be null after this.
+        this.nonPostJoinableTaskFactory = new NonPostJoinableTaskFactory(this);
     }
 
     /// <summary>

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskContext.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskContext.cs
@@ -1038,8 +1038,10 @@ public partial class JoinableTaskContext : IDisposable
                         {
                             taskCompletion.SetCanceled();
                         }
-
-                        taskCompletion.SetResult(true);
+                        else
+                        {
+                            taskCompletion.SetResult(true);
+                        }
 
                         // ensure the cancellation registration is disposed.
                         awaiter.GetResult();

--- a/src/Microsoft.VisualStudio.Threading/ThreadingTools.cs
+++ b/src/Microsoft.VisualStudio.Threading/ThreadingTools.cs
@@ -144,6 +144,67 @@ public static class ThreadingTools
     }
 
     /// <summary>
+    /// Wait a long running or later finishing task, but abort if this work is blocking the main thread.
+    /// </summary>
+    /// <param name="context">The JoinableTaskContext.</param>
+    /// <param name="slowTask">A slow task to wait.</param>
+    /// <param name="cancellationToken">An optional cancellation token.</param>
+    /// <returns>A task is completed either the slow task is completed, or the input cancellation token is triggered, or the context task blocks the main thread (inside JTF.Run).</returns>
+    /// <exception cref="OperationCanceledException">Throw when the cancellation token is triggered or the current task blocks the main thread.</exception>
+    public static Task WaitUnlessBlockingMainThreadAsync(this JoinableTaskContext context, Task slowTask, CancellationToken cancellationToken = default)
+    {
+        Requires.NotNull(context, nameof(context));
+        Requires.NotNull(slowTask, nameof(slowTask));
+
+        if (slowTask.IsCompleted)
+        {
+            return slowTask;
+        }
+
+        if (context.AmbientTask is null)
+        {
+            return slowTask.WithCancellation(cancellationToken);
+        }
+
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled(cancellationToken);
+        }
+
+        return WaitUnlessBlockingMainThreadSlowAsync(context, slowTask, cancellationToken);
+
+        async Task WaitUnlessBlockingMainThreadSlowAsync(JoinableTaskContext context, Task slowTask, CancellationToken cancellationToken)
+        {
+            var taskCompletionSource = new TaskCompletionSource<bool>(slowTask);
+            using (context.OnMainThreadBlocked(
+                static s =>
+                {
+                    // prefer to complete normally if the inner task is completed.
+                    if (!((Task)s.Task.AsyncState!).IsCompleted)
+                    {
+                        s.TrySetResult(false);
+                    }
+                },
+                taskCompletionSource))
+            {
+                using (cancellationToken.Register(s => ((TaskCompletionSource<bool>)s!).TrySetResult(true), taskCompletionSource))
+                {
+                    if (slowTask != await Task.WhenAny(slowTask, taskCompletionSource.Task).ConfigureAwait(false))
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+
+                        // throw when the main thread is blocked
+                        throw new OperationCanceledException();
+                    }
+                }
+
+                // Rethrow any fault/cancellation exception, the task should be completed.
+                await slowTask;
+            }
+        }
+    }
+
+    /// <summary>
     /// Applies the specified <see cref="SynchronizationContext"/> to the caller's context.
     /// </summary>
     /// <param name="syncContext">The synchronization context to apply.</param>

--- a/src/Microsoft.VisualStudio.Threading/ThreadingTools.cs
+++ b/src/Microsoft.VisualStudio.Threading/ThreadingTools.cs
@@ -187,7 +187,7 @@ public static class ThreadingTools
                 },
                 taskCompletionSource))
             {
-                using (cancellationToken.Register(s => ((TaskCompletionSource<bool>)s!).TrySetResult(true), taskCompletionSource))
+                using (cancellationToken.Register(static s => ((TaskCompletionSource<bool>)s!).TrySetResult(true), taskCompletionSource))
                 {
                     if (slowTask != await Task.WhenAny(slowTask, taskCompletionSource.Task).ConfigureAwait(false))
                     {

--- a/src/Microsoft.VisualStudio.Threading/ThreadingTools.cs
+++ b/src/Microsoft.VisualStudio.Threading/ThreadingTools.cs
@@ -146,12 +146,12 @@ public static class ThreadingTools
     /// <summary>
     /// Wait a long running or later finishing task, but abort if this work is blocking the main thread.
     /// </summary>
-    /// <param name="context">The JoinableTaskContext.</param>
     /// <param name="slowTask">A slow task to wait.</param>
+    /// <param name="context">The JoinableTaskContext.</param>
     /// <param name="cancellationToken">An optional cancellation token.</param>
     /// <returns>A task is completed either the slow task is completed, or the input cancellation token is triggered, or the context task blocks the main thread (inside JTF.Run).</returns>
     /// <exception cref="OperationCanceledException">Throw when the cancellation token is triggered or the current task blocks the main thread.</exception>
-    public static Task WaitUnlessBlockingMainThreadAsync(this JoinableTaskContext context, Task slowTask, CancellationToken cancellationToken = default)
+    public static Task WaitUnlessBlockingMainThreadAsync(this Task slowTask, JoinableTaskContext context, CancellationToken cancellationToken = default)
     {
         Requires.NotNull(context, nameof(context));
         Requires.NotNull(slowTask, nameof(slowTask));

--- a/src/Microsoft.VisualStudio.Threading/net472/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/net472/PublicAPI.Unshipped.txt
@@ -17,4 +17,4 @@ Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRecursiveFactoryDetection.
 Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRecursiveFactoryDetection.init -> void
 Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRelevance() -> Microsoft.VisualStudio.Threading.AsyncLazy<T>.RevertRelevance
 Microsoft.VisualStudio.Threading.JoinableTaskContext.OnMainThreadBlocked<TState>(System.Action<TState>! action, TState state) -> System.IDisposable!
-static Microsoft.VisualStudio.Threading.ThreadingTools.WaitUnlessBlockingMainThreadAsync(this Microsoft.VisualStudio.Threading.JoinableTaskContext! context, System.Threading.Tasks.Task! slowTask, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+static Microsoft.VisualStudio.Threading.ThreadingTools.WaitUnlessBlockingMainThreadAsync(this System.Threading.Tasks.Task! slowTask, Microsoft.VisualStudio.Threading.JoinableTaskContext! context, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!

--- a/src/Microsoft.VisualStudio.Threading/net472/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/net472/PublicAPI.Unshipped.txt
@@ -17,3 +17,4 @@ Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRecursiveFactoryDetection.
 Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRecursiveFactoryDetection.init -> void
 Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRelevance() -> Microsoft.VisualStudio.Threading.AsyncLazy<T>.RevertRelevance
 Microsoft.VisualStudio.Threading.JoinableTaskContext.OnMainThreadBlocked<TState>(System.Action<TState>! action, TState state) -> System.IDisposable!
+static Microsoft.VisualStudio.Threading.ThreadingTools.WaitUnlessBlockingMainThreadAsync(this Microsoft.VisualStudio.Threading.JoinableTaskContext! context, System.Threading.Tasks.Task! slowTask, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!

--- a/src/Microsoft.VisualStudio.Threading/net472/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/net472/PublicAPI.Unshipped.txt
@@ -16,3 +16,4 @@ Microsoft.VisualStudio.Threading.AsyncLazy<T>.RevertRelevance.Dispose() -> void
 Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRecursiveFactoryDetection.get -> bool
 Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRecursiveFactoryDetection.init -> void
 Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRelevance() -> Microsoft.VisualStudio.Threading.AsyncLazy<T>.RevertRelevance
+Microsoft.VisualStudio.Threading.JoinableTaskContext.OnMainThreadBlocked<TState>(System.Action<TState>! action, TState state) -> System.IDisposable!

--- a/src/Microsoft.VisualStudio.Threading/net6.0-windows/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/net6.0-windows/PublicAPI.Unshipped.txt
@@ -17,4 +17,4 @@ Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRecursiveFactoryDetection.
 Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRecursiveFactoryDetection.init -> void
 Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRelevance() -> Microsoft.VisualStudio.Threading.AsyncLazy<T>.RevertRelevance
 Microsoft.VisualStudio.Threading.JoinableTaskContext.OnMainThreadBlocked<TState>(System.Action<TState>! action, TState state) -> System.IDisposable!
-static Microsoft.VisualStudio.Threading.ThreadingTools.WaitUnlessBlockingMainThreadAsync(this Microsoft.VisualStudio.Threading.JoinableTaskContext! context, System.Threading.Tasks.Task! slowTask, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+static Microsoft.VisualStudio.Threading.ThreadingTools.WaitUnlessBlockingMainThreadAsync(this System.Threading.Tasks.Task! slowTask, Microsoft.VisualStudio.Threading.JoinableTaskContext! context, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!

--- a/src/Microsoft.VisualStudio.Threading/net6.0-windows/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/net6.0-windows/PublicAPI.Unshipped.txt
@@ -17,3 +17,4 @@ Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRecursiveFactoryDetection.
 Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRecursiveFactoryDetection.init -> void
 Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRelevance() -> Microsoft.VisualStudio.Threading.AsyncLazy<T>.RevertRelevance
 Microsoft.VisualStudio.Threading.JoinableTaskContext.OnMainThreadBlocked<TState>(System.Action<TState>! action, TState state) -> System.IDisposable!
+static Microsoft.VisualStudio.Threading.ThreadingTools.WaitUnlessBlockingMainThreadAsync(this Microsoft.VisualStudio.Threading.JoinableTaskContext! context, System.Threading.Tasks.Task! slowTask, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!

--- a/src/Microsoft.VisualStudio.Threading/net6.0-windows/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/net6.0-windows/PublicAPI.Unshipped.txt
@@ -16,3 +16,4 @@ Microsoft.VisualStudio.Threading.AsyncLazy<T>.RevertRelevance.Dispose() -> void
 Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRecursiveFactoryDetection.get -> bool
 Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRecursiveFactoryDetection.init -> void
 Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRelevance() -> Microsoft.VisualStudio.Threading.AsyncLazy<T>.RevertRelevance
+Microsoft.VisualStudio.Threading.JoinableTaskContext.OnMainThreadBlocked<TState>(System.Action<TState>! action, TState state) -> System.IDisposable!

--- a/src/Microsoft.VisualStudio.Threading/net6.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/net6.0/PublicAPI.Unshipped.txt
@@ -17,4 +17,4 @@ Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRecursiveFactoryDetection.
 Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRecursiveFactoryDetection.init -> void
 Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRelevance() -> Microsoft.VisualStudio.Threading.AsyncLazy<T>.RevertRelevance
 Microsoft.VisualStudio.Threading.JoinableTaskContext.OnMainThreadBlocked<TState>(System.Action<TState>! action, TState state) -> System.IDisposable!
-static Microsoft.VisualStudio.Threading.ThreadingTools.WaitUnlessBlockingMainThreadAsync(this Microsoft.VisualStudio.Threading.JoinableTaskContext! context, System.Threading.Tasks.Task! slowTask, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+static Microsoft.VisualStudio.Threading.ThreadingTools.WaitUnlessBlockingMainThreadAsync(this System.Threading.Tasks.Task! slowTask, Microsoft.VisualStudio.Threading.JoinableTaskContext! context, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!

--- a/src/Microsoft.VisualStudio.Threading/net6.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/net6.0/PublicAPI.Unshipped.txt
@@ -17,3 +17,4 @@ Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRecursiveFactoryDetection.
 Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRecursiveFactoryDetection.init -> void
 Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRelevance() -> Microsoft.VisualStudio.Threading.AsyncLazy<T>.RevertRelevance
 Microsoft.VisualStudio.Threading.JoinableTaskContext.OnMainThreadBlocked<TState>(System.Action<TState>! action, TState state) -> System.IDisposable!
+static Microsoft.VisualStudio.Threading.ThreadingTools.WaitUnlessBlockingMainThreadAsync(this Microsoft.VisualStudio.Threading.JoinableTaskContext! context, System.Threading.Tasks.Task! slowTask, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!

--- a/src/Microsoft.VisualStudio.Threading/net6.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/net6.0/PublicAPI.Unshipped.txt
@@ -16,3 +16,4 @@ Microsoft.VisualStudio.Threading.AsyncLazy<T>.RevertRelevance.Dispose() -> void
 Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRecursiveFactoryDetection.get -> bool
 Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRecursiveFactoryDetection.init -> void
 Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRelevance() -> Microsoft.VisualStudio.Threading.AsyncLazy<T>.RevertRelevance
+Microsoft.VisualStudio.Threading.JoinableTaskContext.OnMainThreadBlocked<TState>(System.Action<TState>! action, TState state) -> System.IDisposable!

--- a/src/Microsoft.VisualStudio.Threading/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/netstandard2.0/PublicAPI.Unshipped.txt
@@ -17,4 +17,4 @@ Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRecursiveFactoryDetection.
 Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRecursiveFactoryDetection.init -> void
 Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRelevance() -> Microsoft.VisualStudio.Threading.AsyncLazy<T>.RevertRelevance
 Microsoft.VisualStudio.Threading.JoinableTaskContext.OnMainThreadBlocked<TState>(System.Action<TState>! action, TState state) -> System.IDisposable!
-static Microsoft.VisualStudio.Threading.ThreadingTools.WaitUnlessBlockingMainThreadAsync(this Microsoft.VisualStudio.Threading.JoinableTaskContext! context, System.Threading.Tasks.Task! slowTask, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+static Microsoft.VisualStudio.Threading.ThreadingTools.WaitUnlessBlockingMainThreadAsync(this System.Threading.Tasks.Task! slowTask, Microsoft.VisualStudio.Threading.JoinableTaskContext! context, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!

--- a/src/Microsoft.VisualStudio.Threading/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/netstandard2.0/PublicAPI.Unshipped.txt
@@ -17,3 +17,4 @@ Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRecursiveFactoryDetection.
 Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRecursiveFactoryDetection.init -> void
 Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRelevance() -> Microsoft.VisualStudio.Threading.AsyncLazy<T>.RevertRelevance
 Microsoft.VisualStudio.Threading.JoinableTaskContext.OnMainThreadBlocked<TState>(System.Action<TState>! action, TState state) -> System.IDisposable!
+static Microsoft.VisualStudio.Threading.ThreadingTools.WaitUnlessBlockingMainThreadAsync(this Microsoft.VisualStudio.Threading.JoinableTaskContext! context, System.Threading.Tasks.Task! slowTask, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!

--- a/src/Microsoft.VisualStudio.Threading/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/netstandard2.0/PublicAPI.Unshipped.txt
@@ -16,3 +16,4 @@ Microsoft.VisualStudio.Threading.AsyncLazy<T>.RevertRelevance.Dispose() -> void
 Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRecursiveFactoryDetection.get -> bool
 Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRecursiveFactoryDetection.init -> void
 Microsoft.VisualStudio.Threading.AsyncLazy<T>.SuppressRelevance() -> Microsoft.VisualStudio.Threading.AsyncLazy<T>.RevertRelevance
+Microsoft.VisualStudio.Threading.JoinableTaskContext.OnMainThreadBlocked<TState>(System.Action<TState>! action, TState state) -> System.IDisposable!

--- a/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskContextTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskContextTests.cs
@@ -1121,14 +1121,14 @@ public class JoinableTaskContextTests : JoinableTaskTestBase
         taskCompletionSource.SetResult(true);
 
         var cancellationSource = new CancellationTokenSource();
-        Assert.Equal(this.Context.WaitUnlessBlockingMainThreadAsync(taskCompletionSource.Task, cancellationSource.Token), taskCompletionSource.Task);
+        Assert.Equal(taskCompletionSource.Task.WaitUnlessBlockingMainThreadAsync(this.Context, cancellationSource.Token), taskCompletionSource.Task);
     }
 
     [Fact]
     public void WaitUnlessBlockingMainThreadAsyncReturnsTaskUnderSimpleCondition()
     {
         var taskCompletionSource = new TaskCompletionSource<bool>();
-        Assert.Equal(this.Context.WaitUnlessBlockingMainThreadAsync(taskCompletionSource.Task, CancellationToken.None), taskCompletionSource.Task);
+        Assert.Equal(taskCompletionSource.Task.WaitUnlessBlockingMainThreadAsync(this.Context, CancellationToken.None), taskCompletionSource.Task);
     }
 
     [Fact]
@@ -1137,7 +1137,7 @@ public class JoinableTaskContextTests : JoinableTaskTestBase
         var taskCompletionSource = new TaskCompletionSource<bool>();
 
         var cancellationSource = new CancellationTokenSource();
-        Task waitingTask = this.Context.WaitUnlessBlockingMainThreadAsync(taskCompletionSource.Task, cancellationSource.Token);
+        Task waitingTask = taskCompletionSource.Task.WaitUnlessBlockingMainThreadAsync(this.Context, cancellationSource.Token);
 
         Assert.False(waitingTask.IsCompleted);
         cancellationSource.Cancel();
@@ -1160,7 +1160,7 @@ public class JoinableTaskContextTests : JoinableTaskTestBase
             var taskCompletionSource = new TaskCompletionSource<bool>();
 
             var cancellationSource = new CancellationTokenSource();
-            Task waitingTask = this.Context.WaitUnlessBlockingMainThreadAsync(taskCompletionSource.Task, cancellationSource.Token);
+            Task waitingTask = taskCompletionSource.Task.WaitUnlessBlockingMainThreadAsync(this.Context, cancellationSource.Token);
 
             Assert.False(waitingTask.IsCompleted);
             cancellationSource.Cancel();
@@ -1184,7 +1184,7 @@ public class JoinableTaskContextTests : JoinableTaskTestBase
         var taskCompletionSource = new TaskCompletionSource<bool>();
 
         var cancellationSource = new CancellationTokenSource();
-        Task waitingTask = this.Context.WaitUnlessBlockingMainThreadAsync(taskCompletionSource.Task, cancellationSource.Token);
+        Task waitingTask = taskCompletionSource.Task.WaitUnlessBlockingMainThreadAsync(this.Context, cancellationSource.Token);
 
         Assert.False(waitingTask.IsCompleted);
         taskCompletionSource.SetResult(true);
@@ -1200,7 +1200,7 @@ public class JoinableTaskContextTests : JoinableTaskTestBase
             var taskCompletionSource = new TaskCompletionSource<bool>();
 
             var cancellationSource = new CancellationTokenSource();
-            Task waitingTask = this.Context.WaitUnlessBlockingMainThreadAsync(taskCompletionSource.Task, cancellationSource.Token);
+            Task waitingTask = taskCompletionSource.Task.WaitUnlessBlockingMainThreadAsync(this.Context, cancellationSource.Token);
 
             Assert.False(waitingTask.IsCompleted);
             taskCompletionSource.SetResult(true);
@@ -1219,7 +1219,7 @@ public class JoinableTaskContextTests : JoinableTaskTestBase
                 var taskCompletionSource = new TaskCompletionSource<bool>();
                 try
                 {
-                    await this.Context.WaitUnlessBlockingMainThreadAsync(taskCompletionSource.Task, CancellationToken.None);
+                    await taskCompletionSource.Task.WaitUnlessBlockingMainThreadAsync(this.Context, CancellationToken.None);
                     Assert.Fail("Expect to throw.");
                 }
                 catch (OperationCanceledException)
@@ -1242,7 +1242,7 @@ public class JoinableTaskContextTests : JoinableTaskTestBase
                 var cancellationSource = new CancellationTokenSource();
                 try
                 {
-                    await this.Context.WaitUnlessBlockingMainThreadAsync(taskCompletionSource.Task, cancellationSource.Token);
+                    await taskCompletionSource.Task.WaitUnlessBlockingMainThreadAsync(this.Context, cancellationSource.Token);
                     Assert.Fail("Expect to throw.");
                 }
                 catch (OperationCanceledException)
@@ -1263,7 +1263,7 @@ public class JoinableTaskContextTests : JoinableTaskTestBase
             var cancellationSource = new CancellationTokenSource();
             try
             {
-                await this.Context.WaitUnlessBlockingMainThreadAsync(taskCompletionSource.Task, cancellationSource.Token);
+                await taskCompletionSource.Task.WaitUnlessBlockingMainThreadAsync(this.Context, cancellationSource.Token);
                 Assert.Fail("Expect to throw.");
             }
             catch (OperationCanceledException)
@@ -1289,7 +1289,7 @@ public class JoinableTaskContextTests : JoinableTaskTestBase
             var cancellationSource = new CancellationTokenSource();
             try
             {
-                await this.Context.WaitUnlessBlockingMainThreadAsync(taskCompletionSource.Task, cancellationSource.Token);
+                await taskCompletionSource.Task.WaitUnlessBlockingMainThreadAsync(this.Context, cancellationSource.Token);
                 Assert.Fail("Expect to throw.");
             }
             catch (OperationCanceledException)
@@ -1314,7 +1314,7 @@ public class JoinableTaskContextTests : JoinableTaskTestBase
 
         JoinableTask firstTask = this.Context.Factory.RunAsync(async () =>
         {
-            await this.Context.WaitUnlessBlockingMainThreadAsync(taskCompletionSource.Task, cancellationSource.Token);
+            await taskCompletionSource.Task.WaitUnlessBlockingMainThreadAsync(this.Context, cancellationSource.Token);
         });
 
         Assert.False(firstTask.IsCompleted);


### PR DESCRIPTION
This PR is to address #1273.

It is to allow other feature to detect whether a blocking waiting task is actually blocking the main thread. It could allow code to detect certain deadlocks (for example, blocking to wait solution loading completion but the current task is blocking the solution to load.) Or it could raise the priority of the current task in a throttling queue (like design time build queue etc).
