### PR TITLE
remove NotifyOfCrossThreadDependency call inside get_NoMessagePumpSynchronizationContext 

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskContext.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskContext.cs
@@ -302,11 +302,6 @@ public partial class JoinableTaskContext : IDisposable
     {
         get
         {
-            // Callers of this method are about to take a private lock, which tends
-            // to cause a deadlock while debugging because of lock contention with the
-            // debugger's expression evaluator. So prevent that.
-            Debugger.NotifyOfCrossThreadDependency();
-
             return NoMessagePumpSyncContext.Default;
         }
     }


### PR DESCRIPTION
When a debugger is attached, NotifyOfCrossThreadDependency will freeze the thread to send notification to the debugger. Because this NoMessagePumpSynchronizationContext is heavily used, including nested inside code holding the JTF lock already, this logic to call this debugger notification in a very common code path leads the process being debugged becomes extremely slow when JTF is heavily used.