### PR TITLE
Update sos-threading tool to use NET 8 runtime

### DIFF
--- a/src/SosThreadingTools/SosThreadingTools.csproj
+++ b/src/SosThreadingTools/SosThreadingTools.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>net7.0-windows</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows</TargetFrameworks>
     <RuntimeIdentifiers>win-x86;win-x64</RuntimeIdentifiers>
     <ExtrasBuildEachRuntimeIdentifier>true</ExtrasBuildEachRuntimeIdentifier>
     <EnableDynamicLoading>true</EnableDynamicLoading>


### PR DESCRIPTION
NET 7 is out of support.