### PR TITLE
Restore VSTHRD200 compatibility for IAsyncEnumerator APIs

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Utils.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Utils.cs
@@ -293,11 +293,11 @@ public static class Utils
 
         // ValueTask and ValueTask<T> have the AsyncMethodBuilderAttribute.
         return (typeSymbol.Name == nameof(Task) && typeSymbol.BelongsToNamespace(Namespaces.SystemThreadingTasks))
-            || IsIAsyncEnumerableOrEnumerator(typeSymbol) || typeSymbol.AllInterfaces.Any(IsIAsyncEnumerableOrEnumerator)
+            || IsIAsyncEnumerable(typeSymbol) || typeSymbol.AllInterfaces.Any(IsIAsyncEnumerable)
             || typeSymbol.GetAttributes().Any(ad => ad.AttributeClass?.Name == Types.AsyncMethodBuilderAttribute.TypeName && ad.AttributeClass.BelongsToNamespace(Types.AsyncMethodBuilderAttribute.Namespace));
 
-        static bool IsIAsyncEnumerableOrEnumerator(ITypeSymbol symbol)
-            => (symbol.Name == "IAsyncEnumerable" || symbol.Name == "IAsyncEnumerator") // TODO: Use nameof after upgrade to netstandard2.1
+        static bool IsIAsyncEnumerable(ITypeSymbol symbol)
+            => symbol.Name == "IAsyncEnumerable" // TODO: Use nameof(IAsyncEnumerable) after upgrade to netstandard2.1
             && symbol.BelongsToNamespace(Namespaces.SystemCollectionsGeneric);
     }
 

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD200UseAsyncNamingConventionAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD200UseAsyncNamingConventionAnalyzerTests.cs
@@ -191,29 +191,6 @@ class Test {
     }
 
     [Fact]
-    public async Task IAsyncEnumeratorOfTReturningMethodWithoutSuffix_GeneratesWarning()
-    {
-        var test = @"
-using System.Collections.Generic;
-
-class Test {
-    IAsyncEnumerator<int> Foo() => default;
-}
-";
-
-        var withFix = @"
-using System.Collections.Generic;
-
-class Test {
-    IAsyncEnumerator<int> FooAsync() => default;
-}
-";
-
-        DiagnosticResult expected = CSVerify.Diagnostic(AddSuffixDescriptor).WithSpan(5, 27, 5, 30);
-        await CSVerify.VerifyCodeFixAsync(test, expected, withFix);
-    }
-
-    [Fact]
     public async Task HomemadeIAsyncEnumerableOfTReturningMethodWithoutSuffix_GeneratesWarning()
     {
         var test = @"
@@ -416,13 +393,13 @@ class Test {
     }
 
     [Fact]
-    public async Task IAsyncEnumeratorOfTReturningMethodWithSuffix_GeneratesNoWarning()
+    public async Task IAsyncEnumeratorOfTReturningMethodWithoutSuffix_GeneratesNoWarning()
     {
         var test = @"
 using System.Collections.Generic;
 
 class Test {
-    IAsyncEnumerator<int> FooAsync() => null;
+    IAsyncEnumerator<int> GetEnumerator() => null;
 }
 ";
         await CSVerify.VerifyAnalyzerAsync(test);


### PR DESCRIPTION
VSTHRD200 started flagging shipped APIs that return `IAsyncEnumerator<T>`. Those APIs cannot be renamed without breaking callers, so preserve their existing names while retaining diagnostics for `IAsyncEnumerable<T>` APIs.