### PR TITLE
Fix regression in inclusion of analyzer's built-in AdditionalFiles

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.JointPackage/Microsoft.VisualStudio.Threading.JointPackage.csproj
+++ b/src/Microsoft.VisualStudio.Threading.JointPackage/Microsoft.VisualStudio.Threading.JointPackage.csproj
@@ -13,8 +13,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.VisualStudio.Threading.Analyzers.CodeFixes\Microsoft.VisualStudio.Threading.Analyzers.CodeFixes.csproj" />
-    <ProjectReference Include="..\Microsoft.VisualStudio.Threading\Microsoft.VisualStudio.Threading.csproj" />
+    <ProjectReference Include="..\Microsoft.VisualStudio.Threading.Analyzers.CodeFixes\Microsoft.VisualStudio.Threading.Analyzers.CodeFixes.csproj" PrivateAssets="none" />
+    <ProjectReference Include="..\Microsoft.VisualStudio.Threading\Microsoft.VisualStudio.Threading.csproj" PrivateAssets="none" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Important metadata was accidentally [dropped in #1429](https://github.com/microsoft/vs-threading/pull/1429/files#diff-34192d5e83f5d2671fc9d53d52e5984ef968daa13dbecdb77d94b819afcba4a7) that resulted in consumers getting the analyzers but not the AdditionalFiles that the analyzers need to do their job properly. This change brings this metadata back.