### PR TITLE
Match configured generic types by metadata name

### DIFF
--- a/docfx/analyzers/configuration.md
+++ b/docfx/analyzers/configuration.md
@@ -25,6 +25,16 @@ all use `vs-threading.TopicA.txt` as the filename for their `AdditionalFiles` it
 
 These files may contain blank lines or comments that start with the `#` character.
 
+Files that contain a backtick use metadata type names. In these files, generic types include
+a backtick followed by the number of type parameters. For example, the metadata name for
+`DbSet<TEntity>` is ``DbSet`1``. Including the arity distinguishes a generic type from a
+non-generic type with the same name.
+
+For backward compatibility, files without any backticks match type names without regard
+to generic arity. For example, `DbSet` in such a file matches both a non-generic `DbSet`
+and every generic `DbSet<T...>` type. Add a backtick anywhere in the file to opt into
+exact metadata-name matching for every entry in that file.
+
 ## Methods that assert the main thread
 
 Code may assert it is running on the main thread by calling a method that is designed
@@ -92,3 +102,5 @@ excluded from VSTHRD103 analysis by specifying them in a configuration file.
 **Line format:** `[Namespace.TypeName]::MethodName`
 
 **Sample:** `[System.Data.SqlClient.SqlDataReader]::Read`
+
+**Generic sample:** ``[Microsoft.EntityFrameworkCore.DbSet`1]::Add``

--- a/docfx/analyzers/configuration.md
+++ b/docfx/analyzers/configuration.md
@@ -25,15 +25,15 @@ all use `vs-threading.TopicA.txt` as the filename for their `AdditionalFiles` it
 
 These files may contain blank lines or comments that start with the `#` character.
 
-Files that contain a backtick use metadata type names. In these files, generic types include
-a backtick followed by the number of type parameters. For example, the metadata name for
-`DbSet<TEntity>` is ``DbSet`1``. Including the arity distinguishes a generic type from a
-non-generic type with the same name.
+Configuration files with at least one entry that contains a backtick use metadata type names
+for all entries. Generic type names include a backtick followed by the number of type parameters.
+For example, the metadata name for `DbSet<TEntity>` is ``DbSet`1``. Including the arity
+distinguishes a generic type from a non-generic type with the same name.
 
-For backward compatibility, files without any backticks match type names without regard
-to generic arity. For example, `DbSet` in such a file matches both a non-generic `DbSet`
-and every generic `DbSet<T...>` type. Add a backtick anywhere in the file to opt into
-exact metadata-name matching for every entry in that file.
+For backward compatibility, configuration files whose entries contain no backticks match type
+names without regard to generic arity. For example, `DbSet` in such a file matches both a
+non-generic `DbSet` and every generic `DbSet<T...>` type. Add a backtick to any entry to opt
+the entire file into exact metadata-name matching.
 
 ## Methods that assert the main thread
 

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/CommonFixes.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/CommonFixes.cs
@@ -26,15 +26,19 @@ internal static class CommonFixes
     internal static async Task<ImmutableArray<QualifiedMember>> ReadMethodsAsync(CodeFixContext codeFixContext, Regex fileNamePattern, CancellationToken cancellationToken)
     {
         ImmutableArray<QualifiedMember>.Builder? result = ImmutableArray.CreateBuilder<QualifiedMember>();
-        foreach (string line in await ReadAdditionalFilesAsync(codeFixContext.Document.Project.AdditionalDocuments, fileNamePattern, cancellationToken))
+        foreach (SourceText text in await ReadAdditionalFileTextsAsync(codeFixContext.Document.Project.AdditionalDocuments, fileNamePattern, cancellationToken))
         {
-            result.Add(ParseAdditionalFileMethodLine(line));
+            bool matchAnyArity = !Contains(text, '`');
+            foreach (string line in ReadLinesFromAdditionalFile(text))
+            {
+                result.Add(ParseAdditionalFileMethodLine(line, matchAnyArity));
+            }
         }
 
         return result.ToImmutable();
     }
 
