### PR TITLE
Remodel how analyzer dependencies are managed

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,7 +8,7 @@
 	],
 	"packageRules": [
 		{
-			"matchJsonata": ["sharedVariableName='CodeAnalysisVersion'"],
+			"matchFileNames": ["Directory.Packages.Analyzers.props"],
 			"enabled": false
 		}
 	],

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -5,5 +5,7 @@
     <Using Remove="System.Net.Http" Condition="'$(TargetFrameworkIdentifier)'=='.NETFramework'" />
   </ItemGroup>
 
+  <Import Project="Directory.Packages.Analyzers.props" Condition="'$(IsAnalyzerProject)'=='true'" />
+
   <Import Project="Directory.Traversal.targets" Condition="'$(IsTraversal)'=='true'" />
 </Project>

--- a/Directory.Packages.Analyzers.props
+++ b/Directory.Packages.Analyzers.props
@@ -1,15 +1,21 @@
 <Project>
+  <!-- These versions are chosen to support the .NET 8 SDK. -->
   <PropertyGroup>
-    <CodeAnalysisVersionForAnalyzers>4.14.0</CodeAnalysisVersionForAnalyzers>
+    <CodeAnalysisVersionForAnalyzers>4.11.0</CodeAnalysisVersionForAnalyzers>
   </PropertyGroup>
   <ItemGroup>
-    <!-- These versions are chosen to support VS 2022 Update 14. -->
+    <PackageVersion Update="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageVersion Update="Microsoft.CodeAnalysis" Version="$(CodeAnalysisVersionForAnalyzers)" />
     <PackageVersion Update="Microsoft.CodeAnalysis.Common" Version="$(CodeAnalysisVersionForAnalyzers)" />
     <PackageVersion Update="Microsoft.CodeAnalysis.CSharp" Version="$(CodeAnalysisVersionForAnalyzers)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(CodeAnalysisVersionForAnalyzers)" />
     <PackageVersion Update="Microsoft.CodeAnalysis.VisualBasic" Version="$(CodeAnalysisVersionForAnalyzers)" />
-    <PackageVersion Update="System.Collections.Immutable" Version="9.0.0" />
-    <PackageVersion Update="System.Memory" Version="4.6.3" />
-    <PackageVersion Update="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="$(CodeAnalysisVersionForAnalyzers)" />
+    <PackageVersion Update="System.Collections.Immutable" Version="8.0.0" />
+    <PackageVersion Update="System.Memory" Version="4.5.5" />
+    <PackageVersion Include="System.Reflection.Metadata" Version="8.0.0" />
+    <PackageVersion Update="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.0" />
+    <PackageVersion Update="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.Analyzers.props
+++ b/Directory.Packages.Analyzers.props
@@ -1,0 +1,15 @@
+<Project>
+  <PropertyGroup>
+    <CodeAnalysisVersionForAnalyzers>4.14.0</CodeAnalysisVersionForAnalyzers>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- These versions are chosen to support VS 2022 Update 14. -->
+    <PackageVersion Update="Microsoft.CodeAnalysis" Version="$(CodeAnalysisVersionForAnalyzers)" />
+    <PackageVersion Update="Microsoft.CodeAnalysis.Common" Version="$(CodeAnalysisVersionForAnalyzers)" />
+    <PackageVersion Update="Microsoft.CodeAnalysis.CSharp" Version="$(CodeAnalysisVersionForAnalyzers)" />
+    <PackageVersion Update="Microsoft.CodeAnalysis.VisualBasic" Version="$(CodeAnalysisVersionForAnalyzers)" />
+    <PackageVersion Update="System.Collections.Immutable" Version="9.0.0" />
+    <PackageVersion Update="System.Memory" Version="4.6.3" />
+    <PackageVersion Update="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
+  </ItemGroup>
+</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,9 +6,8 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <MicrosoftTestingPlatformVersion>2.3.0</MicrosoftTestingPlatformVersion>
     <MicroBuildVersion>2.0.226</MicroBuildVersion>
-    <CodeAnalysisVersion>3.11.0</CodeAnalysisVersion>
+    <CodeAnalysisVersion>5.6.0</CodeAnalysisVersion>
     <CodefixTestingVersion>1.1.4</CodefixTestingVersion>
