### PR TITLE
Fix super set for VSTHRD103

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD103UseAsyncOptionAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD103UseAsyncOptionAnalyzer.cs
@@ -163,7 +163,12 @@ public class VSTHRD103UseAsyncOptionAnalyzer : DiagnosticAnalyzer
         /// </returns>
         private static bool HasSupersetOfParameterTypes(IMethodSymbol candidateMethod, IMethodSymbol baselineMethod)
         {
-            return candidateMethod.Parameters.All(candidateParameter => baselineMethod.Parameters.Any(baselineParameter => baselineParameter.Type?.Equals(candidateParameter.Type, SymbolEqualityComparer.Default) ?? false));
+            if (baselineMethod.Parameters.Length > candidateMethod.Parameters.Length)
+            {
+                return false;
+            }
+
+            return baselineMethod.Parameters.All(baselineParameter => candidateMethod.Parameters.Any(candidateParameter => baselineParameter.Type?.Equals(candidateParameter.Type, SymbolEqualityComparer.Default) ?? false));
         }
 
         private static bool IsInTaskReturningMethodOrDelegate(SyntaxNodeAnalysisContext context)

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD103UseAsyncOptionAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD103UseAsyncOptionAnalyzerTests.cs
@@ -1339,6 +1339,30 @@ class Test {
         await CSVerify.VerifyAnalyzerAsync(test);
     }
 
+    [Fact]
+    public async Task DoNotRaiseForDistinctSyncMethod()
+    {
+        string test = @"
+using System.Threading.Tasks;
+
+class SomeClass {
+    Task Method(){
+        Bar(10, 11);
+        return Task.CompletedTask;
+    }
+
+    Task<int> Foo() => Task.FromResult(11);
+    async Task<int> BarAsync(int id) {
+        var number = await Foo();
+        return Bar(id, number);
+    }
+    int Bar(int id, int number) => id * number;
+}
+";
+
+        await CSVerify.VerifyAnalyzerAsync(test);
+    }
+
     private DiagnosticResult CreateDiagnostic(int line, int column, int length, string methodName)
         => CSVerify.Diagnostic(DescriptorNoAlternativeMethod).WithSpan(line, column, line, column + length).WithArguments(methodName);
 


### PR DESCRIPTION
Fixes bug raised here: https://github.com/microsoft/vs-threading/issues/1422

The method of HasSupersetOfParameterTypes confused me as I think the check was inverted?
I took the liberty to change that as well, but let me know if I overstepped.

Any and all feedback is appreciated

