### PR TITLE
Add `JoinableTaskFactory.DisableProcessing()`

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -82,5 +82,6 @@ dotnet run --no-build -c Release --framework net9.0 -- --list-tests
 ## Coding style
 
 * Honor StyleCop rules and fix any reported build warnings *after* getting tests to pass.
-* In C# files, use namespace *statements* instead of namespace *blocks* for all new files.
+* In C# files, use namespace *statements* instead of namespace *blocks* for all new files that define namespaces.
+* Test files are *not* expected to declare namespaces.
 * Add API doc comments to all new public and internal members.

--- a/samples/DisableProcessing.cs
+++ b/samples/DisableProcessing.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma warning disable VSTHRD103 // Call async methods when in an async method
+
+using System.IO;
+using Microsoft.VisualStudio.Threading;
+
+internal class DisableProcessing
+{
+    private readonly JoinableTaskFactory joinableTaskFactory = null!;
+
+    private void Simple()
+    {
+        #region Simple
+        this.joinableTaskFactory.Run(async delegate
+        {
+            this.joinableTaskFactory.DisableProcessing();
+
+            // Synchronous I/O and lock contentions will NOT result in any reentrancy within this JoinableTask.
+        });
+        #endregion
+    }
+
+    private void Exhaustive()
+    {
+        #region Exhaustive
+        this.joinableTaskFactory.Run(async delegate
+        {
+            // Async I/O isn't expected to synchronously block, and thus would never allow unwanted reentrancy.
+            string content = await File.ReadAllTextAsync(@"somefile.txt");
+
+            // Here, synchronous I/O and lock contentions MAY allow certain reentrancy (e.g. COM RPC messages).
+            content = File.ReadAllText(@"somefile.txt");
+
+            using (this.joinableTaskFactory.DisableProcessing())
+            {
+                // Within this block, synchronous I/O and lock contentions will NOT result in any reentrancy.
+                content = File.ReadAllText(@"somefile.txt");
+            }
+
+            // Just disable the synchronous wait message pump for the rest of this JoinableTask.
+            this.joinableTaskFactory.DisableProcessing();
+
+            // Sync I/O and lock contentions will NOT result in any reentrancy here.
+            content = File.ReadAllText(@"somefile.txt");
+        });
+        #endregion
+    }
+}

--- a/samples/Polyfill.cs
+++ b/samples/Polyfill.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if NETFRAMEWORK
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+internal static class PolyfillExtensions
+{
+    extension(File)
+    {
+        internal static Task<string> ReadAllTextAsync(string path) => throw new NotImplementedException();
+    }
+}
+
+#endif

--- a/samples/SuppressRelevance.cs
+++ b/samples/SuppressRelevance.cs
@@ -1,11 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Threading;
 
-public class SuppressRelevanceSample
+public class SuppressRelevance
 {
     private readonly ReentrantSemaphore semaphore = ReentrantSemaphore.Create(1, null, ReentrantSemaphore.ReentrancyMode.NotAllowed);
 
@@ -19,7 +18,7 @@ public class SuppressRelevanceSample
             await Task.Yield(); // represents some async work
 
             // Fire and forget code that uses the semaphore, but should *not*
-            // inherit our own posession of the semaphore.
+            // inherit our own possession of the semaphore.
             using (this.semaphore.SuppressRelevance())
             {
                 this.DoSomethingLaterAsync().Forget(); // Don't await this, or a deadlock will occur.

--- a/src/Microsoft.VisualStudio.Threading/DispatcherExtensions.cs
+++ b/src/Microsoft.VisualStudio.Threading/DispatcherExtensions.cs
@@ -27,6 +27,13 @@ public static class DispatcherExtensions
     /// and for each asynchronous return to the main thread after an <see langword="await"/>.
     /// </param>
     /// <returns>A <see cref="JoinableTaskFactory"/> that may be used for scheduling async work with the specified priority.</returns>
+    /// <remarks>
+    /// In addition to scheduling work on the UI thread with the specified priority,
+    /// this <see cref="JoinableTaskFactory"/> also ensures that any synchronous waits
+    /// on the main thread within <see cref="JoinableTask" /> objects created with the returned factory
+    /// will honor calls to <see cref="Dispatcher.DisableProcessing()" />, producing similar behavior
+    /// to <see cref="JoinableTaskFactory.DisableProcessing()" />.
+    /// </remarks>
     public static JoinableTaskFactory WithPriority(this JoinableTaskFactory joinableTaskFactory, Dispatcher dispatcher, DispatcherPriority priority)
     {
         Requires.NotNull(joinableTaskFactory, nameof(joinableTaskFactory));
@@ -61,6 +68,9 @@ public static class DispatcherExtensions
             : base(innerFactory)
         {
             this.dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+#if NETFRAMEWORK // Avoid trim warnings on .NET, and only .NET Framework calls CoWait anyway.
+            this.DefaultWaitPolicy = new DispatcherSynchronizationContext(dispatcher);
+#endif
             this.priority = priority;
         }
 

--- a/src/Microsoft.VisualStudio.Threading/JoinableTask+JoinableTaskSynchronizationContext.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTask+JoinableTaskSynchronizationContext.cs
@@ -2,11 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Windows.Win32;
+using Windows.Win32.Foundation;
 
 namespace Microsoft.VisualStudio.Threading
 {
@@ -65,6 +65,24 @@ namespace Microsoft.VisualStudio.Threading
             internal bool MainThreadAffinitized
             {
                 get { return this.mainThreadAffinitized; }
+            }
+
+            /// <summary>
+            /// Gets or sets a value indicating whether synchronous waits should prohibit any message pump (e.g. CoWait).
+            /// </summary>
+            /// <value>The default value is <see langword="false" />.</value>
+            internal bool DisableProcessing
+            {
+                get => field;
+                set
+                {
+                    field = value;
+                    if (value)
+                    {
+                        // This is required so that our override of Wait is invoked.
+                        this.SetWaitNotificationRequired();
+                    }
+                }
             }
 
             /// <summary>
@@ -132,6 +150,42 @@ namespace Microsoft.VisualStudio.Threading
                             TaskScheduler.Default).Wait();
                     }
                 }
+            }
+
+            /// <summary>
+            /// Synchronously blocks without a message pump.
+            /// </summary>
+            /// <param name="waitHandles">An array of type <see cref="IntPtr" /> that contains the native operating system handles.</param>
+            /// <param name="waitAll">true to wait for all handles; false to wait for any handle.</param>
+            /// <param name="millisecondsTimeout">The number of milliseconds to wait, or <see cref="Timeout.Infinite" /> (-1) to wait indefinitely.</param>
+            /// <returns>
+            /// The array index of the object that satisfied the wait.
+            /// </returns>
+            public override unsafe int Wait(IntPtr[] waitHandles, bool waitAll, int millisecondsTimeout)
+            {
+                Requires.NotNull(waitHandles, nameof(waitHandles));
+
+                if (this.DisableProcessing)
+                {
+                    // On .NET Framework we must take special care to NOT end up in a call to CoWait (which lets in RPC calls).
+                    // Off Windows, we can't p/invoke to kernel32, but it appears that .NET never calls CoWait, so we can rely on default behavior.
+                    // We're just going to use the OS as the switch instead of the runtime so that (one day) if we drop our .NET Framework specific target,
+                    // and if .NET ever adds CoWait support on Windows, we'll still behave properly.
+#if NET
+                    if (OperatingSystem.IsWindowsVersionAtLeast(5, 1, 2600))
+#else
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+#endif
+                    {
+                        fixed (IntPtr* pHandles = waitHandles)
+                        {
+                            return (int)PInvoke.WaitForMultipleObjects((uint)waitHandles.Length, (HANDLE*)pHandles, waitAll, (uint)millisecondsTimeout);
+                        }
+                    }
+                }
+
+                // Fallback to sync blocking such that CoWait might be called.
+                return WaitHelper(waitHandles, waitAll, millisecondsTimeout);
             }
 
             /// <summary>

