### PR TITLE
Fix `JoinableTaskContext.serializedTasks` memory leak

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
@@ -927,10 +927,14 @@ public partial class JoinableTask : IJoinableTaskDependent
             {
                 if (!this.IsCompleteRequested)
                 {
+                    // This must be done *before* setting IsCompleteRequested so that the TaskId property will still return the value we need.
+                    ulong? taskId = this.token?.TaskId;
+
                     this.IsCompleteRequested = true;
-                    if (this.token?.TaskId is ulong taskId)
+
+                    if (taskId.HasValue)
                     {
-                        this.JoinableTaskContext.RemoveSerializableIdentifier(taskId);
+                        this.JoinableTaskContext.RemoveSerializableIdentifier(taskId.Value);
                     }
 
                     if (this.mainThreadQueue is object)


### PR DESCRIPTION
The collection of joinable tasks for which an ID is requested grew forever. The code that should purge completed tasks from the collection was never executing because the `TaskId` property is programmed to return `null` for completed tasks, and we query the property directly *after* setting the task as completed.

The fix then is simple: fetch the TaskId value *first* and *then* set the `JoinableTask` as completed.

@sharwell found this and reports that 179MB was held in memory due to this leak in one dump he investigated.

This fixes a memory leak that impacts versions as far back as 17.6. This PR only applies the fix to 17.12, but the commit itself is based on the original bug so the fix can be merged anywhere necessary.