### PR TITLE
Retarget NativeAOT testing to .NET 10

### DIFF
--- a/test/NativeAOTCompatibility.Test/NativeAOTCompatibility.Test.csproj
+++ b/test/NativeAOTCompatibility.Test/NativeAOTCompatibility.Test.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\AOT.props" />
   <PropertyGroup>
-    <TargetFrameworks>net9.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
-    <TargetFrameworks>$(TargetFrameworks);net9.0-windows</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks);net10.0-windows</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/dirs.proj
+++ b/test/dirs.proj
@@ -2,7 +2,7 @@
   <ItemGroup>
     <ProjectReference Include="**\*.csproj" Exclude="NativeAOTCompatibility.Test\**" Publish="false" />
 
-    <MultiRIDProjectReference Include="NativeAOTCompatibility.Test\NativeAOTCompatibility.Test.csproj" TargetFramework="net9.0" />
-    <MultiRIDProjectReference Include="NativeAOTCompatibility.Test\NativeAOTCompatibility.Test.csproj" TargetFramework="net9.0-windows" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
+    <MultiRIDProjectReference Include="NativeAOTCompatibility.Test\NativeAOTCompatibility.Test.csproj" TargetFramework="net10.0" />
+    <MultiRIDProjectReference Include="NativeAOTCompatibility.Test\NativeAOTCompatibility.Test.csproj" TargetFramework="net10.0-windows" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This provides a higher level of validation, and removes the need for VS 2022 to be on the build agent.