--- a/src/Microsoft.VisualStudio.Threading/JoinableTask+JoinableTaskSynchronizationContext.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTask+JoinableTaskSynchronizationContext.cs
@@ -86,6 +86,25 @@ namespace Microsoft.VisualStudio.Threading
             }
 
             /// <summary>
+            /// Gets a <see cref="SynchronizationContext"/> on which <see cref="SynchronizationContext.Wait(IntPtr[], bool, int)"/>
+            /// should be called from <see cref="JoinableTaskSynchronizationContext.Wait(IntPtr[], bool, int)"/>
+            /// when <see cref="DisableProcessing()"/> has not been called.
+            /// </summary>
+            internal SynchronizationContext? DefaultWaitPolicy
+            {
+                get => field;
+                init
+                {
+                    field = value;
+                    if (value is not null)
+                    {
+                        // This is required so that our override of Wait is invoked.
+                        this.SetWaitNotificationRequired();
+                    }
+                }
+            }
+
+            /// <summary>
             /// Forwards the specified message to the job this instance belongs to if applicable; otherwise to the factory.
             /// </summary>
             public override void Post(SendOrPostCallback d, object? state)
@@ -182,6 +201,12 @@ namespace Microsoft.VisualStudio.Threading
                             return (int)PInvoke.WaitForMultipleObjects((uint)waitHandles.Length, (HANDLE*)pHandles, waitAll, (uint)millisecondsTimeout);
                         }
                     }
+                }
+
+                // Use a surrogate default policy if provided.
+                if (this.DefaultWaitPolicy is { } waitPolicy)
+                {
+                    return waitPolicy.Wait(waitHandles, waitAll, millisecondsTimeout);
                 }
 
                 // Fallback to sync blocking such that CoWait might be called.

--- a/src/Microsoft.VisualStudio.Threading/JoinableTask+JoinableTaskSynchronizationContext.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTask+JoinableTaskSynchronizationContext.cs
@@ -44,6 +44,11 @@ namespace Microsoft.VisualStudio.Threading
 
                 this.jobFactory = owner;
                 this.mainThreadAffinitized = true;
+
+                if (owner.DefaultWaitPolicy is not null)
+                {
+                    this.SetWaitNotificationRequired();
+                }
             }
 
             /// <summary>
@@ -56,6 +61,11 @@ namespace Microsoft.VisualStudio.Threading
             {
                 this.job = joinableTask;
                 this.mainThreadAffinitized = mainThreadAffinitized;
+
+                if (joinableTask.DisableProcessing > 0)
+                {
+                    this.SetWaitNotificationRequired();
+                }
             }
 
             /// <summary>
@@ -65,43 +75,6 @@ namespace Microsoft.VisualStudio.Threading
             internal bool MainThreadAffinitized
             {
                 get { return this.mainThreadAffinitized; }
-            }
-
-            /// <summary>
-            /// Gets or sets a value indicating whether synchronous waits should prohibit any message pump (e.g. CoWait).
-            /// </summary>
-            /// <value>The default value is <see langword="false" />.</value>
-            internal bool DisableProcessing
-            {
-                get => field;
-                set
-                {
-                    field = value;
-                    if (value)
-                    {
-                        // This is required so that our override of Wait is invoked.
-                        this.SetWaitNotificationRequired();
-                    }
-                }
-            }
-
-            /// <summary>
-            /// Gets a <see cref="SynchronizationContext"/> on which <see cref="SynchronizationContext.Wait(IntPtr[], bool, int)"/>
-            /// should be called from <see cref="JoinableTaskSynchronizationContext.Wait(IntPtr[], bool, int)"/>
-            /// when <see cref="DisableProcessing()"/> has not been called.
-            /// </summary>
-            internal SynchronizationContext? DefaultWaitPolicy
-            {
-                get => field;
-                init
-                {
-                    field = value;
-                    if (value is not null)
-                    {
-                        // This is required so that our override of Wait is invoked.
-                        this.SetWaitNotificationRequired();
-                    }
-                }
             }
 
             /// <summary>
@@ -184,7 +157,7 @@ namespace Microsoft.VisualStudio.Threading
             {
                 Requires.NotNull(waitHandles, nameof(waitHandles));
 
-                if (this.DisableProcessing)
+                if (this.job?.DisableProcessing > 0)
                 {
                     // On .NET Framework we must take special care to NOT end up in a call to CoWait (which lets in RPC calls).
                     // Off Windows, we can't p/invoke to kernel32, but it appears that .NET never calls CoWait, so we can rely on default behavior.
@@ -204,7 +177,7 @@ namespace Microsoft.VisualStudio.Threading
                 }
 
                 // Use a surrogate default policy if provided.
-                if (this.DefaultWaitPolicy is { } waitPolicy)
+                if (this.jobFactory.DefaultWaitPolicy is { } waitPolicy)
                 {
                     return waitPolicy.Wait(waitHandles, waitAll, millisecondsTimeout);
                 }
@@ -212,6 +185,8 @@ namespace Microsoft.VisualStudio.Threading
                 // Fallback to sync blocking such that CoWait might be called.
                 return WaitHelper(waitHandles, waitAll, millisecondsTimeout);
             }
