### PR TITLE
Add fork detection for upgradeable read lock context

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/AsyncReaderWriterLock.cs
+++ b/src/Microsoft.VisualStudio.Threading/AsyncReaderWriterLock.cs
@@ -710,6 +710,24 @@ public partial class AsyncReaderWriterLock : IDisposable
     }
 
     /// <summary>
+    /// Invoked when a nested lock request is detected from a forked execution context
+    /// of an upgradeable read lock holder — specifically, when the calling thread could hold
+    /// an active lock (it is not an STA thread) but lacks the required
+    /// <see cref="NonConcurrentSynchronizationContext"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>This typically indicates that code holding an upgradeable read lock used
+    /// <c>ConfigureAwait(false)</c> or otherwise left the <see cref="NonConcurrentSynchronizationContext"/>,
+    /// then requested a nested read lock on the forked context.</para>
+    /// <para>This method is called <em>outside</em> the lock's private synchronization object.
+    /// Implementations should be lightweight (e.g., setting a flag or posting a telemetry event).</para>
+    /// <para>The default implementation does nothing. Override to log diagnostics or telemetry.</para>
+    /// </remarks>
+    protected virtual void OnLockForkDetected()
+    {
+    }
+
+    /// <summary>
     /// Invoked when the lock detects an internal error or illegal usage pattern that
     /// indicates a serious flaw that should be immediately reported to the application
     /// and/or bring down the process to avoid hangs or data corruption.
