### PR TITLE
AsyncCrossProcessMutex: Fix foreground thread leak causing non-deterministic test host exit failure

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/AsyncCrossProcessMutex.cs
+++ b/src/Microsoft.VisualStudio.Threading/AsyncCrossProcessMutex.cs
@@ -56,6 +56,7 @@ public class AsyncCrossProcessMutex
         Requires.NotNullOrEmpty(name);
         this.namedMutexOwner = new Thread(this.MutexOwnerThread, 256 * 1024)
         {
+            IsBackground = true,
             Name = $"{nameof(AsyncCrossProcessMutex)}-{name}",
         };
         this.mutex = new Mutex(false, name);

--- a/test/Microsoft.VisualStudio.Threading.Tests/AsyncCrossProcessMutexTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/AsyncCrossProcessMutexTests.cs
@@ -72,7 +72,7 @@ public class AsyncCrossProcessMutexTests : TestBase, IDisposable
     public async Task EnterAsync_Contested()
     {
         // We don't allow attempted reentrancy, so create a new mutex object to use for the contested locks.
-        AsyncCrossProcessMutex mutex2 = new(this.mutex.Name);
+        using AsyncCrossProcessMutex mutex2 = new(this.mutex.Name);
 
         // Acquire and hold the mutex so that we can test timeout behavior.
         using (AsyncCrossProcessMutex.LockReleaser releaser = await this.mutex.EnterAsync())
@@ -95,7 +95,7 @@ public class AsyncCrossProcessMutexTests : TestBase, IDisposable
     public async Task TryEnterAsync_Contested()
     {
         // We don't allow attempted reentrancy, so create a new mutex object to use for the contested locks.
-        AsyncCrossProcessMutex mutex2 = new(this.mutex.Name);
+        using AsyncCrossProcessMutex mutex2 = new(this.mutex.Name);
 
         // Acquire and hold the mutex so that we can test timeout behavior.
         using (AsyncCrossProcessMutex.LockReleaser? releaser = await this.mutex.TryEnterAsync(Timeout.InfiniteTimeSpan))


### PR DESCRIPTION
## Problem

The CI build ([build 23092](https://dev.azure.com/azure-public/vside/_build/results?buildId=23092&view=logs&jobId=2d2b3007-3c5c-5840-9bb0-2b1ea49925f3&j=0da5d1d9-276d-5173-c4c4-9d4d4ed14fdb&t=09bcc455-e770-5f06-0452-f817068d38b7)) failed non-deterministically on both Linux and Windows with:

```
[FATAL ERROR] Foreground threads were left running, forcing process exit
```

All test assertions passed, but the xunit v3 / MTP v2 test host detected foreground threads still alive after the suite finished and force-killed the process with a non-zero exit code.

## Root Cause

`AsyncCrossProcessMutex` creates a dedicated owner thread that is a **foreground** thread by default. Two tests (`EnterAsync_Contested` and `TryEnterAsync_Contested`) created secondary `AsyncCrossProcessMutex` instances without disposing them, leaving those foreground threads alive after the tests completed. The test host then waited 10 seconds and killed the process.

This was non-deterministic because the timing of thread cleanup and GC finalization varied across runs.

## Fix

1. **Library**: Mark the mutex owner thread as `IsBackground = true` so an undisposed instance cannot prevent process exit. This matches the convention used by the other dedicated thread in `AwaitExtensions.cs`.
2. **Tests**: Add `using` declarations to the two tests that were missing disposal of secondary mutex instances.

## Validation

- Reproduced the exact failure locally by running only `AsyncCrossProcessMutexTests` -- all 3 TFMs failed with the same foreground-thread error.
- After the fix, ran the tests 5x consecutively with 0 failures across all TFMs.