+
+            internal void ConsiderDisableProcessing() => this.SetWaitNotificationRequired();
 
             /// <summary>
             /// Called by the joinable task when it has completed.

--- a/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
@@ -330,11 +330,7 @@ public partial class JoinableTask : IJoinableTaskDependent
                         {
                             if (this.mainThreadJobSyncContext is null)
                             {
-                                this.mainThreadJobSyncContext = new JoinableTaskSynchronizationContext(this, true)
-                                {
-                                    DisableProcessing = this.DisableProcessing,
-                                    DefaultWaitPolicy = this.owner.DefaultWaitPolicy,
-                                };
+                                this.mainThreadJobSyncContext = new JoinableTaskSynchronizationContext(this, true);
                             }
                         }
                     }
@@ -380,7 +376,7 @@ public partial class JoinableTask : IJoinableTaskDependent
     /// Gets or sets a value indicating whether CoWait will be prohibited
     /// during synchronously blocking waits from code actively running within this <see cref="JoinableTask"/>.
     /// </summary>
-    internal bool DisableProcessing
+    internal int DisableProcessing
     {
         get => field;
         set
@@ -388,7 +384,7 @@ public partial class JoinableTask : IJoinableTaskDependent
             field = value;
             if (this.mainThreadJobSyncContext is { } syncContext)
             {
-                syncContext.DisableProcessing = value;
+                syncContext.ConsiderDisableProcessing();
             }
         }
     }

--- a/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
@@ -333,6 +333,7 @@ public partial class JoinableTask : IJoinableTaskDependent
                                 this.mainThreadJobSyncContext = new JoinableTaskSynchronizationContext(this, true)
                                 {
                                     DisableProcessing = this.DisableProcessing,
+                                    DefaultWaitPolicy = this.owner.DefaultWaitPolicy,
                                 };
                             }
                         }

--- a/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTask.cs
@@ -330,7 +330,10 @@ public partial class JoinableTask : IJoinableTaskDependent
                         {
                             if (this.mainThreadJobSyncContext is null)
                             {
-                                this.mainThreadJobSyncContext = new JoinableTaskSynchronizationContext(this, true);
+                                this.mainThreadJobSyncContext = new JoinableTaskSynchronizationContext(this, true)
+                                {
+                                    DisableProcessing = this.DisableProcessing,
+                                };
                             }
                         }
                     }
@@ -368,6 +371,23 @@ public partial class JoinableTask : IJoinableTaskDependent
                     // If we're not blocking the threadpool, there is no reason to use a thread pool sync context.
                     return null;
                 }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether CoWait will be prohibited
+    /// during synchronously blocking waits from code actively running within this <see cref="JoinableTask"/>.
+    /// </summary>
+    internal bool DisableProcessing
+    {
+        get => field;
+        set
+        {
+            field = value;
+            if (this.mainThreadJobSyncContext is { } syncContext)
+            {
+                syncContext.DisableProcessing = value;
             }
         }
     }

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
@@ -328,13 +328,11 @@ public partial class JoinableTaskFactory
     /// Calling this method will replace the default implementation of <see cref="SynchronizationContext.Wait(IntPtr[], bool, int)"/>
     /// with one that will not allow such interruptions while that <see cref="JoinableTask"/> is active and in control of
     /// <see cref="SynchronizationContext.Current"/>.
+    /// As this method may be called multiple times, this effect remains until all <see cref="DisableProcessing"/> invocations'
+    /// return values are disposed (in any order).
     /// </para>
     /// <para>
     /// Disabling processing has no effect on non-Windows operating systems.
-    /// </para>
-    /// <para>
-    /// Nested calls to <see cref="DisableProcessing"/> are ignored. Only the outermost call has an effect on the behavior of the ambient <see cref="JoinableTask"/>
-    /// and only disposing the return value from the outermost call will restore the default behavior.
     /// </para>
     /// <para>
     /// Disposing the resulting value will revert to the default behavior.
@@ -756,11 +754,8 @@ public partial class JoinableTaskFactory
         /// <param name="owner">The owner of this struct.</param>
         internal ProcessingDisabledOperation(JoinableTask owner)
         {
-            if (owner.DisableProcessing is false)
-            {
-                owner.DisableProcessing = true;
-                this.owner = owner;
-            }
+            owner.DisableProcessing++;
+            this.owner = owner;
         }
 
         /// <inheritdoc/>
@@ -768,7 +763,7 @@ public partial class JoinableTaskFactory
         {
             if (this.owner is { } owner)
             {
-                owner.DisableProcessing = false;
+                owner.DisableProcessing--;
                 this.owner = null;
             }
         }

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
@@ -99,6 +99,17 @@ public partial class JoinableTaskFactory
     }
 
     /// <summary>
+    /// Gets a <see cref="SynchronizationContext"/> on which <see cref="SynchronizationContext.Wait(IntPtr[], bool, int)"/>
+    /// should be called from <see cref="JoinableTaskSynchronizationContext.Wait(IntPtr[], bool, int)"/>
+    /// when <see cref="DisableProcessing()"/> has not been called.
+    /// </summary>
+    /// <remarks>
+    /// This allows a WPF-aware <see cref="JoinableTaskFactory"/>-derived class within this assembly
+    /// to match <c>Dispatcher.DisableProcessing()</c> behavior.
+    /// </remarks>
+    internal SynchronizationContext? DefaultWaitPolicy { get; init; }
+
+    /// <summary>
     /// Gets or sets the timeout after which no activity while synchronously blocking
     /// suggests a hang has occurred.
     /// </summary>

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
@@ -294,6 +294,56 @@ public partial class JoinableTaskFactory
         return this.RunAsync(asyncMethod, synchronouslyBlocking: false, parentToken, creationOptions: creationOptions);
     }
 
