### PR TITLE
Bump version height of 17.14

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
   "version": "17.14",
+  "buildNumberOffset": 3,
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/v\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
This is necessary because we built some 17.14 versions and then rewinded the branch.