### PR TITLE
Let the user change the element-queue for AsyncQueue<T>

### DIFF
--- a/src/Microsoft.VisualStudio.Threading/AsyncQueue`1.cs
+++ b/src/Microsoft.VisualStudio.Threading/AsyncQueue`1.cs
@@ -33,9 +33,14 @@ public class AsyncQueue<T> : ThreadingTools.ICancellationNotification
     private volatile TaskCompletionSource<object?>? completedSource;
 
     /// <summary>
+    /// The factory for the internal queue of elements. A Queue`1 is constructed, when this is null.
+    /// </summary>
+    private readonly Func<int, ISyncQueue<T>>? elementsQueueFactory;
+
+    /// <summary>
     /// The internal queue of elements. Lazily constructed.
     /// </summary>
-    private Queue<T>? queueElements;
+    private ISyncQueue<T>? queueElements;
 
     /// <summary>
     /// The internal queue of <see cref="DequeueAsync(CancellationToken)"/> waiters. Lazily constructed.
@@ -57,6 +62,15 @@ public class AsyncQueue<T> : ThreadingTools.ICancellationNotification
     /// </summary>
     public AsyncQueue()
     {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AsyncQueue{T}"/> class.
+    /// </summary>
+    /// <param name="elementsQueueFactory">Factory to create the queue used for items, if needed. Takes the initial capacity.</param>
+    public AsyncQueue(Func<int, ISyncQueue<T>> elementsQueueFactory)
+    {
+        this.elementsQueueFactory = elementsQueueFactory;
     }
 
     /// <summary>
@@ -202,7 +216,9 @@ public class AsyncQueue<T> : ThreadingTools.ICancellationNotification
             {
                 if (this.queueElements is null)
                 {
-                    this.queueElements = new Queue<T>(this.InitialCapacity);
+                    this.queueElements = this.elementsQueueFactory is not null
+                        ? this.elementsQueueFactory(this.InitialCapacity)
+                        : new SyncQueue<T>(this.InitialCapacity);
                 }
 
                 this.queueElements.Enqueue(value);

--- a/src/Microsoft.VisualStudio.Threading/ISyncQueue`1.cs
+++ b/src/Microsoft.VisualStudio.Threading/ISyncQueue`1.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.VisualStudio.Threading;
+
+/// <summary>
+/// A synchronously dequeuable queue. There are no thread-safety guarantees.
+/// </summary>
+/// <typeparam name="T">The type of values kept by the queue.</typeparam>
+public interface ISyncQueue<T>
+{
+    /// <summary>
+    /// Gets the number of elements currently in the queue.
+    /// </summary>
+    int Count { get; }
+
+    /// <summary>
+    /// Adds an element to the tail of the queue.
+    /// </summary>
+    /// <param name="value">The value to add.</param>
+    void Enqueue(T value);
+
+    /// <summary>
+    /// Gets the value at the head of the queue without removing it from the queue.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown if the queue is empty.</exception>
+    T Peek();
+
+    /// <summary>
+    /// Gets and removes the element at the head of the queue.
+    /// </summary>
+    /// <returns>The head element.</returns>
+    T Dequeue();
+
+    /// <summary>
+    /// Returns a copy of this queue as an array.
+    /// </summary>
+    T[] ToArray();
+}

--- a/src/Microsoft.VisualStudio.Threading/SyncQueue`1.cs
+++ b/src/Microsoft.VisualStudio.Threading/SyncQueue`1.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Microsoft.VisualStudio.Threading;
+
+/// <summary>
+/// A non-thread-safe wrapper around Queue.
+/// </summary>
+/// <typeparam name="T">The type of values kept by the queue.</typeparam>
+[DebuggerDisplay("Count = {Count}")]
+internal sealed class SyncQueue<T>(int capacity) : ISyncQueue<T>
+{
+    private readonly Queue<T> queue = new(capacity);
+
+    public int Count => this.queue.Count;
+
+    public void Enqueue(T value) => this.queue.Enqueue(value);
+
+    public T Peek() => this.queue.Peek();
+
+    public T Dequeue() => this.queue.Dequeue();
+
+    public T[] ToArray() => this.queue.ToArray();
+}
+

--- a/test/Microsoft.VisualStudio.Threading.Tests/AsyncQueueTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/AsyncQueueTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
@@ -576,6 +577,24 @@ public class AsyncQueueTests : TestBase
         continuationTask.Wait(UnexpectedTimeout);
     }
 
+    [Fact]
+    public async Task AsyncQueueCanUseACustomQueueForElements()
+    {
+        var asyncQueue = new AsyncQueue<int>(capacity => new PrioritizedQueue(capacity));
+
+        asyncQueue.Enqueue(3);
+        asyncQueue.Enqueue(1);
+        asyncQueue.Enqueue(2);
+        asyncQueue.Complete();
+
+        Assert.Equal(1, asyncQueue.Peek());
+        Assert.Equal(1, await asyncQueue.DequeueAsync());
+        Assert.Equal(2, await asyncQueue.DequeueAsync());
+        Assert.True(asyncQueue.TryDequeue(out int item));
+        Assert.Equal(3, item);
+        Assert.False(asyncQueue.TryDequeue(out item));
+    }
+
     private class DerivedQueue<T> : AsyncQueue<T>
     {
         internal Action<T, bool>? OnEnqueuedDelegate { get; set; }
@@ -603,6 +622,43 @@ public class AsyncQueueTests : TestBase
             base.OnCompleted();
 
             this.OnCompletedDelegate?.Invoke();
+        }
+    }
+
+    /// <summary>
+    /// This "prioritied" queue implementation is not optimized for speed, nor does it allow custom types or ordering.
+    /// </summary>
+    private class PrioritizedQueue(int capacity) : ISyncQueue<int>
+    {
+        private readonly List<int> items = new List<int>(capacity);
+
+        public int Count => this.items.Count;
+
+        public void Enqueue(int value)
+        {
+            int index = this.items.BinarySearch(value);
+
+            // for more interesting types, there would be an `else`, moving to the end of items with the same priority, but you can't tell `int`s apart anyway.
+            if (index < 0)
+            {
+                index = ~index;
+            }
+
+            this.items.Insert(index, value);
+        }
+
+        public int Peek() => this.items[0];
+
+        public int Dequeue()
+        {
+            var item = this.items[0];
+            this.items.RemoveAt(0);
+            return item;
+        }
+
+        public int[] ToArray()
+        {
+            return this.items.ToArray();
         }
     }
 }


### PR DESCRIPTION
This allows the user to prioritize queued elements, or use an implementation otherwise different from Queue<T> as backend.

If you think an abstract class is a better fit than an interface or I should change anything else, just reach out (or do it).

I would be happy, if I could use the nice async-wrapper that is AsyncQueue<T> around a queue, that prioritises items and keeps insertion-order between items of the same priority (which the channel from `Channel.CreateUnboundedPrioritized<T>()` doesn't do). Now I don't think that this library needs to offer the whole thing, but AsyncQueue<T> utilises some internal classes like `TaskCompletionSourceWithoutInlining<T>` that I would need to replace, if I want to have a full-fledged copy, without a change in this repository