+#pragma warning disable SA1629 // Documentation text should end with a period
+    /// <summary>
+    /// Prevents filtered message pumps from running during synchronous waits for the ambient <see cref="JoinableTask"/>.
+    /// </summary>
+    /// <returns>
+    /// A value that may be disposed of when the need to suppress synchronous wait message pumps is ended.
+    /// Alternatively it may be discarded if the rest of the <see cref="JoinableTask"/> is intended to have processing disabled.
+    /// </returns>
+    /// <exception cref="InvalidOperationException">Thrown when called outside the context of a <see cref="JoinableTask"/>.</exception>
+    /// <remarks>
+    /// <para>
+    /// During a yielding <see langword="await"/> within a <see cref="JoinableTask"/>, no message pump ever runs
+    /// regardless of whether this method is called, except for the internal one that lets in only relevant work.
+    /// When user code runs within the <see cref="JoinableTask"/> delegate or its callees that ends up requiring
+    /// a synchronous block of the main thread (e.g. synchronous I/O or lock contention), this wait is typically
+    /// implemented by calling <see cref="SynchronizationContext.Wait(IntPtr[], bool, int)"/> on <see cref="SynchronizationContext.Current"/>.
+    /// The default implementation of this method allows for certain interruptions (e.g. COM RPC calls), which
+    /// <em>may</em> avoid deadlocks in certain situations.
+    /// </para>
+    /// <para>
+    /// Calling this method will replace the default implementation of <see cref="SynchronizationContext.Wait(IntPtr[], bool, int)"/>
+    /// with one that will not allow such interruptions while that <see cref="JoinableTask"/> is active and in control of
+    /// <see cref="SynchronizationContext.Current"/>.
+    /// </para>
+    /// <para>
+    /// Disabling processing has no effect on non-Windows operating systems.
+    /// </para>
+    /// <para>
+    /// Nested calls to <see cref="DisableProcessing"/> are ignored. Only the outermost call has an effect on the behavior of the ambient <see cref="JoinableTask"/>
+    /// and only disposing the return value from the outermost call will restore the default behavior.
+    /// </para>
+    /// <para>
+    /// Disposing the resulting value will revert to the default behavior.
+    /// Callers need not ever dispose of this value if the intent is to disable processing for the remainder of that
+    /// <see cref="JoinableTask"/>'s execution.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <para>
+    /// Here is a simple, common usage of this method:
+    /// </para>
+    /// <code source="../../samples/DisableProcessing.cs" region="Simple" lang="C#" />
+    /// <para>
+    /// Following are more examples of how it might be used:
+    /// </para>
+    /// <code source="../../samples/DisableProcessing.cs" region="Exhaustive" lang="C#" />
+    /// </example>
+    public ProcessingDisabledOperation DisableProcessing() => new(this.Context.AmbientTask ?? throw new InvalidOperationException(Strings.NoAmbientTask));
+#pragma warning restore SA1629 // Documentation text should end with a period
+
     /// <summary>
     /// Responds to calls to <see cref="JoinableTaskFactory.MainThreadAwaiter.OnCompleted(Action)"/>
     /// by scheduling a continuation to execute on the Main thread.
@@ -679,6 +729,37 @@ public partial class JoinableTaskFactory
         {
             Environment.FailFast("Unexpected exception thrown in critical scheduling code.", ex);
             throw Assumes.NotReachable();
+        }
+    }
+
+    /// <summary>
+    /// A struct whose disposal will revert the effect of an earlier call to <see cref="DisableProcessing"/>.
+    /// </summary>
+    public struct ProcessingDisabledOperation : IDisposable
+    {
+        private JoinableTask? owner;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProcessingDisabledOperation"/> struct.
+        /// </summary>
+        /// <param name="owner">The owner of this struct.</param>
+        internal ProcessingDisabledOperation(JoinableTask owner)
+        {
+            if (owner.DisableProcessing is false)
+            {
+                owner.DisableProcessing = true;
+                this.owner = owner;
+            }
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            if (this.owner is { } owner)
+            {
+                owner.DisableProcessing = false;
+                this.owner = null;
+            }
         }
     }
 

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
@@ -328,8 +328,9 @@ public partial class JoinableTaskFactory
     /// Calling this method will replace the default implementation of <see cref="SynchronizationContext.Wait(IntPtr[], bool, int)"/>
     /// with one that will not allow such interruptions while that <see cref="JoinableTask"/> is active and in control of
     /// <see cref="SynchronizationContext.Current"/>.
-    /// As this method may be called multiple times, this effect remains until all <see cref="DisableProcessing"/> invocations'
-    /// return values are disposed (in any order).
+    /// As this method may be called multiple times, this effect remains on the target <see cref="JoinableTask"/>
+    /// until all <see cref="DisableProcessing"/> invocations' return values are disposed (in any order).
+    /// The effect only applies to the direct <see cref="JoinableTask"/>. It does not affect any of its children or parents.
     /// </para>
     /// <para>
     /// Disabling processing has no effect on non-Windows operating systems.

--- a/src/Microsoft.VisualStudio.Threading/NoMessagePumpSyncContext.cs
+++ b/src/Microsoft.VisualStudio.Threading/NoMessagePumpSyncContext.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Buffers;
 using System.Runtime.InteropServices;
 using System.Threading;
 using global::Windows.Win32;
@@ -52,10 +51,10 @@ public class NoMessagePumpSyncContext : SynchronizationContext
         Requires.NotNull(waitHandles, nameof(waitHandles));
 
         // On .NET Framework we must take special care to NOT end up in a call to CoWait (which lets in RPC calls).
-        // Off Windows, we can't p/invoke to kernel32, but it appears that .NET Core never calls CoWait, so we can rely on default behavior.
-        // We're just going to use the OS as the switch instead of the framework so that (one day) if we drop our .NET Framework specific target,
-        // and if .NET Core ever adds CoWait support on Windows, we'll still behave properly.
-#if NET5_0_OR_GREATER
+        // Off Windows, we can't p/invoke to kernel32, but it appears that .NET never calls CoWait, so we can rely on default behavior.
+        // We're just going to use the OS as the switch instead of the runtime so that (one day) if we drop our .NET Framework specific target,
+        // and if .NET ever adds CoWait support on Windows, we'll still behave properly.
+#if NET
         if (OperatingSystem.IsWindowsVersionAtLeast(5, 1, 2600))
 #else
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/src/Microsoft.VisualStudio.Threading/ReentrantSemaphore.cs
+++ b/src/Microsoft.VisualStudio.Threading/ReentrantSemaphore.cs
@@ -191,7 +191,7 @@ public abstract class ReentrantSemaphore : IDisposable
     /// <para>
     /// The following snippet demonstrates a way to use this method.
     /// </para>
