### PR TITLE
Fix VSTHRD103 code fix for Task.WaitAll

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/VSTHRD103UseAsyncOptionCodeFix.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/VSTHRD103UseAsyncOptionCodeFix.cs
@@ -66,11 +66,18 @@ public class VSTHRD103UseAsyncOptionCodeFix : CodeFixProvider
             }
 
             var memberAccessExpression = blockingIdentifier?.Parent as MemberAccessExpressionSyntax;
+            IMethodSymbol? blockingMethod = memberAccessExpression is object
+                ? semanticModel.GetSymbolInfo(memberAccessExpression, context.CancellationToken).Symbol as IMethodSymbol
+                : null;
 
             // Check whether this code was already calling the awaiter (in a synchronous fashion).
             asyncAlternativeExists |= memberAccessExpression?.Expression is InvocationExpressionSyntax invoke && invoke.Expression is MemberAccessExpressionSyntax parentMemberAccess && parentMemberAccess.Name.Identifier.Text == nameof(Task.GetAwaiter);
 
-            if (!asyncAlternativeExists)
+            if (string.IsNullOrEmpty(diagnostic.Properties[VSTHRD103UseAsyncOptionAnalyzer.AsyncMethodKeyName]) && blockingMethod?.IsStatic is true)
+            {
+                asyncAlternativeExists = IsAwaitableTaskWaitAll(blockingMethod);
+            }
+            else if (!asyncAlternativeExists)
             {
                 // If we fail to recognize the container, assume it exists since the analyzer thought it would.
                 ITypeSymbol? container = memberAccessExpression is object ? semanticModel.GetTypeInfo(memberAccessExpression.Expression, context.CancellationToken).ConvertedType : null;
@@ -86,6 +93,14 @@ public class VSTHRD103UseAsyncOptionCodeFix : CodeFixProvider
 
     /// <inheritdoc />
     public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    private static bool IsAwaitableTaskWaitAll(IMethodSymbol method)
+    {
+        return method.Name == nameof(Task.WaitAll)
+            && method.ContainingType.Name == nameof(Task)
+            && method.ContainingNamespace.ToDisplayString() == typeof(Task).Namespace
+            && method.Parameters is [{ Type: IArrayTypeSymbol { ElementType.Name: nameof(Task) } }];
+    }
 
     private class ReplaceSyncMethodCallWithAwaitAsync : CodeAction
     {
@@ -143,6 +158,7 @@ public class VSTHRD103UseAsyncOptionCodeFix : CodeFixProvider
             SemanticModel? semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
             AnonymousFunctionExpressionSyntax? originalAnonymousMethodContainerIfApplicable = syncMethodName.FirstAncestorOrSelf<AnonymousFunctionExpressionSyntax>();
             MethodDeclarationSyntax originalMethodDeclaration = syncMethodName.FirstAncestorOrSelf<MethodDeclarationSyntax>() ?? throw new InvalidOperationException("Unable to find containing method.");
+            bool isAwaitableTaskWaitAll = semanticModel?.GetSymbolInfo(syncMethodName, cancellationToken).Symbol is IMethodSymbol methodSymbol && IsAwaitableTaskWaitAll(methodSymbol);
 
             ISymbol? enclosingSymbol = semanticModel?.GetEnclosingSymbol(this.diagnostic.Location.SourceSpan.Start, cancellationToken);
             var hasReturnValue = ((enclosingSymbol as IMethodSymbol)?.ReturnType as INamedTypeSymbol)?.IsGenericType ?? false;
@@ -170,7 +186,14 @@ public class VSTHRD103UseAsyncOptionCodeFix : CodeFixProvider
             ExpressionSyntax syncExpression = GetSynchronousExpression(syncMethodName) ?? throw new InvalidOperationException("Unable to find sync expression.");
 
             ExpressionSyntax awaitExpression;
-            if (!string.IsNullOrEmpty(this.AlternativeAsyncMethod))
+            if (isAwaitableTaskWaitAll)
+            {
+                SimpleNameSyntax whenAllMethodName = syncMethodName.WithIdentifier(SyntaxFactory.Identifier(nameof(Task.WhenAll)));
+                awaitExpression = SyntaxFactory.AwaitExpression(
+                    syncExpression.ReplaceNode(syncMethodName, whenAllMethodName).WithoutLeadingTrivia())
+                    .WithLeadingTrivia(syncExpression.GetLeadingTrivia());
+            }
+            else if (!string.IsNullOrEmpty(this.AlternativeAsyncMethod))
             {
                 // Replace the member being called and await the invocation expression.
                 // While doing so, move leading trivia to the surrounding await expression.

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/VSTHRD103UseAsyncOptionCodeFix.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/VSTHRD103UseAsyncOptionCodeFix.cs
@@ -74,9 +74,9 @@ public class VSTHRD103UseAsyncOptionCodeFix : CodeFixProvider
             // Check whether this code was already calling the awaiter (in a synchronous fashion).
             asyncAlternativeExists |= memberAccessExpression?.Expression is InvocationExpressionSyntax invoke && invoke.Expression is MemberAccessExpressionSyntax parentMemberAccess && parentMemberAccess.Name.Identifier.Text == nameof(Task.GetAwaiter);
 
-            if (string.IsNullOrEmpty(diagnostic.Properties[VSTHRD103UseAsyncOptionAnalyzer.AsyncMethodKeyName]) && blockingMethod?.IsStatic is true)
+            if (string.IsNullOrEmpty(diagnostic.Properties[VSTHRD103UseAsyncOptionAnalyzer.AsyncMethodKeyName]) && semanticModel is object && blockingMethod?.IsStatic is true)
             {
-                asyncAlternativeExists = IsAwaitableTaskWaitAll(blockingMethod);
+                asyncAlternativeExists = IsAwaitableTaskWaitAll(blockingMethod, semanticModel.Compilation);
             }
             else if (!asyncAlternativeExists)
             {
@@ -95,12 +95,13 @@ public class VSTHRD103UseAsyncOptionCodeFix : CodeFixProvider
     /// <inheritdoc />
     public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 
-    private static bool IsAwaitableTaskWaitAll(IMethodSymbol method)
+    private static bool IsAwaitableTaskWaitAll(IMethodSymbol method, Compilation compilation)
     {
+        INamedTypeSymbol? taskType = compilation.GetTypeByMetadataName(typeof(Task).FullName!);
         return method.Name == nameof(Task.WaitAll)
-            && method.ContainingType.Name == nameof(Task)
-            && method.ContainingNamespace.ToDisplayString() == typeof(Task).Namespace
-            && method.Parameters is [{ Type: IArrayTypeSymbol { ElementType.Name: nameof(Task) } }];
+            && SymbolEqualityComparer.Default.Equals(method.ContainingType, taskType)
+            && method.Parameters is [{ Type: IArrayTypeSymbol taskArray }]
+            && SymbolEqualityComparer.Default.Equals(taskArray.ElementType, taskType);
     }
 
     private class ReplaceSyncMethodCallWithAwaitAsync : CodeAction
@@ -162,7 +163,7 @@ public class VSTHRD103UseAsyncOptionCodeFix : CodeFixProvider
             InvocationExpressionSyntax? syncInvocation = syncMethodName.FirstAncestorOrSelf<InvocationExpressionSyntax>();
             bool isAwaitableTaskWaitAll = syncInvocation is object
                 && semanticModel?.GetSymbolInfo(syncInvocation, cancellationToken).Symbol is IMethodSymbol methodSymbol
-                && IsAwaitableTaskWaitAll(methodSymbol);
+                && IsAwaitableTaskWaitAll(methodSymbol, semanticModel.Compilation);
 
             ISymbol? enclosingSymbol = semanticModel?.GetEnclosingSymbol(this.diagnostic.Location.SourceSpan.Start, cancellationToken);
             var hasReturnValue = ((enclosingSymbol as IMethodSymbol)?.ReturnType as INamedTypeSymbol)?.IsGenericType ?? false;

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/VSTHRD103UseAsyncOptionCodeFix.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/VSTHRD103UseAsyncOptionCodeFix.cs
@@ -66,8 +66,9 @@ public class VSTHRD103UseAsyncOptionCodeFix : CodeFixProvider
             }
 
             var memberAccessExpression = blockingIdentifier?.Parent as MemberAccessExpressionSyntax;
-            IMethodSymbol? blockingMethod = memberAccessExpression is object
-                ? semanticModel.GetSymbolInfo(memberAccessExpression, context.CancellationToken).Symbol as IMethodSymbol
+            var blockingInvocation = memberAccessExpression?.Parent as InvocationExpressionSyntax;
+            IMethodSymbol? blockingMethod = blockingInvocation is object
+                ? semanticModel.GetSymbolInfo(blockingInvocation, context.CancellationToken).Symbol as IMethodSymbol
                 : null;
 
             // Check whether this code was already calling the awaiter (in a synchronous fashion).
@@ -158,7 +159,10 @@ public class VSTHRD103UseAsyncOptionCodeFix : CodeFixProvider
             SemanticModel? semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
             AnonymousFunctionExpressionSyntax? originalAnonymousMethodContainerIfApplicable = syncMethodName.FirstAncestorOrSelf<AnonymousFunctionExpressionSyntax>();
             MethodDeclarationSyntax originalMethodDeclaration = syncMethodName.FirstAncestorOrSelf<MethodDeclarationSyntax>() ?? throw new InvalidOperationException("Unable to find containing method.");
-            bool isAwaitableTaskWaitAll = semanticModel?.GetSymbolInfo(syncMethodName, cancellationToken).Symbol is IMethodSymbol methodSymbol && IsAwaitableTaskWaitAll(methodSymbol);
+            InvocationExpressionSyntax? syncInvocation = syncMethodName.FirstAncestorOrSelf<InvocationExpressionSyntax>();
+            bool isAwaitableTaskWaitAll = syncInvocation is object
+                && semanticModel?.GetSymbolInfo(syncInvocation, cancellationToken).Symbol is IMethodSymbol methodSymbol
+                && IsAwaitableTaskWaitAll(methodSymbol);
 
             ISymbol? enclosingSymbol = semanticModel?.GetEnclosingSymbol(this.diagnostic.Location.SourceSpan.Start, cancellationToken);
             var hasReturnValue = ((enclosingSymbol as IMethodSymbol)?.ReturnType as INamedTypeSymbol)?.IsGenericType ?? false;

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/VSTHRD103UseAsyncOptionCodeFix.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/VSTHRD103UseAsyncOptionCodeFix.cs
@@ -66,7 +66,12 @@ public class VSTHRD103UseAsyncOptionCodeFix : CodeFixProvider
             }
 
             var memberAccessExpression = blockingIdentifier?.Parent as MemberAccessExpressionSyntax;
-            var blockingInvocation = memberAccessExpression?.Parent as InvocationExpressionSyntax;
+            InvocationExpressionSyntax? blockingInvocation = blockingIdentifier?.Parent switch
+            {
+                InvocationExpressionSyntax invocation => invocation,
+                MemberAccessExpressionSyntax { Parent: InvocationExpressionSyntax invocation } => invocation,
+                _ => null,
+            };
             IMethodSymbol? blockingMethod = semanticModel is object && blockingInvocation is object
                 ? semanticModel.GetSymbolInfo(blockingInvocation, context.CancellationToken).Symbol as IMethodSymbol
                 : null;

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/VSTHRD103UseAsyncOptionCodeFix.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/VSTHRD103UseAsyncOptionCodeFix.cs
@@ -67,7 +67,7 @@ public class VSTHRD103UseAsyncOptionCodeFix : CodeFixProvider
 
             var memberAccessExpression = blockingIdentifier?.Parent as MemberAccessExpressionSyntax;
             var blockingInvocation = memberAccessExpression?.Parent as InvocationExpressionSyntax;
-            IMethodSymbol? blockingMethod = blockingInvocation is object
+            IMethodSymbol? blockingMethod = semanticModel is object && blockingInvocation is object
                 ? semanticModel.GetSymbolInfo(blockingInvocation, context.CancellationToken).Symbol as IMethodSymbol
                 : null;
 

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD103UseAsyncOptionAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD103UseAsyncOptionAnalyzerTests.cs
@@ -281,6 +281,25 @@ class Test {
     }
 
     [Fact]
+    public async Task TaskWaitAnyOffersNoFix()
+    {
+        var test = @"
+using System.Threading.Tasks;
+
+class Test {
+    Task T() {
+        Task[] tasks = null;
+        Task.{|#0:WaitAny|}(tasks);
+        return Task.CompletedTask;
+    }
+}
+";
+
+        DiagnosticResult expected = CSVerify.Diagnostic(DescriptorNoAlternativeMethod).WithLocation(0).WithArguments("WaitAny");
+        await CSVerify.VerifyCodeFixAsync(test, expected, test);
+    }
+
+    [Fact]
     public async Task TaskWaitInValueTaskReturningMethodGeneratesWarning()
     {
         var test = @"

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD103UseAsyncOptionAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD103UseAsyncOptionAnalyzerTests.cs
@@ -232,6 +232,55 @@ class Test {
     }
 
     [Fact]
+    public async Task TaskWaitAllInTaskReturningMethodGeneratesWarning()
+    {
+        var test = @"
+using System.Threading.Tasks;
+
+class Test {
+    Task T() {
+        Task[] tasks = null;
+        Task.WaitAll(tasks);
+        return Task.CompletedTask;
+    }
+}
+";
+
+        var withFix = @"
+using System.Threading.Tasks;
+
+class Test {
+    async Task T() {
+        Task[] tasks = null;
+        await Task.WhenAll(tasks);
+    }
+}
+";
+        DiagnosticResult expected = CSVerify.Diagnostic(DescriptorNoAlternativeMethod).WithLocation(7, 14).WithArguments("WaitAll");
+        await CSVerify.VerifyCodeFixAsync(test, expected, withFix);
+    }
+
+    [Fact]
+    public async Task TaskWaitAllWithCancellationTokenOffersNoFix()
+    {
+        var test = @"
+using System.Threading;
+using System.Threading.Tasks;
+
+class Test {
+    Task T() {
+        Task[] tasks = null;
+        Task.{|#0:WaitAll|}(tasks, CancellationToken.None);
+        return Task.CompletedTask;
+    }
+}
+";
+
+        DiagnosticResult expected = CSVerify.Diagnostic(DescriptorNoAlternativeMethod).WithLocation(0).WithArguments("WaitAll");
+        await CSVerify.VerifyCodeFixAsync(test, expected, test);
+    }
+
+    [Fact]
     public async Task TaskWaitInValueTaskReturningMethodGeneratesWarning()
     {
         var test = @"

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD103UseAsyncOptionAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD103UseAsyncOptionAnalyzerTests.cs
@@ -281,6 +281,31 @@ class Test {
     }
 
     [Fact]
+    public async Task TaskWaitAllWithTimeoutOffersNoFix()
+    {
+        var test = @"
+using System;
+using System.Threading.Tasks;
+
+class Test {
+    Task T() {
+        Task[] tasks = null;
+        Task.{|#0:WaitAll|}(tasks, 0);
+        Task.{|#1:WaitAll|}(tasks, TimeSpan.Zero);
+        return Task.CompletedTask;
+    }
+}
+";
+
+        DiagnosticResult[] expected =
+        [
+            CSVerify.Diagnostic(DescriptorNoAlternativeMethod).WithLocation(0).WithArguments("WaitAll"),
+            CSVerify.Diagnostic(DescriptorNoAlternativeMethod).WithLocation(1).WithArguments("WaitAll"),
+        ];
+        await CSVerify.VerifyCodeFixAsync(test, expected, test);
+    }
+
+    [Fact]
     public async Task TaskWaitAnyOffersNoFix()
     {
         var test = @"


### PR DESCRIPTION
VSTHRD103 currently offers `await Task;` for static `Task.WaitAll` calls, producing invalid code. This change recognizes the safely awaitable overload and rewrites it to `await Task.WhenAll(...)`.

Cancellation-token and timeout overloads continue to report the synchronous wait, but no automated fix is offered because replacing them with `WhenAll` would not preserve their semantics. Regression tests cover both behaviors.

Fixes #951