### PR TITLE
Create a `Microsoft.VisualStudio.Threading.Only` package

### DIFF
--- a/Microsoft.VisualStudio.Threading.sln
+++ b/Microsoft.VisualStudio.Threading.sln
@@ -51,6 +51,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{C1DAF484-7
 		test\Directory.Build.targets = test\Directory.Build.targets
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.VisualStudio.Threading.JointPackage", "src\Microsoft.VisualStudio.Threading.JointPackage\Microsoft.VisualStudio.Threading.JointPackage.csproj", "{D149A8B3-A98F-4EDD-8C12-5CCDCBFB68DB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -137,6 +139,14 @@ Global
 		{8CDF7526-D625-4E16-A266-BAF654ABE181}.Release|Any CPU.Build.0 = Release|Any CPU
 		{8CDF7526-D625-4E16-A266-BAF654ABE181}.Release|NonWindows.ActiveCfg = Release|Any CPU
 		{8CDF7526-D625-4E16-A266-BAF654ABE181}.Release|NonWindows.Build.0 = Release|Any CPU
+		{D149A8B3-A98F-4EDD-8C12-5CCDCBFB68DB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D149A8B3-A98F-4EDD-8C12-5CCDCBFB68DB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D149A8B3-A98F-4EDD-8C12-5CCDCBFB68DB}.Debug|NonWindows.ActiveCfg = Debug|Any CPU
+		{D149A8B3-A98F-4EDD-8C12-5CCDCBFB68DB}.Debug|NonWindows.Build.0 = Debug|Any CPU
+		{D149A8B3-A98F-4EDD-8C12-5CCDCBFB68DB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D149A8B3-A98F-4EDD-8C12-5CCDCBFB68DB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D149A8B3-A98F-4EDD-8C12-5CCDCBFB68DB}.Release|NonWindows.ActiveCfg = Release|Any CPU
+		{D149A8B3-A98F-4EDD-8C12-5CCDCBFB68DB}.Release|NonWindows.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -152,6 +162,7 @@ Global
 		{7177DEEE-D14D-4A4A-BF6E-8B0CDC26B624} = {96134B19-FB32-4FA0-A565-BD4247D1E5B2}
 		{D5A0D627-7853-43F5-9AF4-E23D062C6ABA} = {96134B19-FB32-4FA0-A565-BD4247D1E5B2}
 		{8CDF7526-D625-4E16-A266-BAF654ABE181} = {96134B19-FB32-4FA0-A565-BD4247D1E5B2}
+		{D149A8B3-A98F-4EDD-8C12-5CCDCBFB68DB} = {96134B19-FB32-4FA0-A565-BD4247D1E5B2}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E2124DFF-970E-4BA1-9E50-3ADB0AABF347}

--- a/src/LibraryNuspecProperties.props
+++ b/src/LibraryNuspecProperties.props
@@ -1,0 +1,12 @@
+<Project>
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net8.0;net472</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(TargetFrameworks);net8.0-windows</TargetFrameworks>
+
+    <Description>Async synchronization primitives, async collections, TPL and dataflow extensions.
+      The JoinableTaskFactory allows synchronously blocking the UI thread for async work. This
+      package is applicable to any .NET application (not just Visual Studio).
+    </Description>
+    <PackageTags>Threading Async Lock Synchronization Threadsafe</PackageTags>
+  </PropertyGroup>
+</Project>

--- a/src/Microsoft.VisualStudio.Threading.JointPackage/Microsoft.VisualStudio.Threading.JointPackage.csproj
+++ b/src/Microsoft.VisualStudio.Threading.JointPackage/Microsoft.VisualStudio.Threading.JointPackage.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\LibraryNuspecProperties.props" />
+  <PropertyGroup>
+    <PackageId>Microsoft.VisualStudio.Threading</PackageId>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeSymbols>false</IncludeSymbols>
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\Microsoft.VisualStudio.Threading\README.md" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.VisualStudio.Threading.Analyzers.CodeFixes\Microsoft.VisualStudio.Threading.Analyzers.CodeFixes.csproj" />
+    <ProjectReference Include="..\Microsoft.VisualStudio.Threading\Microsoft.VisualStudio.Threading.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Microsoft.VisualStudio.Threading/Microsoft.VisualStudio.Threading.csproj
+++ b/src/Microsoft.VisualStudio.Threading/Microsoft.VisualStudio.Threading.csproj
@@ -1,17 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\LibraryNuspecProperties.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0;net472</TargetFrameworks>
-
-    <Summary>Async synchronization primitives, async collections, TPL and dataflow extensions.</Summary>
-    <Description>Async synchronization primitives, async collections, TPL and dataflow extensions.
-      The JoinableTaskFactory allows synchronously blocking the UI thread for async work. This
-      package is applicable to any .NET application (not just Visual Studio).</Description>
-    <PackageTags>Threading Async Lock Synchronization Threadsafe</PackageTags>
-
+    <PackageId>Microsoft.VisualStudio.Threading.Only</PackageId>
+    <Description>$(Description)
+      This package contains only the library, without a dependency on the analyzers.
+      Use the Microsoft.VisualStudio.Threading package to get the library and analyzers together.
+    </Description>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
-    <TargetFrameworks>$(TargetFrameworks);net8.0-windows</TargetFrameworks>
     <UseWPF Condition=" '$(TargetFramework)' != 'net8.0' ">true</UseWPF>
   </PropertyGroup>
   <ItemGroup>
@@ -33,12 +30,6 @@
     <PackageReference Include="Microsoft.VisualStudio.Validation" />
     <PackageReference Include="Microsoft.Win32.Registry" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
     <PackageReference Include="Microsoft.Windows.CsWin32" PrivateAssets="all" />
-  </ItemGroup>
-  <ItemGroup>
-    <!-- We don't consume the analyzers in this library itself,
-         but we reference the project to add a package dependency so users of this library will
-    automatically get the analyzers. -->
-    <ProjectReference Include="..\Microsoft.VisualStudio.Threading.Analyzers.CodeFixes\Microsoft.VisualStudio.Threading.Analyzers.CodeFixes.csproj" PrivateAssets="none" Condition="'$(ExcludeRestorePackageImports)' != ''" />
   </ItemGroup>
   <Import Project="OptProf.targets" Condition=" '$(TargetFramework)' == 'net472' " />
 </Project>


### PR DESCRIPTION
This new package has the library, but no analyzers dependency. The analyzers dependency is retained by the original `Microsoft.VisualStudio.Threading` package, along with a new dependency on the `Microsoft.VisualStudio.Threading.Only` package.

This allows consumers like StreamJsonRpc to express a dependency on `Microsoft.VisualStudio.Threading.Only` instead of `Microsoft.VisualStudio.Threading` in order to prevent its downstream users from having threading analyzers applied automatically, which they may not want.