### PR TITLE
Include WinDbg package in GitHub releases

### DIFF
--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -87,7 +87,9 @@ extends:
             title: v$(resources.pipeline.CI.runName)
             isDraft: true # After running this step, visit the new draft release, edit, and publish.
             isPreRelease: $(IsPrerelease)
-            assets: $(Pipeline.Workspace)/CI/deployables-Windows/NuGet/*.nupkg
+            assets: |
+              $(Pipeline.Workspace)/CI/deployables-Windows/NuGet/*.nupkg
+              $(Pipeline.Workspace)/CI/deployables-Windows/WinDBGGallery/*.nupkg
             changeLogCompareToRelease: lastNonDraftRelease
             changeLogType: issueBased
             changeLogLabels: |


### PR DESCRIPTION
## Summary
- upload `WinDBGGallery/*.nupkg` alongside public NuGet packages when creating GitHub releases

This restores the WinDbg extension as a release asset while retaining the existing NuGet package list.