-    /// <code source="../../samples/ApiSamples.cs" region="SuppressRelevance" lang="C#" />
+    /// <code source="../../samples/SuppressRelevance.cs" region="SuppressRelevance" lang="C#" />
     /// </example>
     public virtual RevertRelevance SuppressRelevance() => default;
 

--- a/src/Microsoft.VisualStudio.Threading/Strings.resx
+++ b/src/Microsoft.VisualStudio.Threading/Strings.resx
@@ -193,4 +193,7 @@
   <data name="SyncContextNotSet" xml:space="preserve">
     <value>No SynchronizationContext to reach the main thread has been set.</value>
   </data>
+  <data name="NoAmbientTask" xml:space="preserve">
+    <value>No JoinableTask is active.</value>
+  </data>
 </root>

--- a/test/Microsoft.VisualStudio.Threading.Tests/AsyncCrossProcessMutexTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/AsyncCrossProcessMutexTests.cs
@@ -157,14 +157,14 @@ public class AsyncCrossProcessMutexTests : TestBase, IDisposable
         using AsyncCrossProcessMutex mutex2 = new(this.mutex.Name);
 
         AsyncCrossProcessMutex.LockReleaser? abandonedReleaser = await this.mutex.TryEnterAsync(Timeout.InfiniteTimeSpan);
-        Assert.False(abandonedReleaser.Value.IsAbandoned);
+        Assert.False(abandonedReleaser?.IsAbandoned);
 
         // Dispose the mutex WITHOUT first releasing it.
         this.mutex.Dispose();
 
         using (AsyncCrossProcessMutex.LockReleaser? releaser2 = await mutex2.TryEnterAsync(Timeout.InfiniteTimeSpan))
         {
-            Assert.True(releaser2.Value.IsAbandoned);
+            Assert.True(releaser2?.IsAbandoned);
         }
     }
 

--- a/test/Microsoft.VisualStudio.Threading.Tests/CoWaitMainThreadTransition.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/CoWaitMainThreadTransition.cs
@@ -1,0 +1,199 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if NETFRAMEWORK
+
+using System;
+using System.Reflection;
+using System.Runtime.ExceptionServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+/// <summary>
+/// Probes whether the calling STA thread's current synchronous wait allows COM RPC calls to
+/// penetrate. Spawns an MTA thread that marshals a COM call back to the STA thread; the call
+/// succeeds if and only if the thread is performing a CoWait (message-pumping wait) rather than
+/// a plain <c>WaitForMultipleObjects</c> wait.
+/// </summary>
+/// <remarks>
+/// Create the probe before blocking the STA thread, then call <see cref="Wait"/> after unblocking
+/// to learn whether the COM call was delivered. Dispose when done to cancel any pending call and
+/// release resources.
+/// </remarks>
+public sealed class CoWaitMainThreadTransition : IDisposable
+{
+    /// <summary>Best-effort delay in milliseconds used when cancelling or joining the caller thread.</summary>
+    private const int CallCancellationDelayMs = 500;
+
+    private const int RpcECallCanceled = unchecked((int)0x80010002);
+
+    private static readonly Guid IDispatchGuid = new("00020400-0000-0000-C000-000000000046");
+
+    private readonly ManualResetEventSlim signalReceived = new();
+    private readonly ManualResetEventSlim callerReady = new();
+    private readonly Thread callerThread;
+    private Exception? backgroundFailure;
+    private uint callerThreadId;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CoWaitMainThreadTransition"/> class and
+    /// immediately starts the background MTA thread that will attempt the COM call.
+    /// </summary>
+    internal CoWaitMainThreadTransition()
+    {
+        IMainThreadSignaler signaler = new MainThreadSignaler(this.signalReceived);
+        IntPtr signalerInterface = Marshal.GetIDispatchForObject(signaler);
+        try
+        {
+            Marshal.ThrowExceptionForHR(NativeMethods.CoMarshalInterThreadInterfaceInStream(in IDispatchGuid, signalerInterface, out IntPtr stream));
+
+            this.callerThread = new Thread(() => this.InvokeSignalOnBackgroundThread(stream))
+            {
+                IsBackground = true,
+            };
+        }
+        finally
+        {
+            Marshal.Release(signalerInterface);
+        }
+
+#pragma warning disable CA1416 // Apartment state is only relevant on Windows, and the probe is not used elsewhere.
+        this.callerThread.SetApartmentState(ApartmentState.MTA);
+#pragma warning restore CA1416
+        this.callerThread.Start();
+    }
+
+    /// <summary>
+    /// A COM-visible IDispatch interface used to signal the main STA thread from an MTA background thread.
+    /// </summary>
+    [ComVisible(true)]
+    [Guid("A1D1F0E7-564F-4B9F-8DB2-D40185F115FB")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIDispatch)]
+    public interface IMainThreadSignaler
+    {
+        /// <summary>Signals the main thread that it has received a COM RPC call.</summary>
+        [DispId(1)]
+        void Signal();
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (this.callerThread.IsAlive)
+        {
+            this.CancelPendingCall();
+            _ = this.callerThread.Join(CallCancellationDelayMs);
+        }
+
+        this.callerReady.Dispose();
+        this.signalReceived.Dispose();
+    }
+
+    /// <summary>
+    /// Blocks until the COM call completes or <paramref name="timeout"/> elapses.
+    /// </summary>
+    /// <param name="timeout">The maximum time to wait.</param>
+    /// <returns>
+    /// <see langword="true"/> if the COM call was delivered within <paramref name="timeout"/>;
+    /// <see langword="false"/> if the call did not penetrate the wait (i.e., no CoWait was used).
+    /// </returns>
+    internal bool Wait(TimeSpan timeout)
+    {
+        bool interruptedWait = this.signalReceived.Wait(timeout);
+        if (!interruptedWait)
+        {
+            this.CancelPendingCall();
+        }
+
+        if (interruptedWait)
+        {
+            Assert.True(this.callerThread.Join(timeout), "Timed out waiting for the COM call to finish.");
+        }
+        else
+        {
+            _ = this.callerThread.Join(CallCancellationDelayMs);
+        }
+
+        if (this.backgroundFailure is object && (interruptedWait || this.backgroundFailure.HResult != RpcECallCanceled))
+        {
+            ExceptionDispatchInfo.Capture(this.backgroundFailure).Throw();
+        }
+
+        return interruptedWait;
+    }
+
+    private void CancelPendingCall()
+    {
+        Assert.True(this.callerReady.Wait(CallCancellationDelayMs), "Timed out waiting for the COM caller thread to initialize.");
+        if (this.callerThread.IsAlive && this.callerThreadId != 0)
+        {
+            _ = NativeMethods.CoCancelCall(this.callerThreadId, 0);
+        }
+    }
+
+    private void InvokeSignalOnBackgroundThread(IntPtr stream)
+    {
+        try
+        {
+            this.callerThreadId = NativeMethods.GetCurrentThreadId();
+            Marshal.ThrowExceptionForHR(NativeMethods.CoEnableCallCancellation(IntPtr.Zero));
+            this.callerReady.Set();
+
+            Thread.Sleep(50);
+            Marshal.ThrowExceptionForHR(NativeMethods.CoGetInterfaceAndReleaseStream(stream, in IDispatchGuid, out object signaler));
+            signaler.GetType().InvokeMember(nameof(IMainThreadSignaler.Signal), BindingFlags.InvokeMethod, binder: null, target: signaler, args: Array.Empty<object>());
+        }
+        catch (Exception ex)
+        {
+            this.backgroundFailure = ex;
+            this.callerReady.Set();
+        }
+        finally
+        {
+            _ = NativeMethods.CoDisableCallCancellation(IntPtr.Zero);
+        }
+    }
+
+    /// <summary>
+    /// COM-visible implementation of <see cref="IMainThreadSignaler"/> that uses the free-threaded
+    /// marshaler so the COM proxy routes calls back to whichever STA thread holds the object.
+    /// </summary>
+    [ComVisible(true)]
+    [ClassInterface(ClassInterfaceType.None)]
+    public sealed class MainThreadSignaler : StandardOleMarshalObject, IMainThreadSignaler
+    {
+        private readonly ManualResetEventSlim signalReceived;
+
+        /// <summary>Initializes a new instance of the <see cref="MainThreadSignaler"/> class.</summary>
+        /// <param name="signalReceived">The event to set when <see cref="Signal"/> is called.</param>
+        internal MainThreadSignaler(ManualResetEventSlim signalReceived)
+        {
+            this.signalReceived = signalReceived;
+        }
+
+        /// <inheritdoc/>
+        public void Signal() => this.signalReceived.Set();
+    }
+
+    private static class NativeMethods
+    {
+        [DllImport("ole32.dll")]
+        internal static extern int CoMarshalInterThreadInterfaceInStream(in Guid riid, IntPtr pUnk, out IntPtr ppStm);
+
+        [DllImport("ole32.dll")]
+        internal static extern int CoGetInterfaceAndReleaseStream(IntPtr pStm, in Guid iid, [MarshalAs(UnmanagedType.IDispatch)] out object ppv);
+
+        [DllImport("ole32.dll")]
+        internal static extern int CoEnableCallCancellation(IntPtr pReserved);
+
+        [DllImport("ole32.dll")]
+        internal static extern int CoDisableCallCancellation(IntPtr pReserved);
+
+        [DllImport("ole32.dll")]
+        internal static extern int CoCancelCall(uint dwThreadId, uint ulTimeout);
+
+        [DllImport("kernel32.dll")]
+        internal static extern uint GetCurrentThreadId();
+    }
+}
+#endif