-    internal static async Task<ImmutableArray<string>> ReadAdditionalFilesAsync(IEnumerable<TextDocument> additionalFiles, Regex fileNamePattern, CancellationToken cancellationToken)
+    internal static async Task<ImmutableArray<SourceText>> ReadAdditionalFileTextsAsync(IEnumerable<TextDocument> additionalFiles, Regex fileNamePattern, CancellationToken cancellationToken)
     {
         if (additionalFiles is null)
         {
@@ -50,13 +54,26 @@ internal static class CommonFixes
                                           let fileName = Path.GetFileName(doc.Name)
                                           where fileNamePattern.IsMatch(fileName)
                                           select doc;
-        ImmutableArray<string>.Builder? result = ImmutableArray.CreateBuilder<string>();
+        ImmutableArray<SourceText>.Builder? result = ImmutableArray.CreateBuilder<SourceText>();
         foreach (TextDocument? doc in docs)
         {
-            SourceText? text = await doc.GetTextAsync(cancellationToken);
-            result.AddRange(ReadLinesFromAdditionalFile(text));
+            SourceText text = await doc.GetTextAsync(cancellationToken);
+            result.Add(text);
         }
 
         return result.ToImmutable();
+    }
+
+    private static bool Contains(SourceText text, char value)
+    {
+        for (int i = 0; i < text.Length; i++)
+        {
+            if (text[i] == value)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/CommonFixes.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/CommonFixes.cs
@@ -63,17 +63,4 @@ internal static class CommonFixes
 
         return result.ToImmutable();
     }
-
-    private static bool Contains(SourceText text, char value)
-    {
-        for (int i = 0; i < text.Length; i++)
-        {
-            if (text[i] == value)
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
 }

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/CommonFixes.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/CommonFixes.cs
@@ -28,8 +28,9 @@ internal static class CommonFixes
         ImmutableArray<QualifiedMember>.Builder? result = ImmutableArray.CreateBuilder<QualifiedMember>();
         foreach (SourceText text in await ReadAdditionalFileTextsAsync(codeFixContext.Document.Project.AdditionalDocuments, fileNamePattern, cancellationToken))
         {
-            bool matchAnyArity = !Contains(text, '`');
-            foreach (string line in ReadLinesFromAdditionalFile(text))
+            ImmutableArray<string> lines = ReadLinesFromAdditionalFile(text).ToImmutableArray();
+            bool matchAnyArity = !lines.Any(line => line.IndexOf('`') >= 0);
+            foreach (string line in lines)
             {
                 result.Add(ParseAdditionalFileMethodLine(line, matchAnyArity));
             }

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/CommonInterest.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/CommonInterest.cs
@@ -390,7 +390,7 @@ public static class CommonInterest
         return from file in analyzerOptions.AdditionalFiles.OrderBy(x => x.Path, StringComparer.Ordinal)
                let fileName = Path.GetFileName(file.Path)
                where fileNamePattern.IsMatch(fileName)
-               let text = file.GetText(cancellationToken)
+               let text = file.GetText(cancellationToken) ?? throw new InvalidOperationException($"Unable to read additional file: {file.Path}")
                select text;
     }
 
@@ -487,16 +487,14 @@ public static class CommonInterest
             }
 
             if (!this.IsMember
-                && (this.IsWildcard || typeSymbol.MetadataName == this.Type.Name)
-                && typeSymbol.BelongsToNamespace(this.Type.Namespace))
+                && ((this.IsWildcard && typeSymbol.BelongsToNamespace(this.Type.Namespace)) || this.Type.IsMatch(typeSymbol)))
             {
                 return true;
             }
 
             if (this.IsMember
                 && memberSymbol?.Name == this.Member.Name
-                && typeSymbol.MetadataName == this.Type.Name
-                && typeSymbol.BelongsToNamespace(this.Type.Namespace))
+                && this.Type.IsMatch(typeSymbol))
             {
                 return true;
             }

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/CommonInterest.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/CommonInterest.cs
@@ -328,9 +328,9 @@ public static class CommonInterest
     }
 
     public static QualifiedMember ParseAdditionalFileMethodLine(string line)