-    <CodeAnalysisAnalyzerVersion>3.11.0-beta1.26226.5</CodeAnalysisAnalyzerVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="DNNE" Version="2.1.2" />
@@ -41,11 +40,6 @@
     <PackageVersion Include="Xunit.Combinatorial" Version="2.0.24" />
     <PackageVersion Include="Xunit.StaFact" Version="3.0.13" />
   </ItemGroup>
-  <!-- Analyzer projects must use versions of these packages that the VS host provides.
-       Pinning here ensures a dependency update bot won't silently upgrade them to versions VS can't load. -->
-  <ItemGroup Condition="'$(IsAnalyzerProject)'=='true'">
-    <PackageVersion Update="System.Memory" Version="4.5.5" />
-  </ItemGroup>
   <ItemGroup Label="Library.Template">
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.9.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CrashDump" Version="$(MicrosoftTestingPlatformVersion)" />
@@ -56,7 +50,7 @@
     <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
   </ItemGroup>
   <ItemGroup>
-    <GlobalPackageReference Include="Microsoft.CodeAnalysis.ResxSourceGenerator" Version="$(CodeAnalysisAnalyzerVersion)" />
+    <GlobalPackageReference Include="Microsoft.CodeAnalysis.ResxSourceGenerator" Version="5.0.0-1.25277.114" />
   </ItemGroup>
   <ItemGroup Label="Library.Template">
     <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.1.593" />

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/FixUtils.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/FixUtils.cs
@@ -160,9 +160,8 @@ internal static class FixUtils
                 Solution? solution = await Renamer.RenameSymbolAsync(
                     document.Project.Solution,
                     methodSymbol,
-                    ////new SymbolRenameOptions { RenameInComments = true }, // Required by later compiler version
+                    default,
                     newName,
-                    document.Project.Solution.Workspace.Options,
                     cancellationToken).ConfigureAwait(false);
                 document = solution.GetDocumentOrThrow(document.Id);
                 semanticModel = null;

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/FixUtils.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/FixUtils.cs
@@ -160,7 +160,7 @@ internal static class FixUtils
                 Solution? solution = await Renamer.RenameSymbolAsync(
                     document.Project.Solution,
                     methodSymbol,
-                    default,
+                    default(SymbolRenameOptions),
                     newName,
                     cancellationToken).ConfigureAwait(false);
                 document = solution.GetDocumentOrThrow(document.Id);

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/VSTHRD200UseAsyncNamingConventionCodeFix.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/VSTHRD200UseAsyncNamingConventionCodeFix.cs
@@ -70,7 +70,7 @@ public class VSTHRD200UseAsyncNamingConventionCodeFix : CodeFixProvider
             Solution? updatedSolution = await Renamer.RenameSymbolAsync(
                 solution,
                 methodSymbol,
-                default,
+                default(SymbolRenameOptions),
                 this.newName,
                 cancellationToken).ConfigureAwait(false);
 

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/VSTHRD200UseAsyncNamingConventionCodeFix.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/VSTHRD200UseAsyncNamingConventionCodeFix.cs
@@ -70,8 +70,8 @@ public class VSTHRD200UseAsyncNamingConventionCodeFix : CodeFixProvider
             Solution? updatedSolution = await Renamer.RenameSymbolAsync(
                 solution,
                 methodSymbol,
+                default,
                 this.newName,
-                solution.Workspace.Options,
                 cancellationToken).ConfigureAwait(false);
 
             return updatedSolution;

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -2,14 +2,7 @@
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove($(MSBuildThisFile), $(MSBuildThisFileDirectory)..))" />
 
-  <PropertyGroup>
-    <CodeAnalysisVersionForTests>5.3.0</CodeAnalysisVersionForTests>
-  </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Update="Microsoft.CodeAnalysis" Version="$(CodeAnalysisVersionForTests)" />
-    <PackageVersion Update="Microsoft.CodeAnalysis.Common" Version="$(CodeAnalysisVersionForTests)" />
-    <PackageVersion Update="Microsoft.CodeAnalysis.CSharp" Version="$(CodeAnalysisVersionForTests)" />
-    <PackageVersion Update="Microsoft.CodeAnalysis.VisualBasic" Version="$(CodeAnalysisVersionForTests)" />
-    <PackageVersion Update="System.Collections.Immutable" Version="9.0.13" />
+    <PackageVersion Update="System.Collections.Immutable" Version="10.0.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This updates some dependencies, but more importantly it adopts the pattern in the vs-mef repo for how analyzer dependencies are expressed so that they don't accidentally get updated with other dependencies.