### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "powershell": {
-      "version": "7.5.0",
+      "version": "7.5.1",
       "commands": [
         "pwsh"
       ],

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Refer to https://hub.docker.com/_/microsoft-dotnet-sdk for available versions
-FROM mcr.microsoft.com/dotnet/sdk:9.0.203-noble@sha256:2c9a4956a61fc45d9111fb36ec9fb86932e4842af9eb9bc9306bf8757f53674d
+FROM mcr.microsoft.com/dotnet/sdk:9.0.300-noble@sha256:9f7bd4d010026e15a57d9cf876f2f7d08c3eeed6a0ea987b8c5ba8c75e68e948
 
 # Installing mono makes `dotnet test` work without errors even for net472.
 # But installing it takes a long time, so it's excluded by default.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,6 +7,7 @@
     <BaseOutputPath Condition=" '$(BaseOutputPath)' == '' ">$(RepoRootPath)bin\$(MSBuildProjectName)\</BaseOutputPath>
     <PackageOutputPath>$(RepoRootPath)bin\Packages\$(Configuration)\NuGet\</PackageOutputPath>
     <VSIXOutputPath>$(RepoRootPath)bin\Packages\$(Configuration)\Vsix\$(Platform)\</VSIXOutputPath>
+    <SBOMFileDestPath>$(VSIXOutputPath)</SBOMFileDestPath>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <AnalysisLevel>latest</AnalysisLevel>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -49,9 +49,9 @@
     <PackageVersion Update="Microsoft.CodeAnalysis.VisualBasic" Version="$(CodeAnalysisVersionForTests)" />
   </ItemGroup>
   <ItemGroup Label="Library.Template">
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Internal.MicroBuild.NonShipping" Version="$(MicroBuildVersion)" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
   </ItemGroup>
   <ItemGroup>
@@ -61,7 +61,8 @@
     <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.1.593" />
     <GlobalPackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59" />
     <GlobalPackageReference Include="Microsoft.VisualStudio.Internal.MicroBuild.VisualStudio" Version="$(MicroBuildVersion)" />
