### PR TITLE
Fix an invalid operation exception when enumerating RarelyRemoveItemSet.

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/RarelyRemoveItemSet`1.cs
+++ b/src/Microsoft.VisualStudio.Threading/RarelyRemoveItemSet`1.cs
@@ -205,7 +205,7 @@ internal struct RarelyRemoveItemSet<T>
 
                     case IndexBeforeFirstArrayElement:
                         this.currentIndex = 0;
-                        return true;
+                        return this.count > 0;
                 }
             }
 

--- a/test/Microsoft.VisualStudio.Threading.Tests/RarelyRemoveItemSetTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/RarelyRemoveItemSetTests.cs
@@ -128,6 +128,26 @@ public class RarelyRemoveItemSetTests : TestBase
     }
 
     [Fact]
+    public void RemoveFromTwoEnumeration()
+    {
+        var value1 = new GenericParameterHelper(1);
+        var value2 = new GenericParameterHelper(2);
+        this.list.Add(value1);
+        this.list.Add(value2);
+
+        this.list.Remove(value1);
+        this.list.Remove(value2);
+
+        int count = 0;
+        foreach (GenericParameterHelper item in this.list.EnumerateAndClear())
+        {
+            count++;
+        }
+
+        Assert.Equal(0, count);
+    }
+
+    [Fact]
     public void RemoveFromMultiple()
     {
         var values = new GenericParameterHelper[5];


### PR DESCRIPTION
An invalid operation exception was thrown inside JTF logic when it enumerates RarelyRemoveItemSet.

It happens in the middle of loading solution sometime.
