### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,6 +26,10 @@
 			"groupName": "Dockerfile and global.json updates"
 		},
 		{
+			"matchPackageNames": ["*"],
+			"allowedVersions": "!/-g[a-f0-9]+$/"
+		},
+		{
 			"matchPackageNames": [
 				"System.Collections.Immutable",
 				"System.Composition*",

--- a/.github/workflows/docs_validate.yml
+++ b/.github/workflows/docs_validate.yml
@@ -17,7 +17,7 @@ jobs:
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
     - name: 🔗 Markup Link Checker (mlc)
-      uses: becheran/mlc@v0.19.2
+      uses: becheran/mlc@v0.21.0
       with:
         args: --do-not-warn-for-redirect-to https://learn.microsoft.com*,https://dotnet.microsoft.com/*,https://dev.azure.com/*,https://app.codecov.io/*,https://badges.gitter.im/*,https://github.com/*,https://app.gitter.im/* -p docfx -i https://aka.ms/onboardsupport,https://aka.ms/spot,https://msrc.microsoft.com/*,https://www.microsoft.com/msrc*,https://microsoft.com/msrc*,https://microsoft.sharepoint.com/*
     - name: ⚙ Install prerequisites

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    <MicroBuildVersion>2.0.181</MicroBuildVersion>
+    <MicroBuildVersion>2.0.187</MicroBuildVersion>
     <CodeAnalysisVersion>3.11.0</CodeAnalysisVersion>
     <CodeAnalysisVersionForTests>4.12.0</CodeAnalysisVersionForTests>
     <CodefixTestingVersion>1.1.2</CodefixTestingVersion>
@@ -50,7 +50,7 @@
     <PackageVersion Update="Microsoft.CodeAnalysis.VisualBasic" Version="$(CodeAnalysisVersionForTests)" />
   </ItemGroup>
   <ItemGroup Label="Library.Template">
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Internal.MicroBuild.NonShipping" Version="$(MicroBuildVersion)" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />
     <PackageVersion Include="xunit" Version="2.9.3" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -52,7 +52,7 @@
   <ItemGroup Label="Library.Template">
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Internal.MicroBuild.NonShipping" Version="$(MicroBuildVersion)" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />
     <PackageVersion Include="xunit" Version="2.9.3" />
   </ItemGroup>
   <ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,7 @@
     <CodeAnalysisVersion>3.11.0</CodeAnalysisVersion>
     <CodeAnalysisVersionForTests>4.12.0</CodeAnalysisVersionForTests>
     <CodefixTestingVersion>1.1.2</CodefixTestingVersion>
-    <MicrosoftDiagnosticsRuntimeVersion>3.1.525101</MicrosoftDiagnosticsRuntimeVersion>
+    <MicrosoftDiagnosticsRuntimeVersion>3.0.442202</MicrosoftDiagnosticsRuntimeVersion>
     <CodeAnalysisAnalyzerVersion>3.11.0-beta1.24527.2</CodeAnalysisAnalyzerVersion>
   </PropertyGroup>
   <ItemGroup>
@@ -26,9 +26,9 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.XUnit" Version="$(CodefixTestingVersion)" />
     <PackageVersion Include="Microsoft.Diagnostics.Runtime.Utilities" Version="$(MicrosoftDiagnosticsRuntimeVersion)" />
     <PackageVersion Include="Microsoft.Diagnostics.Runtime" Version="$(MicrosoftDiagnosticsRuntimeVersion)" />
-    <PackageVersion Include="Microsoft.VisualStudio.Interop" Version="17.13.40002" />
-    <PackageVersion Include="Microsoft.VisualStudio.Shell.15.0" Version="17.13.40002" />
-    <PackageVersion Include="Microsoft.VisualStudio.Shell.Framework" Version="17.13.40002" />
+    <PackageVersion Include="Microsoft.VisualStudio.Interop" Version="17.12.40391" />
+    <PackageVersion Include="Microsoft.VisualStudio.Shell.15.0" Version="17.12.40392" />
+    <PackageVersion Include="Microsoft.VisualStudio.Shell.Framework" Version="17.12.40391" />
     <PackageVersion Include="Microsoft.VisualStudio.Validation" Version="17.8.8" />
     <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.162" />

--- a/azure-pipelines/install-dependencies.yml
+++ b/azure-pipelines/install-dependencies.yml
@@ -14,13 +14,13 @@ steps:
   - template: WIFtoPATauth.yml
     parameters:
       wifServiceConnectionName: azure-public/vside package pull
-      deadPATServiceConnectionId: 0ae39abc-4d06-4436-a7b5-865833df49db # azure-public/msft_consumption
+      deadPATServiceConnectionId: 46f0d4d4-9fff-4c58-a1ab-3b8f97e3b78a # azure-public/msft_consumption_public
 
 - task: NuGetAuthenticate@1
   displayName: 🔏 Authenticate NuGet feeds
   inputs:
     ${{ if and(parameters.needsAzurePublicFeeds, eq(variables['system.collectionId'], '011b8bdf-6d56-4f87-be0d-0092136884d9')) }}:
-      nuGetServiceConnections: azure-public/msft_consumption
+      nuGetServiceConnections: azure-public/msft_consumption_public
 
 - powershell: |
     $AccessToken = '$(System.AccessToken)' # Avoid specifying the access token directly on the init.ps1 command line to avoid it showing up in errors

--- a/nuget.config
+++ b/nuget.config
@@ -5,7 +5,7 @@
   </config>
   <packageSources>
     <clear />
-    <add key="msft_consumption" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/nuget/v3/index.json" />
+    <add key="msft_consumption_public" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption_public/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <!-- Defend against user or machine level disabling of sources that we list in this file. -->

--- a/src/SosThreadingTools/DumpAsyncCommand.cs
+++ b/src/SosThreadingTools/DumpAsyncCommand.cs
@@ -370,7 +370,7 @@ internal class DumpAsyncCommand : SOSLinkedCommand, ICommandHandler
                         {
                             if (visitedObjects.Add(stackObject.Address))
                             {
-                                ClrObject joinableTaskObject = stackObject.Type is null ? runtime.Heap.GetObject(stackObject.Address) : runtime.Heap.GetObject(stackObject.Address, stackObject.Type);
+                                var joinableTaskObject = new ClrObject(stackObject.Address, stackObject.Type);
                                 int state = joinableTaskObject.ReadField<int>("state");
                                 if ((state & 0x10) == 0x10)
                                 {


### PR DESCRIPTION
- **Renovate should not update to versions from non-release branches**
- **Drop group name in renovate**
- **Update xunit (#346)**
- **Switch nuget feed**
- **Update becheran/mlc action to v0.21.0 (#347)**
- **Update dependency Microsoft.NET.Test.Sdk to 17.13.0 (#348)**
- **Bump MicroBuildVersion to 2.0.187**
- **Rollback dependencies to publicly available versions**