@@ -1072,6 +1090,7 @@ public partial class AsyncReaderWriterLock : IDisposable
     {
         bool issued = false;
         bool isOrdinaryNestedLock = false; // ordinary nested lock is a nested lock always granted immediately. We don't need write ETW event to reduce noise in traces.
+        bool lockForkDetected = false;
 
         lock (this.syncObject)
         {
@@ -1097,6 +1116,21 @@ public partial class AsyncReaderWriterLock : IDisposable
                     switch (awaiter.Kind)
                     {
                         case LockKind.Read:
+                            // Detect fork from upgradeable read context: the caller holds an active
+                            // upgradeable read lock in its nesting chain but is executing on a thread
+                            // that lacks the NonConcurrentSynchronizationContext, which typically means
+                            // code used ConfigureAwait(false) and forked off the exclusive context.
+                            // We skip this when hasWrite because the write fork path below already
+                            // handles that case (with a hard failure), and we only report on the
+                            // first request (!previouslyQueued) to avoid duplicate telemetry from
+                            // PendAwaiter retries.
+                            if (!previouslyQueued && hasUpgradeableRead && !hasWrite &&
+                                this.CanCurrentThreadHoldActiveLock &&
+                                !(SynchronizationContext.Current is NonConcurrentSynchronizationContext))
+                            {
+                                lockForkDetected = true;
+                            }
+
                             if (this.issuedWriteLocks.Count == 0 && (skipPendingWriteLockCheck || this.waitingWriters.Count == 0))
                             {
                                 issued = true;
@@ -1176,6 +1210,11 @@ public partial class AsyncReaderWriterLock : IDisposable
             {
                 this.GetActiveLockSet(awaiter.Kind).Add(awaiter);
             }
+        }
+
+        if (lockForkDetected)
+        {
+            this.OnLockForkDetected();
         }
 
         if (issued)

--- a/test/Microsoft.VisualStudio.Threading.Tests/AsyncReaderWriterLockTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/AsyncReaderWriterLockTests.cs
@@ -4085,6 +4085,70 @@ public class AsyncReaderWriterLockTests : TestBase, IDisposable
     }
 
     [Fact]
+    public async Task UpgradeableReadLockForksAndAsksForReadLock()
+    {
+        var lck = new LockWithForkDetection();
+        using (await lck.UpgradeableReadLockAsync())
+        {
+            await Task.Run(async delegate
+            {
+                // This requests a read lock from a thread pool thread (no NonConcurrentSynchronizationContext)
+                // while holding an upgradeable read lock. This is a fork of the exclusive context and should
+                // be detected via the OnLockForkDetected virtual method.
+                using (await lck.ReadLockAsync())
+                {
+                    Assert.True(lck.IsReadLockHeld);
+                }
+            });
+        }
+
+        Assert.Equal(1, lck.ForkDetectedCount);
+        lck.Complete();
+        Assert.True(lck.Completion.Wait(UnexpectedTimeout));
+    }
+
+    [Fact]
+    public async Task UpgradeableReadLockDoesNotForkOnCorrectContext()
+    {
+        var lck = new LockWithForkDetection();
+        using (await lck.UpgradeableReadLockAsync())
+        {
+            // Request a nested read lock on the correct context (with NonConcurrentSynchronizationContext).
+            // This should NOT trigger fork detection.
+            using (await lck.ReadLockAsync())
+            {
+                Assert.True(lck.IsReadLockHeld);
+            }
+        }
+
+        Assert.Equal(0, lck.ForkDetectedCount);
+        lck.Complete();
+        Assert.True(lck.Completion.Wait(UnexpectedTimeout));
+    }
+
+    [Fact]
+    public async Task ReadLockForkFromReadOnlyContextDoesNotTriggerDetection()
+    {
+        var lck = new LockWithForkDetection();
+        using (await lck.ReadLockAsync())
+        {
+            await Task.Run(async delegate
+            {
+                // Fork from a read-only context. This should NOT trigger fork detection
+                // because read locks don't require NonConcurrentSynchronizationContext.
+                using (await lck.ReadLockAsync())
+                {
+                    Assert.True(lck.IsReadLockHeld);
+                }
+            });
+        }
+
+        Assert.Equal(0, lck.ForkDetectedCount);
+        lck.Complete();
+        Assert.True(lck.Completion.Wait(UnexpectedTimeout));
+    }
+
+    [Fact]
     public async Task WriteNestsReadWithWriteReleasedFirst()
     {
         await Assert.ThrowsAsync<InvalidOperationException>(async delegate
@@ -5325,6 +5389,18 @@ public class AsyncReaderWriterLockTests : TestBase, IDisposable
         public CriticalErrorException(Exception innerException)
             : base(innerException?.Message, innerException)
         {
+        }
+    }
+
+    private class LockWithForkDetection : AsyncReaderWriterLock
+    {
+        private int forkDetectedCount;
+
+        internal int ForkDetectedCount => this.forkDetectedCount;
+
+        protected override void OnLockForkDetected()
+        {
+            Interlocked.Increment(ref this.forkDetectedCount);
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds a virtual method `OnLockForkDetected()` on `AsyncReaderWriterLock` that is called when a nested read lock request is detected from a forked execution context of an upgradeable read lock holder. This enables consumers like CPS to override the method and send telemetry to identify fork scenarios.

## Background

This addresses Watson crash [bug #1761459](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1761459) in CPS (`ProjectLockService.OnCompleted`), where `IsLockSupportingContext` can flip between `IsCompleted` and `OnCompleted` when a nesting UR lock is released by another thread. The root cause is a race condition that occurs when code holding an upgradeable read lock uses `ConfigureAwait(false)` and then requests a nested read lock from the forked context.

## Design

The existing write lock already has a fork check in `TryIssueLock` (lines 1110-1113) that throws `InvalidOperationException`. For the upgradeable read case, we use a **non-breaking** approach: a virtual method hook instead of throwing, since throwing would be a behavior change affecting many consumers.

### Fork detection criteria (all must be true):
- A **read lock** is being requested (`!previouslyQueued` — first request only, to avoid duplicate telemetry from `PendAwaiter` retries)
- The nesting chain contains an **active upgradeable read lock** (`hasUpgradeableRead`)
- No write lock in the nesting chain (`!hasWrite` — the write fork path already handles that)
- The calling thread is **MTA** (`CanCurrentThreadHoldActiveLock` — excludes STA/UI thread)
- The calling thread **lacks** `NonConcurrentSynchronizationContext`

The virtual method is called **outside** `syncObject` to avoid reentrancy concerns.

## Changes
- `AsyncReaderWriterLock.cs`: Added `OnLockForkDetected()` virtual method and fork detection logic in `TryIssueLock`
- `AsyncReaderWriterLockTests.cs`: Added 3 tests and a `LockWithForkDetection` helper class:
  - `UpgradeableReadLockForksAndAsksForReadLock` — verifies detection fires on forked UR context
  - `UpgradeableReadLockDoesNotForkOnCorrectContext` — verifies no false positive on correct context
  - `ReadLockForkFromReadOnlyContextDoesNotTriggerDetection` — verifies no detection for read-only forks

## Test Results
All 153 `AsyncReaderWriterLockTests` pass (149 succeeded, 4 pre-existing skips).