--- a/test/Microsoft.VisualStudio.Threading.Tests/DispatcherExtensionsTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/DispatcherExtensionsTests.cs
@@ -66,6 +66,50 @@ public class DispatcherExtensionsTests : JoinableTaskTestBase
             await Task.WhenAll(idleTask.Task, normalTask.Task).WithCancellation(this.TimeoutToken);
         });
     }
+
+#if NETFRAMEWORK
+    [StaFact]
+    public void WithPriority_MatchesDisableProcessingWithinDelegate()
+    {
+        this.SimulateUIThread(delegate
+        {
+            JoinableTaskFactory? normalPriorityJtf = this.asyncPump.WithPriority(Dispatcher.CurrentDispatcher, DispatcherPriority.Normal);
+            normalPriorityJtf.Run(delegate
+            {
+                this.AssertProcessingAllowed();
+
+                using (Dispatcher.CurrentDispatcher.DisableProcessing())
+                {
+                    this.AssertProcessingDisabled();
+                }
+
+                return Task.CompletedTask;
+            });
+
+            return Task.CompletedTask;
+        });
+    }
+
+    [StaFact]
+    public void WithPriority_MatchesDisableProcessingOutsideDelegate()
+    {
+        this.SimulateUIThread(delegate
+        {
+            JoinableTaskFactory? normalPriorityJtf = this.asyncPump.WithPriority(Dispatcher.CurrentDispatcher, DispatcherPriority.Normal);
+            using (Dispatcher.CurrentDispatcher.DisableProcessing())
+            {
+                normalPriorityJtf.Run(delegate
+                {
+                    this.AssertProcessingDisabled();
+
+                    return Task.CompletedTask;
+                });
+            }
+
+            return Task.CompletedTask;
+        });
+    }
+#endif
 }
 
 

--- a/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskFactoryTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskFactoryTests.cs
@@ -201,6 +201,25 @@ public class JoinableTaskFactoryTests : JoinableTaskTestBase
         });
     }
 
+    [StaFact]
+    public void DisableProcessing_RefCounted()
+    {
+        this.asyncPump.Run(() =>
+        {
+            JoinableTaskFactory.ProcessingDisabledOperation first = this.asyncPump.DisableProcessing();
+            JoinableTaskFactory.ProcessingDisabledOperation second = this.asyncPump.DisableProcessing();
+
+            // Dispose things in a FIFO order instead of a nested LIFO order.
+            // Processing should only be re-enabled after the last reference is disposed.
+            first.Dispose();
+            this.AssertProcessingDisabled();
+            second.Dispose();
+            this.AssertProcessingAllowed();
+
+            return Task.CompletedTask;
+        });
+    }
+
 #endif
 
     /// <summary>

--- a/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskFactoryTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskFactoryTests.cs
@@ -182,7 +182,7 @@ public class JoinableTaskFactoryTests : JoinableTaskTestBase
     }
 
     [StaFact]
