### PR TITLE
Fix build breaks (via Library.Template update)

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -141,6 +141,9 @@ jobs:
         - ${{ if parameters.EnableOptProf }}:
           - powershell: Write-Host "##vso[task.setvariable variable=PROFILINGINPUTSDROPNAME]$(tools/variables/ProfilingInputsDropName.ps1)"
             displayName: ⚙ Set ProfilingInputsDropName for optprof
+      sdl:
+        binskim:
+          analyzeTargetGlob: $(Build.ArtifactStagingDirectory)\symbols-Windows\**
 
       outputParentDirectory: $(Build.ArtifactStagingDirectory)
       outputs:

--- a/azure-pipelines/microbuild.before.yml
+++ b/azure-pipelines/microbuild.before.yml
@@ -42,9 +42,8 @@ steps:
 
   - task: MicroBuildSigningPlugin@4
     inputs:
-      signType: Real
+      signType: Test
       zipSources: false
-      ConnectedPMEServiceName: 6cc74545-d7b9-4050-9dfa-ebefcc8961ea # devdiv's SC ID
     displayName: 🔧 Install MicroBuild Signing Plugin
 
   - ${{ if parameters.EnableLocalization }}:

--- a/samples/samples.csproj
+++ b/samples/samples.csproj
@@ -21,4 +21,8 @@
     </ProjectReference>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.Internal.MicroBuild.NonShipping" PrivateAssets="all" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Our builds recently started failing because binskim was including our recently added sample.dll, and because optprof runs were stale but couldn't run due to the new real signing requirement.

But optprof shouldn't need to be real-signed, and binskim should only scan shipping binaries.
I applied the fixes to Library.Template, and this then merges that in.