### PR TITLE
Add `AsyncBarrier.SignalAndWait(CancellationToken)` overload

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/AsyncBarrier.cs
+++ b/src/Microsoft.VisualStudio.Threading/AsyncBarrier.cs
@@ -24,7 +24,7 @@ public class AsyncBarrier
     /// <summary>
     /// The set of participants who have reached the barrier, with their awaiters that can resume those participants.
     /// </summary>
-    private readonly Stack<TaskCompletionSource<EmptyStruct>> waiters;
+    private readonly Stack<Waiter> waiters;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AsyncBarrier"/> class.
@@ -37,15 +37,22 @@ public class AsyncBarrier
 
         // Allocate the stack so no resizing is necessary.
         // We don't need space for the last participant, since we never have to store it.
-        this.waiters = new Stack<TaskCompletionSource<EmptyStruct>>(participants - 1);
+        this.waiters = new Stack<Waiter>(participants - 1);
     }
+
+    /// <inheritdoc cref="SignalAndWait(CancellationToken)" />
+    public Task SignalAndWait() => this.SignalAndWait(CancellationToken.None).AsTask();
 
     /// <summary>
     /// Signals that a participant is ready, and returns a Task
     /// that completes when all other participants have also signaled ready.
     /// </summary>
-    /// <returns>A Task, which will complete (or may already be completed) when the last participant calls this method.</returns>
-    public Task SignalAndWait()
+    /// <param name="cancellationToken">
+    /// A token that signals the caller's lost interest in waiting.
+    /// The signal effect of the method is not canceled with the token.
+    /// </param>
+    /// <returns>A task which will complete (or may already be completed) when the last participant calls this method.</returns>
+    public ValueTask SignalAndWait(CancellationToken cancellationToken)
     {
         lock (this.waiters)
         {
@@ -55,24 +62,51 @@ public class AsyncBarrier
                 // Unleash everyone that preceded this one.
                 while (this.waiters.Count > 0)
                 {
-                    Task.Factory.StartNew(
-                        state => ((TaskCompletionSource<EmptyStruct>)state!).SetResult(default(EmptyStruct)),
-                        this.waiters.Pop(),
-                        CancellationToken.None,
-                        TaskCreationOptions.None,
-                        TaskScheduler.Default);
+                    Waiter waiter = this.waiters.Pop();
+                    waiter.CompletionSource.TrySetResult(default);
+                    waiter.CancellationRegistration.Dispose();
                 }
 
                 // And allow this one to continue immediately.
-                return Task.CompletedTask;
+                return new ValueTask(cancellationToken.IsCancellationRequested
+                    ? Task.FromCanceled(cancellationToken)
+                    : Task.CompletedTask);
             }
             else
             {
                 // We need more folks. So suspend this caller.
-                var tcs = new TaskCompletionSource<EmptyStruct>();
-                this.waiters.Push(tcs);
-                return tcs.Task;
+                TaskCompletionSource<EmptyStruct> tcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+                CancellationTokenRegistration ctr;
+                if (cancellationToken.CanBeCanceled)
+                {
+#if NET
+                    ctr = cancellationToken.Register(
+                        static (tcs, ct) => ((TaskCompletionSource<EmptyStruct>)tcs!).TrySetCanceled(ct), tcs);
+#else
+                    ctr = cancellationToken.Register(
+                        static s =>
+                        {
+                            var t = (Tuple<TaskCompletionSource<EmptyStruct>, CancellationToken>)s!;
+                            t.Item1.TrySetCanceled(t.Item2);
+                        },
+                        Tuple.Create(tcs, cancellationToken));
+#endif
+                }
+                else
+                {
+                    ctr = default;
+                }
+
+                this.waiters.Push(new Waiter(tcs, ctr));
+                return new ValueTask(tcs.Task);
             }
         }
+    }
+
+    private readonly struct Waiter(TaskCompletionSource<EmptyStruct> completionSource, CancellationTokenRegistration cancellationRegistration)
+    {
+        internal readonly TaskCompletionSource<EmptyStruct> CompletionSource => completionSource;
+
+        internal readonly CancellationTokenRegistration CancellationRegistration => cancellationRegistration;
     }
 }

--- a/src/Microsoft.VisualStudio.Threading/net472/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/net472/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+Microsoft.VisualStudio.Threading.AsyncBarrier.SignalAndWait(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask

--- a/src/Microsoft.VisualStudio.Threading/net6.0-windows/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/net6.0-windows/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+Microsoft.VisualStudio.Threading.AsyncBarrier.SignalAndWait(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask

--- a/src/Microsoft.VisualStudio.Threading/net6.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/net6.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+Microsoft.VisualStudio.Threading.AsyncBarrier.SignalAndWait(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask

--- a/src/Microsoft.VisualStudio.Threading/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+Microsoft.VisualStudio.Threading.AsyncBarrier.SignalAndWait(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask


### PR DESCRIPTION
Also optimize the pre-existing code.
The new overload returns `ValueTask` to leave open the option of optimizing to zero-allocation use via `IValueTaskSource`.

Closes #1329