-    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.7.115" />
+    <!-- The condition works around https://github.com/dotnet/sdk/issues/44951 -->
+    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.7.115" Condition="!('$(TF_BUILD)'=='true' and '$(dotnetformat)'=='true')" />
     <GlobalPackageReference Include="PolySharp" Version="1.15.0" />
     <GlobalPackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556" />
   </ItemGroup>

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,16 @@
+# Support
+
+## How to file issues and get help
+
+This project uses GitHub Issues to track bugs and feature requests.
+Please search the existing issues before filing new issues to avoid duplicates.
+For new issues, file your bug or feature request as a new Issue.
+
+Note that this repo is primarily used for Visual Studio and related products and support will be focused on those scenarios.
+
+## Microsoft Support Policy
+
+Microsoft support for this software is available only for its use in officially supported products such as Visual Studio.
+Support and servicing is limited to the latest released version.
+For more information, see [Visual Studio Product Lifecycle and Servicing](https://learn.microsoft.com/visualstudio/productinfo/vs-servicing).
+Assisted support is available from a professional support engineer by opening a ticket with the [Microsoft assisted support team](https://support.serviceshub.microsoft.com/supportforbusiness/onboarding).

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -198,8 +198,10 @@ jobs:
       IsOptProf: ${{ parameters.IsOptProf }}
 
   - ${{ if and(parameters.EnableDotNetFormatCheck, not(parameters.EnableLinuxBuild)) }}:
-    - script: dotnet format --verify-no-changes --no-restore
+    - script: dotnet format --verify-no-changes
       displayName: 💅 Verify formatted code
+      env:
+        dotnetformat: true # part of a workaround for https://github.com/dotnet/sdk/issues/44951
 
   - ${{ if eq(variables['system.collectionId'], '011b8bdf-6d56-4f87-be0d-0092136884d9') }}:
     - template: microbuild.after.yml
@@ -238,8 +240,10 @@ jobs:
           Is1ESPT: ${{ parameters.Is1ESPT }}
           RunTests: ${{ parameters.RunTests }}
       - ${{ if parameters.EnableDotNetFormatCheck }}:
-        - script: dotnet format --verify-no-changes --no-restore
+        - script: dotnet format --verify-no-changes
           displayName: 💅 Verify formatted code
+          env:
+            dotnetformat: true # part of a workaround for https://github.com/dotnet/sdk/issues/44951
 
   - ${{ if parameters.EnableMacOSBuild }}:
     - job: macOS
@@ -279,6 +283,8 @@ jobs:
       - macOS
     pool: ${{ parameters.windowsPool }} # Use Windows agent because PublishSymbols task requires it (https://github.com/microsoft/azure-pipelines-tasks/issues/13821).
     condition: succeededOrFailed()
+    variables:
+      ONEES_ENFORCED_CODEQL_ENABLED: false # CodeQL runs on build jobs, we don't need it here
     ${{ if eq(variables['system.collectionId'], '011b8bdf-6d56-4f87-be0d-0092136884d9') }}:
       templateContext:
         ${{ if not(parameters.RealSign) }}:

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.203",
+    "version": "9.0.300",
     "rollForward": "patch",
     "allowPrerelease": false
   },

--- a/tools/Get-3rdPartySymbolFiles.ps1
+++ b/tools/Get-3rdPartySymbolFiles.ps1
@@ -1,0 +1,91 @@
+Function Get-FileFromWeb([Uri]$Uri, $OutFile) {
+    $OutDir = Split-Path $OutFile
+    if (!(Test-Path $OutFile)) {
+        Write-Verbose "Downloading $Uri..."
+        if (!(Test-Path $OutDir)) { New-Item -ItemType Directory -Path $OutDir | Out-Null }
+        try {
+            (New-Object System.Net.WebClient).DownloadFile($Uri, $OutFile)
+        }
+        finally {
+            # This try/finally causes the script to abort
+        }
+    }
+}
+
+Function Unzip($Path, $OutDir) {
+    $OutDir = (New-Item -ItemType Directory -Path $OutDir -Force).FullName
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+    # Start by extracting to a temporary directory so that there are no file conflicts.
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($Path, "$OutDir.out")
+
+    # Now move all files from the temp directory to $OutDir, overwriting any files.
+    Get-ChildItem -Path "$OutDir.out" -Recurse -File | ForEach-Object {
+        $destinationPath = Join-Path -Path $OutDir -ChildPath $_.FullName.Substring("$OutDir.out".Length).TrimStart([io.path]::DirectorySeparatorChar, [io.path]::AltDirectorySeparatorChar)
+        if (!(Test-Path -Path (Split-Path -Path $destinationPath -Parent))) {
+            New-Item -ItemType Directory -Path (Split-Path -Path $destinationPath -Parent) | Out-Null
+        }
+        Move-Item -Path $_.FullName -Destination $destinationPath -Force
+    }
+    Remove-Item -Path "$OutDir.out" -Recurse -Force
+}
+
+Function Get-SymbolsFromPackage($id, $version) {
+    $symbolPackagesPath = "$PSScriptRoot/../obj/SymbolsPackages"
+    New-Item -ItemType Directory -Path $symbolPackagesPath -Force | Out-Null
+    $nupkgPath = Join-Path $symbolPackagesPath "$id.$version.nupkg"
+    $snupkgPath = Join-Path $symbolPackagesPath "$id.$version.snupkg"
+    $unzippedPkgPath = Join-Path $symbolPackagesPath "$id.$version"
+    Get-FileFromWeb -Uri "https://www.nuget.org/api/v2/package/$id/$version" -OutFile $nupkgPath
+    Get-FileFromWeb -Uri "https://www.nuget.org/api/v2/symbolpackage/$id/$version" -OutFile $snupkgPath
+
+    Unzip -Path $nupkgPath -OutDir $unzippedPkgPath
+    Unzip -Path $snupkgPath -OutDir $unzippedPkgPath
+
+    Get-ChildItem -Recurse -LiteralPath $unzippedPkgPath -Filter *.pdb | % {
+        # Collect the DLLs/EXEs as well.
+        $rootName = Join-Path $_.Directory $_.BaseName
+        if ($rootName.EndsWith('.ni')) {
+            $rootName = $rootName.Substring(0, $rootName.Length - 3)
+        }
+
+        $dllPath = "$rootName.dll"
+        $exePath = "$rootName.exe"
+        if (Test-Path $dllPath) {
+            $BinaryImagePath = $dllPath
+        }
+        elseif (Test-Path $exePath) {
+            $BinaryImagePath = $exePath
+        }
+        else {
+            Write-Warning "`"$_`" found with no matching binary file."
+            $BinaryImagePath = $null
+        }
+
+        if ($BinaryImagePath) {
+            Write-Output $BinaryImagePath
+            Write-Output $_.FullName
+        }
+    }
+}
+
+Function Get-PackageVersion($id) {
+    $versionProps = [xml](Get-Content -LiteralPath $PSScriptRoot\..\Directory.Packages.props)
+    $version = $versionProps.Project.ItemGroup.PackageVersion | ? { $_.Include -eq $id } | % { $_.Version }
+    if (!$version) {
+        Write-Error "No package version found in Directory.Packages.props for the package '$id'"
+    }
+
+    $version
+}
+
+# All 3rd party packages for which symbols packages are expected should be listed here.
+# These must all be sourced from nuget.org, as it is the only feed that supports symbol packages.
+$3rdPartyPackageIds = @()
+
+$3rdPartyPackageIds | % {
+    $version = Get-PackageVersion $_
+    if ($version) {
+        Get-SymbolsFromPackage -id $_ -version $version
+    }
+}

--- a/tools/Get-SymbolFiles.ps1
+++ b/tools/Get-SymbolFiles.ps1
@@ -43,7 +43,7 @@ $PDBs |% {
     }
 } |% {
     # Collect the DLLs/EXEs as well.
-    $rootName = "$($_.Directory)/$($_.BaseName)"
+    $rootName = Join-Path $_.Directory $_.BaseName
     if ($rootName.EndsWith('.ni')) {
         $rootName = $rootName.Substring(0, $rootName.Length - 3)
     }

--- a/tools/artifacts/symbols.ps1
+++ b/tools/artifacts/symbols.ps1
@@ -1,7 +1,10 @@
 $BinPath = [System.IO.Path]::GetFullPath("$PSScriptRoot/../../bin")
+$3rdPartyPath = [System.IO.Path]::GetFullPath("$PSScriptRoot/../../obj/SymbolsPackages")
 if (!(Test-Path $BinPath)) { return }
 $symbolfiles = & "$PSScriptRoot/../Get-SymbolFiles.ps1" -Path $BinPath | Get-Unique
+$3rdPartyFiles = & "$PSScriptRoot/../Get-3rdPartySymbolFiles.ps1"
 
 @{
     "$BinPath" = $SymbolFiles;
+    "$3rdPartyPath" = $3rdPartyFiles;
 }


### PR DESCRIPTION
- Reapply "Avoid `dotnet format` hang"
- Another CodeQL skip
- Revert "Opt in to the new MicroBuild SBOM behavior"
- Update actions/download-artifact digest to d3f86a1
- Update dependency powershell to 7.5.1
- Update mcr.microsoft.com/dotnet/sdk:9.0.203-noble Docker digest to c849687
- Reapply "Opt in to the new MicroBuild SBOM behavior"
- Deploy SBOMs next to the VSIX they describe
- Update xunit
- Update SUPPORT.md with links to product support
- Refine SUPPORT.md wording
- Add support for a repo to hard-code extra SDKs that must be installed
- Add script for collecting 3rd party symbol files
- Reapply "Avoid `dotnet format` hang"
- Fix 3rd party symbol archival
- Update Dockerfile and global.json updates to v9.0.300
- Update dependency Microsoft.NET.Test.Sdk to 17.14.0
- Update mcr.microsoft.com/dotnet/sdk:9.0.300-noble Docker digest to 9f7bd4d
- Update becheran/mlc action to v0.22.0
- Update dependency Microsoft.NET.Test.Sdk to 17.14.1
