### PR TITLE
Add `IPendingExecutionRequestState` interface to expose completion state of `SingleExecuteProtector`

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/IPendingExecutionRequestState.cs
+++ b/src/Microsoft.VisualStudio.Threading/IPendingExecutionRequestState.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.Threading
+{
+    /// <summary>
+    /// An optional interface implemented by pending request state posted to the underline synchronization context. It allows synchronization context to remove completed requests.
+    /// </summary>
+    public interface IPendingExecutionRequestState
+    {
+        /// <summary>
+        /// Gets a value indicating whether the current request has been completed, and can be skipped.
+        /// </summary>
+        bool IsCompleted { get; }
+    }
+}

--- a/src/Microsoft.VisualStudio.Threading/IPendingExecutionRequestState.cs
+++ b/src/Microsoft.VisualStudio.Threading/IPendingExecutionRequestState.cs
@@ -1,11 +1,16 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.VisualStudio.Threading
 {
     /// <summary>
     /// An optional interface implemented by pending request state posted to the underline synchronization context. It allows synchronization context to remove completed requests.
     /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Experimental("VSOnly")]
     public interface IPendingExecutionRequestState
     {
         /// <summary>

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
@@ -1058,7 +1058,7 @@ public partial class JoinableTaskFactory
     /// A delegate wrapper that ensures the delegate is only invoked at most once.
     /// </summary>
     [DebuggerDisplay("{DelegateLabel}")]
-    internal class SingleExecuteProtector
+    internal class SingleExecuteProtector : IPendingExecutionRequestState
     {
         /// <summary>
         /// Executes the delegate if it has not already executed.
@@ -1111,6 +1111,11 @@ public partial class JoinableTaskFactory
             Requires.NotNull(job, nameof(job));
             this.job = job;
         }
+
+        /// <summary>
+        /// Gets a value indicating whether the current request has been completed, and can be skipped.
+        /// </summary>
+        bool IPendingExecutionRequestState.IsCompleted => this.HasBeenExecuted;
 
         /// <summary>
         /// Gets a value indicating whether this instance has already executed.

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
@@ -1058,7 +1058,9 @@ public partial class JoinableTaskFactory
     /// A delegate wrapper that ensures the delegate is only invoked at most once.
     /// </summary>
     [DebuggerDisplay("{DelegateLabel}")]
+#pragma warning disable VSOnly // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     internal class SingleExecuteProtector : IPendingExecutionRequestState
+#pragma warning restore VSOnly // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     {
         /// <summary>
         /// Executes the delegate if it has not already executed.

--- a/src/Microsoft.VisualStudio.Threading/net472/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/net472/PublicAPI.Unshipped.txt
@@ -1,2 +1,4 @@
 Microsoft.VisualStudio.Threading.AsyncBarrier.SignalAndWait(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask
+Microsoft.VisualStudio.Threading.IPendingExecutionRequestState
+Microsoft.VisualStudio.Threading.IPendingExecutionRequestState.IsCompleted.get -> bool
 static Microsoft.VisualStudio.Threading.JoinableTaskContext.CreateNoOpContext() -> Microsoft.VisualStudio.Threading.JoinableTaskContext!

--- a/src/Microsoft.VisualStudio.Threading/net8.0-windows/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/net8.0-windows/PublicAPI.Unshipped.txt
@@ -1,2 +1,4 @@
 Microsoft.VisualStudio.Threading.AsyncBarrier.SignalAndWait(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask
+Microsoft.VisualStudio.Threading.IPendingExecutionRequestState
+Microsoft.VisualStudio.Threading.IPendingExecutionRequestState.IsCompleted.get -> bool
 static Microsoft.VisualStudio.Threading.JoinableTaskContext.CreateNoOpContext() -> Microsoft.VisualStudio.Threading.JoinableTaskContext!

--- a/src/Microsoft.VisualStudio.Threading/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/net8.0/PublicAPI.Unshipped.txt
@@ -1,2 +1,4 @@
 Microsoft.VisualStudio.Threading.AsyncBarrier.SignalAndWait(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask
+Microsoft.VisualStudio.Threading.IPendingExecutionRequestState
+Microsoft.VisualStudio.Threading.IPendingExecutionRequestState.IsCompleted.get -> bool
 static Microsoft.VisualStudio.Threading.JoinableTaskContext.CreateNoOpContext() -> Microsoft.VisualStudio.Threading.JoinableTaskContext!

--- a/src/Microsoft.VisualStudio.Threading/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Threading/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,2 +1,4 @@
 Microsoft.VisualStudio.Threading.AsyncBarrier.SignalAndWait(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask
+Microsoft.VisualStudio.Threading.IPendingExecutionRequestState
+Microsoft.VisualStudio.Threading.IPendingExecutionRequestState.IsCompleted.get -> bool
 static Microsoft.VisualStudio.Threading.JoinableTaskContext.CreateNoOpContext() -> Microsoft.VisualStudio.Threading.JoinableTaskContext!


### PR DESCRIPTION
For customized SynchronizationContext implementation, knowing whether a pending request has been completed could allow it to remove completed requests. Because JTF requests are potentially sent to multiple queues, including the JTF internal queue, many of those requests can be processed especially inside low priority or delayed queues. For low priority queue, completed tasks showing up for high memory usages. This new contract provides a way to make improvements.

This is only for advanced scenarios, common JTF consumers would not access the request or have chance to use it incorrectly.