### PR TITLE
reduce overhead when running in no main thread mode

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
@@ -320,7 +320,7 @@ public partial class JoinableTask : IJoinableTaskDependent
     {
         get
         {
-            if (this.JoinableTaskContext.IsOnMainThread)
+            if (this.JoinableTaskContext.IsOnMainThread && !this.JoinableTaskContext.IsNoOpContext)
             {
                 if (this.mainThreadJobSyncContext is null)
                 {

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
@@ -28,7 +28,7 @@ public partial class JoinableTaskFactory
     /// </summary>
     private readonly JoinableTaskContext owner;
 
-    private readonly SynchronizationContext mainThreadJobSyncContext;
+    private readonly SynchronizationContext? mainThreadJobSyncContext;
 
     /// <summary>
     /// The collection to add all created tasks to. May be <see langword="null" />.
@@ -71,7 +71,7 @@ public partial class JoinableTaskFactory
 
         this.owner = owner;
         this.jobCollection = collection;
-        this.mainThreadJobSyncContext = new JoinableTaskSynchronizationContext(this);
+        this.mainThreadJobSyncContext = owner.IsNoOpContext ? null : new JoinableTaskSynchronizationContext(this);
     }
 
     /// <summary>


### PR DESCRIPTION
The primary reason is IsOnMainThread only check the thread id matches the initial thread id, so it can be true if the task happens to start on the same thread pool thread to initialize the JoinableTaskContext in a no main thread application. It leads some unnecessary work, including marking the task main thread blocking, and tracking its dependent tasks.

All these work, including tracking nested factories seem to be unnecessary in this mode.