-    public void DisableProcessing_Nested()
+    public void DisableProcessing_NestedProcessingDisabled()
     {
         this.asyncPump.Run(() =>
         {
@@ -197,6 +197,26 @@ public class JoinableTaskFactoryTests : JoinableTaskTestBase
             }
 
             this.AssertProcessingAllowed();
+            return Task.CompletedTask;
+        });
+    }
+
+    [StaFact]
+    public void DisableProcessing_NestedTasks()
+    {
+        this.asyncPump.Run(() =>
+        {
+            using (this.asyncPump.DisableProcessing())
+            {
+                this.asyncPump.Run(() =>
+                {
+                    // Child JoinableTasks do not inherit the processing-disabled state of their parents.
+                    this.AssertProcessingAllowed();
+
+                    return Task.CompletedTask;
+                });
+            }
+
             return Task.CompletedTask;
         });
     }

--- a/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskFactoryTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskFactoryTests.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Runtime.InteropServices;
-using System.Threading;
 using System.Threading.Tasks;
 
 public class JoinableTaskFactoryTests : JoinableTaskTestBase
@@ -12,13 +10,6 @@ public class JoinableTaskFactoryTests : JoinableTaskTestBase
         : base(logger)
     {
     }
-
-    private static bool MightCoWaitBeUsed
-#if NETFRAMEWORK
-        => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-#else
-        => false;
-#endif
 
     [Fact]
     public void OnTransitioningToMainThread_DoesNotHoldPrivateLock()
@@ -208,30 +199,6 @@ public class JoinableTaskFactoryTests : JoinableTaskTestBase
             this.AssertProcessingAllowed();
             return Task.CompletedTask;
         });
-    }
-
-    private void AssertProcessingDisabled()
-    {
-        Assert.SkipUnless(MightCoWaitBeUsed, "DisableProcessing has no effect in this environment.");
-
-        // For this check to work, we need to be on the main thread.
-        Assert.True(this.asyncPump.Context.IsOnMainThread);
-        Assert.Equal(ApartmentState.STA, Thread.CurrentThread.GetApartmentState());
-
-        using CoWaitMainThreadTransition transition = new();
-        Assert.False(transition.Wait(ExpectedTimeout));
-    }
-
-    private void AssertProcessingAllowed()
-    {
-        Assert.SkipUnless(MightCoWaitBeUsed, "DisableProcessing has no effect in this environment.");
-
-        // For this check to work, we need to be on the main thread.
-        Assert.True(this.asyncPump.Context.IsOnMainThread);
-        Assert.Equal(ApartmentState.STA, Thread.CurrentThread.GetApartmentState());
-
-        using CoWaitMainThreadTransition transition = new();
-        Assert.True(transition.Wait(UnexpectedTimeout));
     }
 
 #endif

--- a/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskFactoryTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskFactoryTests.cs
@@ -1,7 +1,9 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Runtime.InteropServices;
+using System.Threading;
 using System.Threading.Tasks;
 
 public class JoinableTaskFactoryTests : JoinableTaskTestBase
@@ -10,6 +12,13 @@ public class JoinableTaskFactoryTests : JoinableTaskTestBase
         : base(logger)
     {
     }
+
+    private static bool MightCoWaitBeUsed
+#if NETFRAMEWORK
+        => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+#else
+        => false;
+#endif
 
     [Fact]
     public void OnTransitioningToMainThread_DoesNotHoldPrivateLock()
@@ -137,6 +146,95 @@ public class JoinableTaskFactoryTests : JoinableTaskTestBase
             Assert.False(this.asyncPump.SwitchToMainThreadAsync(alwaysYield: false).GetAwaiter().IsCompleted);
         });
     }
+
+    [Fact]
+    public void DisableProcessing_ThrowsOutsideJoinableTask()
+    {
+        Assert.Throws<InvalidOperationException>(() => this.asyncPump.DisableProcessing());
+    }
+
+    [Fact]
+    public void DisableProcessing_InsideJoinableTask()
+    {
+        this.asyncPump.Run(delegate
+        {
+            using (this.asyncPump.DisableProcessing())
+            {
+            }
+
+            return Task.CompletedTask;
+        });
+    }
+
+    [Fact]
+    public void ProcessingDisabledOperation_Dispose_DoesNotThrowFromDefaultValue()
+    {
+        default(JoinableTaskFactory.ProcessingDisabledOperation).Dispose();
+    }
+
+#if NETFRAMEWORK
+    [StaFact]
+    public void DisableProcessing()
+    {
+        this.asyncPump.Run(() =>
+        {
+            this.AssertProcessingAllowed();
+
+            using (this.asyncPump.DisableProcessing())
+            {
+                this.AssertProcessingDisabled();
+            }
+
+            this.AssertProcessingAllowed();
+            return Task.CompletedTask;
+        });
+    }
+
+    [StaFact]
+    public void DisableProcessing_Nested()
+    {
+        this.asyncPump.Run(() =>
+        {
+            using (this.asyncPump.DisableProcessing())
+            {
+                using (this.asyncPump.DisableProcessing())
+                {
+                    this.AssertProcessingDisabled();
+                }
+
+                this.AssertProcessingDisabled();
+            }
+
+            this.AssertProcessingAllowed();
+            return Task.CompletedTask;
+        });
+    }
+
+    private void AssertProcessingDisabled()
+    {
+        Assert.SkipUnless(MightCoWaitBeUsed, "DisableProcessing has no effect in this environment.");
+
+        // For this check to work, we need to be on the main thread.
+        Assert.True(this.asyncPump.Context.IsOnMainThread);
+        Assert.Equal(ApartmentState.STA, Thread.CurrentThread.GetApartmentState());
+
+        using CoWaitMainThreadTransition transition = new();
+        Assert.False(transition.Wait(ExpectedTimeout));
+    }
+
+    private void AssertProcessingAllowed()
+    {
+        Assert.SkipUnless(MightCoWaitBeUsed, "DisableProcessing has no effect in this environment.");
+
+        // For this check to work, we need to be on the main thread.
+        Assert.True(this.asyncPump.Context.IsOnMainThread);
+        Assert.Equal(ApartmentState.STA, Thread.CurrentThread.GetApartmentState());
+
+        using CoWaitMainThreadTransition transition = new();
+        Assert.True(transition.Wait(UnexpectedTimeout));
+    }
+
+#endif
 
     /// <summary>
     /// A <see cref="JoinableTaskFactory"/> that allows a test to inject code

--- a/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskTestBase.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskTestBase.cs
@@ -96,4 +96,30 @@ public abstract class JoinableTaskTestBase : TestBase
         this.dispatcherContext.Post(s => this.testFrame.Continue = false, null);
         this.PushFrame();
     }
