### PR TITLE
Bump MessagePack (for tests) to 2.5.302

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,6 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="DNNE" Version="2.1.2" />
+    <PackageVersion Include="MessagePack" Version="2.5.302" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.8" />
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="$(CodeAnalysisVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />


### PR DESCRIPTION
This resolves a Component Governance alert.