-        => ParseAdditionalFileMethodLine(line, matchAnyArity: false);
+        => ParseAdditionalFileMethodLine(line, matchAnyArity: line.IndexOf('`') < 0);
 
-    private static QualifiedMember ParseAdditionalFileMethodLine(string line, bool matchAnyArity)
+    public static QualifiedMember ParseAdditionalFileMethodLine(string line, bool matchAnyArity)
     {
         if (!CommonInterestParsing.TryParseMemberReference(line, out ReadOnlyMemory<char> typeNameMemory, out string? memberName))
         {

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/CommonInterest.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/CommonInterest.cs
@@ -328,7 +328,7 @@ public static class CommonInterest
     }
 
     public static QualifiedMember ParseAdditionalFileMethodLine(string line)
-        => ParseAdditionalFileMethodLine(line, matchAnyArity: line.IndexOf('`') < 0);
+        => ParseAdditionalFileMethodLine(line, matchAnyArity: true);
 
     public static QualifiedMember ParseAdditionalFileMethodLine(string line, bool matchAnyArity)
     {

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/CommonInterest.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/CommonInterest.cs
@@ -78,8 +78,9 @@ public static class CommonInterest
     {
         foreach (SourceText text in ReadAdditionalFileTexts(analyzerOptions, fileNamePattern, cancellationToken))
         {
-            bool matchAnyArity = !Contains(text, '`');
-            foreach (string line in ReadLinesFromAdditionalFile(text))
+            ImmutableArray<string> lines = ReadLinesFromAdditionalFile(text).ToImmutableArray();
+            bool matchAnyArity = !lines.Any(line => line.IndexOf('`') >= 0);
+            foreach (string line in lines)
             {
                 yield return ParseAdditionalFileMethodLine(line, matchAnyArity);
             }
@@ -90,8 +91,9 @@ public static class CommonInterest
     {
         foreach (SourceText text in ReadAdditionalFileTexts(analyzerOptions, fileNamePattern, cancellationToken))
         {
-            bool matchAnyArity = !Contains(text, '`');
-            foreach (string line in ReadLinesFromAdditionalFile(text))
+            ImmutableArray<string> lines = ReadLinesFromAdditionalFile(text).ToImmutableArray();
+            bool matchAnyArity = !lines.Any(line => line.IndexOf('`') >= 0);
+            foreach (string line in lines)
             {
                 if (!CommonInterestParsing.TryParseNegatableTypeOrMemberReference(line, out bool negated, out ReadOnlyMemory<char> typeNameMemory, out string? memberNameValue))
                 {
@@ -340,30 +342,6 @@ public static class CommonInterest
         (ImmutableArray<string> containingNamespace, string? typeName) = SplitQualifiedIdentifier(typeNameMemory);
         var containingType = new QualifiedType(containingNamespace, typeName, matchAnyArity);
         return new QualifiedMember(containingType, memberName!);
-    }
-
-    /// <summary>
-    /// Determines whether a character appears in source text without materializing the text as a string.
-    /// </summary>
-    /// <param name="text">The source text to search.</param>
-    /// <param name="value">The character to find.</param>
-    /// <returns><see langword="true"/> if <paramref name="value"/> appears in <paramref name="text"/>; otherwise, <see langword="false"/>.</returns>
-    public static bool Contains(SourceText text, char value)
-    {
-        if (text is null)
-        {
-            throw new ArgumentNullException(nameof(text));
-        }
-
-        for (int i = 0; i < text.Length; i++)
-        {
-            if (text[i] == value)
-            {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     /// <summary>

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/CommonInterest.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/CommonInterest.cs
@@ -343,6 +343,25 @@ public static class CommonInterest
     }
 
     /// <summary>
+    /// Determines whether a character appears in source text without materializing the text as a string.
+    /// </summary>
+    /// <param name="text">The source text to search.</param>
+    /// <param name="value">The character to find.</param>
+    /// <returns><see langword="true"/> if <paramref name="value"/> appears in <paramref name="text"/>; otherwise, <see langword="false"/>.</returns>
+    public static bool Contains(SourceText text, char value)
+    {
+        for (int i = 0; i < text.Length; i++)
+        {
+            if (text[i] == value)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Splits a qualified type name (e.g. <c>My.Namespace.MyType</c>) into its containing namespace
     /// segments and the simple type name, without allocating an intermediate joined string.
     /// </summary>
@@ -392,25 +411,6 @@ public static class CommonInterest
                where fileNamePattern.IsMatch(fileName)
                let text = file.GetText(cancellationToken) ?? throw new InvalidOperationException($"Unable to read additional file: {file.Path}")
                select text;
-    }
-
-    /// <summary>
-    /// Determines whether a character appears in source text without materializing the text as a string.
-    /// </summary>
-    /// <param name="text">The source text to search.</param>
-    /// <param name="value">The character to find.</param>
-    /// <returns><see langword="true"/> if <paramref name="value"/> appears in <paramref name="text"/>; otherwise, <see langword="false"/>.</returns>
-    public static bool Contains(SourceText text, char value)
-    {
-        for (int i = 0; i < text.Length; i++)
-        {
-            if (text[i] == value)
-            {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     private static bool TestGetAwaiterMethod(IMethodSymbol getAwaiterMethod)

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/CommonInterest.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/CommonInterest.cs
@@ -394,7 +394,13 @@ public static class CommonInterest
                select text;
     }
 
-    private static bool Contains(SourceText text, char value)
+    /// <summary>
+    /// Determines whether a character appears in source text without materializing the text as a string.
+    /// </summary>
+    /// <param name="text">The source text to search.</param>
+    /// <param name="value">The character to find.</param>
+    /// <returns><see langword="true"/> if <paramref name="value"/> appears in <paramref name="text"/>; otherwise, <see langword="false"/>.</returns>
+    public static bool Contains(SourceText text, char value)
     {
         for (int i = 0; i < text.Length; i++)
         {

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/CommonInterest.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/CommonInterest.cs
@@ -40,7 +40,9 @@ public static class CommonInterest
         new SyncBlockingMethod(new QualifiedMember(new QualifiedType(Namespaces.SystemThreadingTasks, nameof(Task)), nameof(Task.WaitAny)), null),
         new SyncBlockingMethod(new QualifiedMember(new QualifiedType(Namespaces.SystemRuntimeCompilerServices, nameof(ConfiguredTaskAwaitable.ConfiguredTaskAwaiter)), nameof(ConfiguredTaskAwaitable.ConfiguredTaskAwaiter.GetResult)), null),
         new SyncBlockingMethod(new QualifiedMember(new QualifiedType(Namespaces.SystemRuntimeCompilerServices, nameof(TaskAwaiter)), nameof(TaskAwaiter.GetResult)), null),
+        new SyncBlockingMethod(new QualifiedMember(new QualifiedType(Namespaces.SystemRuntimeCompilerServices, nameof(TaskAwaiter) + "`1"), nameof(TaskAwaiter.GetResult)), null),
         new SyncBlockingMethod(new QualifiedMember(new QualifiedType(Namespaces.SystemRuntimeCompilerServices, nameof(ValueTaskAwaiter)), nameof(ValueTaskAwaiter.GetResult)), null),
+        new SyncBlockingMethod(new QualifiedMember(new QualifiedType(Namespaces.SystemRuntimeCompilerServices, nameof(ValueTaskAwaiter) + "`1"), nameof(ValueTaskAwaiter.GetResult)), null),
         new SyncBlockingMethod(new QualifiedMember(new QualifiedType(Namespaces.SystemRuntimeCompilerServices, nameof(ConfiguredValueTaskAwaitable.ConfiguredValueTaskAwaiter)), nameof(ConfiguredValueTaskAwaitable.ConfiguredValueTaskAwaiter.GetResult)), null),
     ];
 
@@ -53,7 +55,9 @@ public static class CommonInterest
     public static readonly ImmutableArray<SyncBlockingMethod> SyncBlockingProperties =
     [
         new SyncBlockingMethod(new QualifiedMember(new QualifiedType(Namespaces.SystemThreadingTasks, nameof(Task)), nameof(Task<int>.Result)), null),
+        new SyncBlockingMethod(new QualifiedMember(new QualifiedType(Namespaces.SystemThreadingTasks, nameof(Task) + "`1"), nameof(Task<int>.Result)), null),
         new SyncBlockingMethod(new QualifiedMember(new QualifiedType(Namespaces.SystemThreadingTasks, nameof(ValueTask)), nameof(ValueTask<int>.Result)), null),
+        new SyncBlockingMethod(new QualifiedMember(new QualifiedType(Namespaces.SystemThreadingTasks, nameof(ValueTask) + "`1"), nameof(ValueTask<int>.Result)), null),
     ];
 
     public static readonly IEnumerable<QualifiedMember> ThreadAffinityTestingMethods =
@@ -63,6 +67,7 @@ public static class CommonInterest
 
     public static readonly ImmutableArray<QualifiedMember> TaskConfigureAwait = ImmutableArray.Create(
         new QualifiedMember(new QualifiedType(Types.Task.Namespace, Types.Task.TypeName), nameof(Task.ConfigureAwait)),
+        new QualifiedMember(new QualifiedType(Types.Task.Namespace, Types.Task.TypeName + "`1"), nameof(Task.ConfigureAwait)),
         new QualifiedMember(new QualifiedType(Types.AwaitExtensions.Namespace, Types.AwaitExtensions.TypeName), Types.AwaitExtensions.ConfigureAwaitRunInline));
 
     private const RegexOptions FileNamePatternRegexOptions = RegexOptions.IgnoreCase | RegexOptions.Singleline;
@@ -71,25 +76,33 @@ public static class CommonInterest
 
     public static IEnumerable<QualifiedMember> ReadMethods(AnalyzerOptions analyzerOptions, Regex fileNamePattern, CancellationToken cancellationToken)
     {
-        foreach (string line in ReadAdditionalFiles(analyzerOptions, fileNamePattern, cancellationToken))
+        foreach (SourceText text in ReadAdditionalFileTexts(analyzerOptions, fileNamePattern, cancellationToken))
         {
-            yield return ParseAdditionalFileMethodLine(line);
+            bool matchAnyArity = !Contains(text, '`');
+            foreach (string line in ReadLinesFromAdditionalFile(text))
+            {
+                yield return ParseAdditionalFileMethodLine(line, matchAnyArity);
+            }
         }
     }
 
     public static IEnumerable<TypeMatchSpec> ReadTypesAndMembers(AnalyzerOptions analyzerOptions, Regex fileNamePattern, CancellationToken cancellationToken)
     {
-        foreach (string line in ReadAdditionalFiles(analyzerOptions, fileNamePattern, cancellationToken))
+        foreach (SourceText text in ReadAdditionalFileTexts(analyzerOptions, fileNamePattern, cancellationToken))
         {
-            if (!CommonInterestParsing.TryParseNegatableTypeOrMemberReference(line, out bool negated, out ReadOnlyMemory<char> typeNameMemory, out string? memberNameValue))
+            bool matchAnyArity = !Contains(text, '`');
+            foreach (string line in ReadLinesFromAdditionalFile(text))
             {
-                throw new InvalidOperationException($"Parsing error on line: {line}");
-            }
+                if (!CommonInterestParsing.TryParseNegatableTypeOrMemberReference(line, out bool negated, out ReadOnlyMemory<char> typeNameMemory, out string? memberNameValue))
+                {
+                    throw new InvalidOperationException($"Parsing error on line: {line}");
+                }
 
-            (ImmutableArray<string> containingNamespace, string? typeName) = SplitQualifiedIdentifier(typeNameMemory);
-            var type = new QualifiedType(containingNamespace, typeName);
-            QualifiedMember member = memberNameValue is not null ? new QualifiedMember(type, memberNameValue) : default(QualifiedMember);
-            yield return new TypeMatchSpec(type, member, negated);
+                (ImmutableArray<string> containingNamespace, string? typeName) = SplitQualifiedIdentifier(typeNameMemory);
+                var type = new QualifiedType(containingNamespace, typeName, matchAnyArity);
+                QualifiedMember member = memberNameValue is not null ? new QualifiedMember(type, memberNameValue) : default(QualifiedMember);
+                yield return new TypeMatchSpec(type, member, negated);
+            }
         }
     }
 
@@ -105,12 +118,7 @@ public static class CommonInterest
             throw new ArgumentNullException(nameof(fileNamePattern));
         }
 
-        IEnumerable<SourceText>? docs = from file in analyzerOptions.AdditionalFiles.OrderBy(x => x.Path, StringComparer.Ordinal)
-                                        let fileName = Path.GetFileName(file.Path)
-                                        where fileNamePattern.IsMatch(fileName)
-                                        let text = file.GetText(cancellationToken)
-                                        select text;
-        return docs.SelectMany(ReadLinesFromAdditionalFile);
+        return ReadAdditionalFileTexts(analyzerOptions, fileNamePattern, cancellationToken).SelectMany(ReadLinesFromAdditionalFile);
     }
 
     public static bool Contains(this ImmutableArray<QualifiedMember> methods, ISymbol symbol)
@@ -320,6 +328,9 @@ public static class CommonInterest
     }
 
     public static QualifiedMember ParseAdditionalFileMethodLine(string line)
+        => ParseAdditionalFileMethodLine(line, matchAnyArity: false);
+
+    private static QualifiedMember ParseAdditionalFileMethodLine(string line, bool matchAnyArity)
     {
         if (!CommonInterestParsing.TryParseMemberReference(line, out ReadOnlyMemory<char> typeNameMemory, out string? memberName))
         {
@@ -327,7 +338,7 @@ public static class CommonInterest
         }
 
         (ImmutableArray<string> containingNamespace, string? typeName) = SplitQualifiedIdentifier(typeNameMemory);
-        var containingType = new QualifiedType(containingNamespace, typeName);
+        var containingType = new QualifiedType(containingNamespace, typeName, matchAnyArity);
         return new QualifiedMember(containingType, memberName!);
     }
 
@@ -362,6 +373,38 @@ public static class CommonInterest
         }
 
         return (nsBuilder.ToImmutable(), typeName);
+    }
+
+    private static IEnumerable<SourceText> ReadAdditionalFileTexts(AnalyzerOptions analyzerOptions, Regex fileNamePattern, CancellationToken cancellationToken)
+    {
+        if (analyzerOptions is null)
+        {
+            throw new ArgumentNullException(nameof(analyzerOptions));
+        }
+
+        if (fileNamePattern is null)
+        {
+            throw new ArgumentNullException(nameof(fileNamePattern));
+        }
+
+        return from file in analyzerOptions.AdditionalFiles.OrderBy(x => x.Path, StringComparer.Ordinal)
+               let fileName = Path.GetFileName(file.Path)
+               where fileNamePattern.IsMatch(fileName)
+               let text = file.GetText(cancellationToken)
+               select text;
+    }
+
+    private static bool Contains(SourceText text, char value)
+    {
+        for (int i = 0; i < text.Length; i++)
+        {
+            if (text[i] == value)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static bool TestGetAwaiterMethod(IMethodSymbol getAwaiterMethod)
@@ -444,7 +487,7 @@ public static class CommonInterest
             }
 
             if (!this.IsMember
-                && (this.IsWildcard || typeSymbol.Name == this.Type.Name)
+                && (this.IsWildcard || typeSymbol.MetadataName == this.Type.Name)
                 && typeSymbol.BelongsToNamespace(this.Type.Namespace))
             {
                 return true;
@@ -452,7 +495,7 @@ public static class CommonInterest
 
             if (this.IsMember
                 && memberSymbol?.Name == this.Member.Name
-                && typeSymbol.Name == this.Type.Name
+                && typeSymbol.MetadataName == this.Type.Name
                 && typeSymbol.BelongsToNamespace(this.Type.Namespace))
             {
                 return true;
@@ -465,18 +508,33 @@ public static class CommonInterest
     public readonly struct QualifiedType
     {
         public QualifiedType(ImmutableArray<string> containingTypeNamespace, string typeName)
+            : this(containingTypeNamespace, typeName, matchAnyArity: false)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="QualifiedType"/> struct.
+        /// </summary>
+        /// <param name="containingTypeNamespace">The namespace containing the type.</param>
+        /// <param name="typeName">The simple or metadata name of the type.</param>
+        /// <param name="matchAnyArity"><see langword="true"/> to match the simple name across all generic arities; otherwise, to match the metadata name exactly.</param>
+        internal QualifiedType(ImmutableArray<string> containingTypeNamespace, string typeName, bool matchAnyArity)
         {
             this.Namespace = containingTypeNamespace;
             this.Name = typeName;
+            this.MatchAnyArity = matchAnyArity;
         }
 
         public ImmutableArray<string> Namespace { get; }
 
         public string Name { get; }
 
+        private bool MatchAnyArity { get; }
+
         public bool IsMatch(ISymbol symbol)
         {
-            return symbol?.Name == this.Name
+            return symbol is not null
+                && (this.MatchAnyArity ? symbol.Name : symbol.MetadataName) == this.Name
                 && symbol.BelongsToNamespace(this.Namespace);
         }
 

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/CommonInterest.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/CommonInterest.cs
@@ -350,6 +350,11 @@ public static class CommonInterest
     /// <returns><see langword="true"/> if <paramref name="value"/> appears in <paramref name="text"/>; otherwise, <see langword="false"/>.</returns>
     public static bool Contains(SourceText text, char value)
     {
+        if (text is null)
+        {
+            throw new ArgumentNullException(nameof(text));
+        }
+
         for (int i = 0; i < text.Length; i++)
         {
             if (text[i] == value)

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/AdditionalFiles/vs-threading.SyncMethodsToExcludeFromVSTHRD103.legacy.txt
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/AdditionalFiles/vs-threading.SyncMethodsToExcludeFromVSTHRD103.legacy.txt
@@ -1,2 +1,2 @@
-# This file has no metadata arity markers, so its type names match every arity.
+# Backticks in comments do not opt the file into metadata-name matching: `1.
 [TestNamespace.LegacyTestClass]::SlowSyncMethod

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/AdditionalFiles/vs-threading.SyncMethodsToExcludeFromVSTHRD103.legacy.txt
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/AdditionalFiles/vs-threading.SyncMethodsToExcludeFromVSTHRD103.legacy.txt
@@ -1,0 +1,2 @@
+# This file has no metadata arity markers, so its type names match every arity.
+[TestNamespace.LegacyTestClass]::SlowSyncMethod

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/AdditionalFiles/vs-threading.SyncMethodsToExcludeFromVSTHRD103.mocks.txt
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/AdditionalFiles/vs-threading.SyncMethodsToExcludeFromVSTHRD103.mocks.txt
@@ -1,2 +1,3 @@
 # Test exclusions for VSTHRD103 analyzer
 [TestNamespace.TestClass]::SlowSyncMethod
+[TestNamespace.GenericTestClass`1]::SlowSyncMethod

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD103UseAsyncOptionAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD103UseAsyncOptionAnalyzerTests.cs
@@ -1364,6 +1364,92 @@ namespace TestNamespace {
     }
 
     [Fact]
+    public async Task GenericTypeExclusion_DoesNotExcludeNonGenericType()
+    {
+        string test = """
+            using System.Threading.Tasks;
+
+            class Test {
+                async Task T() {
+                    TestNamespace.GenericTestClass<int>.SlowSyncMethod();
+                    TestNamespace.GenericTestClass.{|#0:SlowSyncMethod|}();
+                }
+            }
+
+            namespace TestNamespace {
+                class GenericTestClass {
+                    public static void SlowSyncMethod() { }
+                    public static Task SlowSyncMethodAsync() => Task.CompletedTask;
+                }
+
+                class GenericTestClass<T> {
+                    public static void SlowSyncMethod() { }
+                    public static Task SlowSyncMethodAsync() => Task.CompletedTask;
+                }
+            }
+            """;
+
+        await CSVerify.VerifyAnalyzerAsync(test, CSVerify.Diagnostic(Descriptor).WithLocation(0).WithArguments("SlowSyncMethod", "SlowSyncMethodAsync"));
+    }
+
+    [Fact]
+    public async Task NonGenericTypeExclusion_DoesNotExcludeGenericType()
+    {
+        string test = """
+            using System.Threading.Tasks;
+
+            class Test {
+                async Task T() {
+                    TestNamespace.TestClass<int>.{|#0:SlowSyncMethod|}();
+                }
+            }
+
+            namespace TestNamespace {
+                class TestClass {
+                    public static void SlowSyncMethod() { }
+                    public static Task SlowSyncMethodAsync() => Task.CompletedTask;
+                }
+
+                class TestClass<T> {
+                    public static void SlowSyncMethod() { }
+                    public static Task SlowSyncMethodAsync() => Task.CompletedTask;
+                }
+            }
+            """;
+
+        await CSVerify.VerifyAnalyzerAsync(test, CSVerify.Diagnostic(Descriptor).WithLocation(0).WithArguments("SlowSyncMethod", "SlowSyncMethodAsync"));
+    }
+
+    [Fact]
+    public async Task LegacyFileExclusion_MatchesAllArities()
+    {
+        string test = """
+            using System.Threading.Tasks;
+
+            class Test {
+                async Task T() {
+                    TestNamespace.LegacyTestClass.SlowSyncMethod();
+                    TestNamespace.LegacyTestClass<int>.SlowSyncMethod();
+                }
+            }
+
+            namespace TestNamespace {
+                class LegacyTestClass {
+                    public static void SlowSyncMethod() { }
+                    public static Task SlowSyncMethodAsync() => Task.CompletedTask;
+                }
+
+                class LegacyTestClass<T> {
+                    public static void SlowSyncMethod() { }
+                    public static Task SlowSyncMethodAsync() => Task.CompletedTask;
+                }
+            }
+            """;
+
+        await CSVerify.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
     public async Task SyncMethodCallInAsyncMethod_NotExcludedViaAdditionalFiles_GeneratesWarning()
     {
         var test = @"


### PR DESCRIPTION
VSTHRD103 exclusions could not distinguish a non-generic type from a generic type with the same simple name, and CLR metadata names such as `DbSet``1` did not match generic symbols.

This change adds per-file compatibility modes for analyzer configuration:

- Files containing a backtick use exact metadata type names, including generic arity.
- Legacy files without a backtick continue matching simple type names across all arities.
- Version detection is performed independently for each AdditionalFile, without materializing the whole `SourceText` as a string.

Tests cover exact generic/non-generic separation, legacy matching across arities, and mixed legacy/v2 files in one compilation. The configuration documentation now explains both modes and includes an Entity Framework `DbSet` example.