+
+#if NETFRAMEWORK
+    protected void AssertProcessingDisabled()
+    {
+        Assert.SkipUnless(MightCoWaitBeUsed, "DisableProcessing has no effect in this environment.");
+
+        // For this check to work, we need to be on the main thread.
+        Assert.True(this.asyncPump.Context.IsOnMainThread);
+        Assert.Equal(ApartmentState.STA, Thread.CurrentThread.GetApartmentState());
+
+        using CoWaitMainThreadTransition transition = new();
+        Assert.False(transition.Wait(ExpectedTimeout));
+    }
+
+    protected void AssertProcessingAllowed()
+    {
+        Assert.SkipUnless(MightCoWaitBeUsed, "DisableProcessing has no effect in this environment.");
+
+        // For this check to work, we need to be on the main thread.
+        Assert.True(this.asyncPump.Context.IsOnMainThread);
+        Assert.Equal(ApartmentState.STA, Thread.CurrentThread.GetApartmentState());
+
+        using CoWaitMainThreadTransition transition = new();
+        Assert.True(transition.Wait(UnexpectedTimeout));
+    }
+#endif
 }

--- a/test/Microsoft.VisualStudio.Threading.Tests/NoMessagePumpSyncContextTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/NoMessagePumpSyncContextTests.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+
+/// <summary>
+/// Tests for <see cref="NoMessagePumpSyncContext"/>.
+/// </summary>
+public class NoMessagePumpSyncContextTests : TestBase
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NoMessagePumpSyncContextTests"/> class.
+    /// </summary>
+    /// <param name="logger">The logger to use for test output.</param>
+    public NoMessagePumpSyncContextTests(ITestOutputHelper logger)
+        : base(logger)
+    {
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NoMessagePumpSyncContext.Default"/> returns a usable singleton instance.
+    /// </summary>
+    [Fact]
+    public void Default_IsNonNull()
+    {
+        Assert.NotNull(NoMessagePumpSyncContext.Default);
+    }
+
+    /// <summary>
+    /// Verifies that the default singleton is itself a <see cref="NoMessagePumpSyncContext"/>.
+    /// </summary>
+    [Fact]
+    public void Default_IsNoMessagePumpSyncContext()
+    {
+        Assert.IsType<NoMessagePumpSyncContext>(NoMessagePumpSyncContext.Default);
+    }
+
+#if NETFRAMEWORK
+    /// <summary>
+    /// Establishes the baseline: on a plain STA thread without a special synchronization context,
+    /// <see cref="WaitHandle.WaitOne()"/> uses <c>CoWaitForMultipleHandles</c>,
+    /// which allows COM RPC calls to be dispatched to the thread while it waits.
+    /// </summary>
+    [StaFact]
+    public void Wait_ComRpcPenetratesDefaultStaWait()
+    {
+        using CoWaitMainThreadTransition probe = new();
+        using ManualResetEvent mre = new(false);
+
+        // Block the STA thread; the default CoWait allows the COM call to execute Signal().
+        mre.WaitOne((int)ExpectedTimeout.TotalMilliseconds);
+
+        // The COM call should have been delivered while the thread was blocked.
+        Assert.True(probe.Wait(TimeSpan.FromMilliseconds(AsyncDelay)));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NoMessagePumpSyncContext.Wait"/> uses
+    /// <c>WaitForMultipleObjects</c> rather than <c>CoWaitForMultipleHandles</c>, preventing
+    /// COM RPC calls from being dispatched to the thread while it is synchronously waiting.
+    /// </summary>
+    [StaFact]
+    public void Wait_BlocksComRpcCalls()
+    {
+        using (NoMessagePumpSyncContext.Default.Apply())
+        {
+            using CoWaitMainThreadTransition probe = new();
+            using ManualResetEvent mre = new(false);
+
+            // Block the STA thread; NoMessagePumpSyncContext uses WaitForMultipleObjects,
+            // so the COM call cannot be dispatched while the thread is waiting.
+            mre.WaitOne((int)ExpectedTimeout.TotalMilliseconds);
+
+            // The COM call should NOT have been delivered.
+            Assert.False(probe.Wait(TimeSpan.FromMilliseconds(AsyncDelay)));
+        }
+    }
+#endif
+}

--- a/test/Microsoft.VisualStudio.Threading.Tests/NonConcurrentSynchronizationContextTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/NonConcurrentSynchronizationContextTests.cs
@@ -48,7 +48,7 @@ public class NonConcurrentSynchronizationContextTests : TestBase
         var eventArgs = new TaskCompletionSource<(object?, Exception)>();
         this.nonSticky.UnhandledException += (s, e) => eventArgs.SetResult((s, e));
         this.nonSticky.Post(s => throw new InvalidOperationException(), null);
-        (object sender, Exception ex) = await eventArgs.Task.WithCancellation(this.TimeoutToken);
+        (object? sender, Exception? ex) = await eventArgs.Task.WithCancellation(this.TimeoutToken);
         Assert.Same(this.nonSticky, sender);
         Assert.IsType<InvalidOperationException>(ex);
     }

--- a/test/Microsoft.VisualStudio.Threading.Tests/TestBase.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/TestBase.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft;
@@ -34,6 +35,13 @@ public abstract class TestBase
     {
         this.Logger = logger;
     }
+
+    protected static bool MightCoWaitBeUsed
+#if NETFRAMEWORK
+        => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+#else
+        => false;
+#endif
 
     /// <summary>
     /// Gets or sets the source of <see cref="TimeoutToken"/> that influences

--- a/test/NativeAOTCompatibility.Test/NativeAOTCompatibility.Test.csproj
+++ b/test/NativeAOTCompatibility.Test/NativeAOTCompatibility.Test.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net10.0</TargetFrameworks>
     <IsTestProject>false</IsTestProject>
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
     <TargetFrameworks>$(TargetFrameworks);net10.0-windows</TargetFrameworks>

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "18.0",
+  "version": "18.7",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/v\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
Sample use case:

```cs
jtf.Run(
    async delegate
    {
        jtf.DisableProcessing();
        // Code that cannot afford to be interrupted by COM RPC calls during synchronously blocking calls.
    });
```

This also enhances the `JoinableTaskFactory.WithPriority(Dispatcher)` extension method so that it automatically honors calls to `Dispatcher.DisableProcessing()` to match its behavior.