### PR TITLE
Coalesce JoinableTaskFactory dispatcher posts

### DIFF
--- a/docfx/docs/threading_rules.md
+++ b/docfx/docs/threading_rules.md
@@ -299,9 +299,46 @@ The following describes how to replace the mechanism for getting to the
 UI thread in a host-independent way:
 
 You can set your own priority by creating your own derived type of
-`JoinableTaskFactory` and overriding the `PostToUnderlyingSynchronizationContext`
-method. This method is responsible both for initial switches to the UI
-thread as well as resuming on the UI thread after a yielding await.
+`JoinableTaskFactory`.
+
+The base implementation coalesces pending callbacks so that only one driver
+message at a time is queued to the underlying synchronization context. A
+derived type that does not override `PostToUnderlyingSynchronizationContext`
+inherits this behavior.
+
+For backward compatibility, an override of
+`PostToUnderlyingSynchronizationContext` remains fully authoritative and does
+not automatically coalesce. Existing derived types may suppress a post,
+redirect it, or apply semantics that the base class cannot safely assume. Such
+types therefore retain their original behavior.
+
+A derived type may explicitly opt into coalescing by routing
+`PostToUnderlyingSynchronizationContext` through
+`PostToUnderlyingSynchronizationContextWithCoalescing`, and overriding
+`PostToUnderlyingSynchronizationContextCore` with the actual dispatcher
+operation:
+
+```csharp
+protected override void PostToUnderlyingSynchronizationContext(
+    SendOrPostCallback callback,
+    object state)
+{
+    this.PostToUnderlyingSynchronizationContextWithCoalescing(callback, state);
+}
+
+protected override void PostToUnderlyingSynchronizationContextCore(
+    SendOrPostCallback callback,
+    object state)
+{
+    this.dispatcher.Post(callback, state);
+}
+```
+
+`PostToUnderlyingSynchronizationContext` is responsible both for initial
+switches to the UI thread and for resuming on the UI thread after a yielding
+await. When coalescing is enabled, the core method may be called once for a
+sequence of pending callbacks and should only perform the underlying post; it
+should not call the coalescing helper.
 
 Note that the `JoinableTaskFactory` class has no default constructor, so when
 implementing your own `JoinableTaskFactory`-derived type you will need to add

--- a/docfx/docs/threading_rules.md
+++ b/docfx/docs/threading_rules.md
@@ -16,17 +16,17 @@ The rules are listed below with minimal examples. For a more thorough explanatio
 
 If a method has certain thread apartment requirements (STA or MTA) it must either:
 
-   1. Have an asynchronous signature, and asynchronously marshal to the appropriate
+1. Have an asynchronous signature, and asynchronously marshal to the appropriate
    thread if it isn't originally invoked on a compatible thread. The recommended
    means of switching to the main thread is:
 
-      ```csharp
+```csharp
       await joinableTaskFactoryInstance.SwitchToMainThreadAsync();
-      ```
+```
 
       OR
 
-   2. Have a synchronous signature, and throw an exception when called on the wrong thread.
+2. Have a synchronous signature, and throw an exception when called on the wrong thread.
      This can be done in Visual Studio with `ThreadHelper.ThrowIfNotOnUIThread()` or
      `ThreadHelper.ThrowIfOnUIThread()`.
 
@@ -316,7 +316,9 @@ A derived type may explicitly opt into coalescing by routing
 `PostToUnderlyingSynchronizationContext` through
 `PostToUnderlyingSynchronizationContextWithCoalescing`, and overriding
 `PostToUnderlyingSynchronizationContextCore` with the actual dispatcher
-operation:
+operation. Because `JoinableTaskFactory` is defined in another assembly, C#
+requires these `protected internal` base members to be declared `protected`
+when overridden:
 
 ```csharp
 protected override void PostToUnderlyingSynchronizationContext(
@@ -330,7 +332,7 @@ protected override void PostToUnderlyingSynchronizationContextCore(
     SendOrPostCallback callback,
     object state)
 {
-    this.dispatcher.Post(callback, state);
+    this.UnderlyingSynchronizationContext!.Post(callback, state);
 }
 ```
 
@@ -338,7 +340,9 @@ protected override void PostToUnderlyingSynchronizationContextCore(
 switches to the UI thread and for resuming on the UI thread after a yielding
 await. When coalescing is enabled, the core method may be called once for a
 sequence of pending callbacks and should only perform the underlying post; it
-should not call the coalescing helper.
+should not call the coalescing helper. Replace the synchronization-context post
+shown above with the custom dispatcher or priority operation required by the
+derived factory.
 
 Note that the `JoinableTaskFactory` class has no default constructor, so when
 implementing your own `JoinableTaskFactory`-derived type you will need to add

--- a/docfx/docs/threading_rules.md
+++ b/docfx/docs/threading_rules.md
@@ -16,17 +16,17 @@ The rules are listed below with minimal examples. For a more thorough explanatio
 
 If a method has certain thread apartment requirements (STA or MTA) it must either:
 
-1. Have an asynchronous signature, and asynchronously marshal to the appropriate
+   1. Have an asynchronous signature, and asynchronously marshal to the appropriate
    thread if it isn't originally invoked on a compatible thread. The recommended
    means of switching to the main thread is:
 
-```csharp
+      ```csharp
       await joinableTaskFactoryInstance.SwitchToMainThreadAsync();
-```
+      ```
 
       OR
 
-2. Have a synchronous signature, and throw an exception when called on the wrong thread.
+   2. Have a synchronous signature, and throw an exception when called on the wrong thread.
      This can be done in Visual Studio with `ThreadHelper.ThrowIfNotOnUIThread()` or
      `ThreadHelper.ThrowIfOnUIThread()`.
 

--- a/src/Microsoft.VisualStudio.Threading/DispatcherExtensions.cs
+++ b/src/Microsoft.VisualStudio.Threading/DispatcherExtensions.cs
@@ -77,6 +77,12 @@ public static class DispatcherExtensions
         /// <inheritdoc />
         protected internal override void PostToUnderlyingSynchronizationContext(SendOrPostCallback callback, object state)
         {
+            this.PostToUnderlyingSynchronizationContextWithCoalescing(callback, state);
+        }
+
+        /// <inheritdoc />
+        protected internal override void PostToUnderlyingSynchronizationContextCore(SendOrPostCallback callback, object state)
+        {
             this.dispatcher.BeginInvoke(this.priority, callback, state);
         }
     }

--- a/src/Microsoft.VisualStudio.Threading/DispatcherExtensions.cs
+++ b/src/Microsoft.VisualStudio.Threading/DispatcherExtensions.cs
@@ -4,6 +4,7 @@
 #if NETFRAMEWORK || WINDOWS
 
 using System;
+using System.Globalization;
 using System.Threading;
 using System.Windows.Threading;
 
@@ -72,6 +73,49 @@ public static class DispatcherExtensions
             this.DefaultWaitPolicy = new DispatcherSynchronizationContext(dispatcher);
 #endif
             this.priority = priority;
+        }
+
+        /// <inheritdoc />
+        internal override void ExecutePendingUnderlyingSynchronizationContextCallback(
+            SendOrPostCallback callback,
+            object state,
+            ExecutionContext? executionContext)
+        {
+            if (executionContext is null)
+            {
+                callback(state);
+                return;
+            }
+
+            CultureInfo dispatcherCulture = CultureInfo.CurrentCulture;
+            CultureInfo dispatcherUICulture = CultureInfo.CurrentUICulture;
+            CultureInfo resultingCulture = dispatcherCulture;
+            CultureInfo resultingUICulture = dispatcherUICulture;
+            try
+            {
+                ExecutionContext.Run(
+                    executionContext,
+                    _ =>
+                    {
+                        CultureInfo.CurrentCulture = dispatcherCulture;
+                        CultureInfo.CurrentUICulture = dispatcherUICulture;
+                        try
+                        {
+                            callback(state);
+                        }
+                        finally
+                        {
+                            resultingCulture = CultureInfo.CurrentCulture;
+                            resultingUICulture = CultureInfo.CurrentUICulture;
+                        }
+                    },
+                    null);
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = resultingCulture;
+                CultureInfo.CurrentUICulture = resultingUICulture;
+            }
         }
 
         /// <inheritdoc />

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
@@ -703,6 +703,11 @@ public partial class JoinableTaskFactory
             {
                 this.RemoveCompletedPendingUnderlyingSynchronizationContextCallbacks();
                 postAnotherCallback = this.pendingUnderlyingSynchronizationContextCallbacks?.Count > 0;
+                if (!postAnotherCallback)
+                {
+                    this.pendingUnderlyingSynchronizationContextCallbacks = null;
+                }
+
                 this.underlyingSynchronizationContextCallbackPending = postAnotherCallback;
             }
 

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
@@ -23,10 +23,14 @@ namespace Microsoft.VisualStudio.Threading;
 /// </remarks>
 public partial class JoinableTaskFactory
 {
+    private static readonly SendOrPostCallback ExecuteOnePendingUnderlyingSynchronizationContextCallbackDelegate = state => ((JoinableTaskFactory)state!).ExecuteOnePendingUnderlyingSynchronizationContextCallback();
+
     /// <summary>
     /// The <see cref="JoinableTaskContext"/> that owns this instance.
     /// </summary>
     private readonly JoinableTaskContext owner;
+
+    private readonly object pendingUnderlyingSynchronizationContextCallbacksLock = new();
 
     private readonly SynchronizationContext? mainThreadJobSyncContext;
 
@@ -34,6 +38,10 @@ public partial class JoinableTaskFactory
     /// The collection to add all created tasks to. May be <see langword="null" />.
     /// </summary>
     private readonly JoinableTaskCollection? jobCollection;
+
+    private Queue<SingleExecuteProtector>? pendingUnderlyingSynchronizationContextCallbacks;
+
+    private bool underlyingSynchronizationContextCallbackPending;
 
     /// <summary>
     /// Backing field for the <see cref="HangDetectionTimeout"/> property.
@@ -414,7 +422,20 @@ public partial class JoinableTaskFactory
 
         if (this.UnderlyingSynchronizationContext is object)
         {
-            this.PostToUnderlyingSynchronizationContext(SingleExecuteProtector.ExecuteOnce, callback);
+            bool postCallback;
+            lock (this.pendingUnderlyingSynchronizationContextCallbacksLock)
+            {
+                this.pendingUnderlyingSynchronizationContextCallbacks ??= new Queue<SingleExecuteProtector>();
+                this.RemoveCompletedPendingUnderlyingSynchronizationContextCallbacks();
+                this.pendingUnderlyingSynchronizationContextCallbacks.Enqueue(callback);
+                postCallback = !this.underlyingSynchronizationContextCallbackPending;
+                this.underlyingSynchronizationContextCallbackPending = true;
+            }
+
+            if (postCallback)
+            {
+                this.PostPendingUnderlyingSynchronizationContextCallback();
+            }
         }
         else
         {
@@ -656,6 +677,66 @@ public partial class JoinableTaskFactory
         {
             Report.Fail(Strings.NotAllowedUnderURorWLock); // pops a CHK assert dialog, but doesn't throw.
             Verify.FailOperation(Strings.NotAllowedUnderURorWLock); // actually throws, even in RET.
+        }
+    }
+
+    private void ExecuteOnePendingUnderlyingSynchronizationContextCallback()
+    {
+        SingleExecuteProtector? callback = null;
+        try
+        {
+            lock (this.pendingUnderlyingSynchronizationContextCallbacksLock)
+            {
+                this.RemoveCompletedPendingUnderlyingSynchronizationContextCallbacks();
+                if (this.pendingUnderlyingSynchronizationContextCallbacks?.Count > 0)
+                {
+                    callback = this.pendingUnderlyingSynchronizationContextCallbacks.Dequeue();
+                }
+            }
+
+            callback?.TryExecute();
+        }
+        finally
+        {
+            bool postAnotherCallback;
+            lock (this.pendingUnderlyingSynchronizationContextCallbacksLock)
+            {
+                this.RemoveCompletedPendingUnderlyingSynchronizationContextCallbacks();
+                postAnotherCallback = this.pendingUnderlyingSynchronizationContextCallbacks?.Count > 0;
+                this.underlyingSynchronizationContextCallbackPending = postAnotherCallback;
+            }
+
+            if (postAnotherCallback)
+            {
+                this.PostPendingUnderlyingSynchronizationContextCallback();
+            }
+        }
+    }
+
+    private void PostPendingUnderlyingSynchronizationContextCallback()
+    {
+        try
+        {
+            this.PostToUnderlyingSynchronizationContext(ExecuteOnePendingUnderlyingSynchronizationContextCallbackDelegate, this);
+        }
+        catch
+        {
+            lock (this.pendingUnderlyingSynchronizationContextCallbacksLock)
+            {
+                this.underlyingSynchronizationContextCallbackPending = false;
+            }
+
+            throw;
+        }
+    }
+
+    private void RemoveCompletedPendingUnderlyingSynchronizationContextCallbacks()
+    {
+        Assumes.True(Monitor.IsEntered(this.pendingUnderlyingSynchronizationContextCallbacksLock));
+
+        while (this.pendingUnderlyingSynchronizationContextCallbacks?.Count > 0 && this.pendingUnderlyingSynchronizationContextCallbacks.Peek().HasBeenExecuted)
+        {
+            this.pendingUnderlyingSynchronizationContextCallbacks.Dequeue();
         }
     }
 

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
@@ -728,12 +728,9 @@ public partial class JoinableTaskFactory
         {
             lock (this.pendingUnderlyingSynchronizationContextCallbacksLock)
             {
-                this.RemoveCompletedPendingUnderlyingSynchronizationContextCallbacks();
-                if (this.pendingUnderlyingSynchronizationContextCallbacks?.Count == 0)
-                {
-                    this.pendingUnderlyingSynchronizationContextCallbacks = null;
-                }
-
+                // Every callback remains in its owning JoinableTask's execution queue, so abandon this
+                // secondary route when no underlying message was established.
+                this.pendingUnderlyingSynchronizationContextCallbacks = null;
                 this.underlyingSynchronizationContextCallbackPending = false;
             }
 

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
@@ -773,7 +773,7 @@ public partial class JoinableTaskFactory
 
                 if (postCompletion is object)
                 {
-                    this.PostPendingUnderlyingSynchronizationContextCallback(postCompletion);
+                    this.PostPendingUnderlyingSynchronizationContextCallback(postCompletion, propagateException: false);
                 }
 
                 if (callback is { } work)
@@ -804,7 +804,7 @@ public partial class JoinableTaskFactory
         while (continueSynchronously);
     }
 
-    private void PostPendingUnderlyingSynchronizationContextCallback(TaskCompletionSource<object?> postCompletion)
+    private void PostPendingUnderlyingSynchronizationContextCallback(TaskCompletionSource<object?> postCompletion, bool propagateException = true)
     {
         try
         {
@@ -845,7 +845,10 @@ public partial class JoinableTaskFactory
 
             postCompletion.SetException(ex);
             _ = postCompletion.Task.Exception;
-            throw;
+            if (propagateException)
+            {
+                throw;
+            }
         }
     }
 

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
@@ -723,6 +723,12 @@ public partial class JoinableTaskFactory
         {
             lock (this.pendingUnderlyingSynchronizationContextCallbacksLock)
             {
+                this.RemoveCompletedPendingUnderlyingSynchronizationContextCallbacks();
+                if (this.pendingUnderlyingSynchronizationContextCallbacks?.Count == 0)
+                {
+                    this.pendingUnderlyingSynchronizationContextCallbacks = null;
+                }
+
                 this.underlyingSynchronizationContextCallbackPending = false;
             }
 

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
@@ -46,8 +46,6 @@ public partial class JoinableTaskFactory
 
     private bool underlyingSynchronizationContextCallbackPending;
 
-    private TaskCompletionSource<object?>? underlyingSynchronizationContextPostCompletion;
-
     /// <summary>
     /// Backing field for the <see cref="HangDetectionTimeout"/> property.
     /// </summary>
@@ -672,8 +670,7 @@ public partial class JoinableTaskFactory
     {
         Requires.NotNull(callback, nameof(callback));
 
-        TaskCompletionSource<object?>? postCompletion = null;
-        Task? waitForPost = null;
+        bool postCallback = false;
         lock (this.pendingUnderlyingSynchronizationContextCallbacksLock)
         {
             this.pendingUnderlyingSynchronizationContextCallbacks ??= new Queue<(SendOrPostCallback, object)>();
@@ -682,24 +679,23 @@ public partial class JoinableTaskFactory
             if (!this.underlyingSynchronizationContextCallbackPending)
             {
                 this.underlyingSynchronizationContextCallbackPending = true;
-                postCompletion = this.underlyingSynchronizationContextPostCompletion = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
-            }
-            else
-            {
-                waitForPost = this.underlyingSynchronizationContextPostCompletion?.Task;
+                postCallback = true;
             }
         }
 
-        if (postCompletion is object)
+        if (postCallback)
         {
-            this.PostPendingUnderlyingSynchronizationContextCallback(postCompletion);
-        }
-        else if (!IsSynchronouslyPosting(this))
-        {
-            waitForPost?.GetAwaiter().GetResult();
+            this.PostPendingUnderlyingSynchronizationContextCallback(propagateException: true);
         }
     }
 
+    /// <summary>
+    /// Checks whether this thread is currently inside an underlying synchronous post for the specified factory.
+    /// </summary>
+    /// <remarks>
+    /// The full chain is tracked so nested posts across factories (for example A to B to A) recognize an
+    /// ancestor factory and drain it iteratively instead of recursively posting another driver message.
+    /// </remarks>
     private static bool IsSynchronouslyPosting(JoinableTaskFactory factory)
     {
         return synchronouslyPostingFactories?.Contains(factory) is true;
@@ -747,7 +743,7 @@ public partial class JoinableTaskFactory
         {
             continueSynchronously = false;
             (SendOrPostCallback Callback, object State)? callback = null;
-            TaskCompletionSource<object?>? postCompletion = null;
+            bool postSuccessor = false;
             bool completeSynchronousDrainAfterCallback = false;
             try
             {
@@ -767,7 +763,7 @@ public partial class JoinableTaskFactory
                     }
                     else if (this.pendingUnderlyingSynchronizationContextCallbacks?.Count > 0)
                     {
-                        postCompletion = this.underlyingSynchronizationContextPostCompletion = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+                        postSuccessor = true;
                     }
                     else
                     {
@@ -776,9 +772,9 @@ public partial class JoinableTaskFactory
                     }
                 }
 
-                if (postCompletion is object)
+                if (postSuccessor)
                 {
-                    this.PostPendingUnderlyingSynchronizationContextCallback(postCompletion, propagateException: false);
+                    this.PostPendingUnderlyingSynchronizationContextCallback(propagateException: false);
                 }
 
                 if (callback is { } work)
@@ -809,7 +805,7 @@ public partial class JoinableTaskFactory
         while (continueSynchronously);
     }
 
-    private void PostPendingUnderlyingSynchronizationContextCallback(TaskCompletionSource<object?> postCompletion, bool propagateException = true)
+    private void PostPendingUnderlyingSynchronizationContextCallback(bool propagateException)
     {
         try
         {
@@ -823,33 +819,17 @@ public partial class JoinableTaskFactory
             {
                 synchronousPostingChain.RemoveAt(synchronousPostingChain.Count - 1);
             }
-
-            lock (this.pendingUnderlyingSynchronizationContextCallbacksLock)
-            {
-                if (this.underlyingSynchronizationContextPostCompletion == postCompletion)
-                {
-                    this.underlyingSynchronizationContextPostCompletion = null;
-                }
-            }
-
-            postCompletion.SetResult(null);
         }
-        catch (Exception ex)
+        catch
         {
             lock (this.pendingUnderlyingSynchronizationContextCallbacksLock)
             {
-                if (this.underlyingSynchronizationContextPostCompletion == postCompletion)
-                {
-                    // Every callback remains in its owning JoinableTask's execution queue, so abandon this
-                    // secondary route when no underlying message was established.
-                    this.pendingUnderlyingSynchronizationContextCallbacks = null;
-                    this.underlyingSynchronizationContextCallbackPending = false;
-                    this.underlyingSynchronizationContextPostCompletion = null;
-                }
+                // Every callback remains in its owning JoinableTask's execution queue, so abandon this
+                // secondary route when no underlying message was established.
+                this.pendingUnderlyingSynchronizationContextCallbacks = null;
+                this.underlyingSynchronizationContextCallbackPending = false;
             }
 
-            postCompletion.SetException(ex);
-            _ = postCompletion.Task.Exception;
             if (propagateException)
             {
                 throw;
@@ -861,6 +841,8 @@ public partial class JoinableTaskFactory
     {
         Assumes.True(Monitor.IsEntered(this.pendingUnderlyingSynchronizationContextCallbacksLock));
 
+        // Only inspect the head to keep enqueue and drain operations O(1). Completed entries behind live work
+        // are removed as they reach the head, while coalescing still limits the underlying context to one driver.
 #pragma warning disable VSOnly // IPendingExecutionRequestState is intended for evaluation purposes only.
         while (this.pendingUnderlyingSynchronizationContextCallbacks?.Count > 0
             && this.pendingUnderlyingSynchronizationContextCallbacks.Peek().State is IPendingExecutionRequestState { IsCompleted: true })

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using JoinableTaskSynchronizationContext = Microsoft.VisualStudio.Threading.JoinableTask.JoinableTaskSynchronizationContext;
@@ -477,6 +478,27 @@ public partial class JoinableTaskFactory
     }
 
     /// <summary>
+    /// Executes a pending callback under its captured execution context.
+    /// </summary>
+    /// <param name="callback">The callback to invoke.</param>
+    /// <param name="state">State to pass to the callback.</param>
+    /// <param name="executionContext">The execution context captured for the callback, or <see langword="null"/> when flow was suppressed.</param>
+    internal virtual void ExecutePendingUnderlyingSynchronizationContextCallback(
+        SendOrPostCallback callback,
+        object state,
+        ExecutionContext? executionContext)
+    {
+        if (executionContext is object)
+        {
+            ExecutionContext.Run(executionContext, ExecutePendingUnderlyingSynchronizationContextCallbackDelegate, (callback, state));
+        }
+        else
+        {
+            callback(state);
+        }
+    }
+
+    /// <summary>
     /// Posts a message to the specified underlying SynchronizationContext for processing when the main thread
     /// is freely available.
     /// </summary>
@@ -724,6 +746,13 @@ public partial class JoinableTaskFactory
         return synchronouslyPostingFactories?.Contains(factory) is true;
     }
 
+    private static void DisposeExecutionContext(ExecutionContext? executionContext)
+    {
+#if NETFRAMEWORK
+        executionContext?.Dispose();
+#endif
+    }
+
     /// <summary>
     /// Throws an exception if an active AsyncReaderWriterLock
     /// upgradeable read or write lock is held by the caller.
@@ -762,6 +791,7 @@ public partial class JoinableTaskFactory
     private void ExecuteOnePendingUnderlyingSynchronizationContextCallback()
     {
         bool continueSynchronously;
+        ExceptionDispatchInfo? synchronousCallbackException = null;
         do
         {
             continueSynchronously = false;
@@ -802,13 +832,17 @@ public partial class JoinableTaskFactory
 
                 if (callback is { } work)
                 {
-                    if (work.ExecutionContext is object)
+                    try
                     {
-                        ExecutionContext.Run(work.ExecutionContext, ExecutePendingUnderlyingSynchronizationContextCallbackDelegate, (work.Callback, work.State));
+                        this.ExecutePendingUnderlyingSynchronizationContextCallback(work.Callback, work.State, work.ExecutionContext);
                     }
-                    else
+                    catch (Exception ex) when (completeSynchronousDrainAfterCallback)
                     {
-                        work.Callback(work.State);
+                        synchronousCallbackException ??= ExceptionDispatchInfo.Capture(ex);
+                    }
+                    finally
+                    {
+                        DisposeExecutionContext(work.ExecutionContext);
                     }
                 }
             }
@@ -833,10 +867,13 @@ public partial class JoinableTaskFactory
             }
         }
         while (continueSynchronously);
+
+        synchronousCallbackException?.Throw();
     }
 
     private void PostPendingUnderlyingSynchronizationContextCallback(bool propagateException)
     {
+        var driver = new UnderlyingSynchronizationContextCallback(this);
         try
         {
             List<JoinableTaskFactory> synchronousPostingChain = synchronouslyPostingFactories ??= new();
@@ -849,7 +886,7 @@ public partial class JoinableTaskFactory
 
             try
             {
-                this.PostToUnderlyingSynchronizationContextCore(ExecuteOnePendingUnderlyingSynchronizationContextCallbackDelegate, new UnderlyingSynchronizationContextCallback(this));
+                this.PostToUnderlyingSynchronizationContextCore(ExecuteOnePendingUnderlyingSynchronizationContextCallbackDelegate, driver);
             }
             finally
             {
@@ -863,10 +900,20 @@ public partial class JoinableTaskFactory
         }
         catch
         {
+            if (driver.HasExecuted)
+            {
+                throw;
+            }
+
             lock (this.pendingUnderlyingSynchronizationContextCallbacksLock)
             {
                 // Every callback remains in its owning JoinableTask's execution queue, so abandon this
                 // secondary route when no underlying message was established.
+                while (this.pendingUnderlyingSynchronizationContextCallbacks?.Count > 0)
+                {
+                    DisposeExecutionContext(this.pendingUnderlyingSynchronizationContextCallbacks.Dequeue().ExecutionContext);
+                }
+
                 this.pendingUnderlyingSynchronizationContextCallbacks = null;
                 this.underlyingSynchronizationContextCallbackPending = false;
             }
@@ -889,7 +936,7 @@ public partial class JoinableTaskFactory
             && this.pendingUnderlyingSynchronizationContextCallbacks.Peek().State is IPendingExecutionRequestState { IsCompleted: true })
 #pragma warning restore VSOnly
         {
-            this.pendingUnderlyingSynchronizationContextCallbacks.Dequeue();
+            DisposeExecutionContext(this.pendingUnderlyingSynchronizationContextCallbacks.Dequeue().ExecutionContext);
         }
     }
 
@@ -1654,6 +1701,8 @@ public partial class JoinableTaskFactory
         {
             this.factory = factory;
         }
+
+        internal bool HasExecuted => Volatile.Read(ref this.factory) is null;
 
         internal void Execute()
         {

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
@@ -727,45 +727,58 @@ public partial class JoinableTaskFactory
 
     private void ExecuteOnePendingUnderlyingSynchronizationContextCallback()
     {
-        (SendOrPostCallback Callback, object State)? callback = null;
-        try
+        bool continueSynchronously;
+        do
         {
-            lock (this.pendingUnderlyingSynchronizationContextCallbacksLock)
+            continueSynchronously = false;
+            (SendOrPostCallback Callback, object State)? callback = null;
+            try
             {
-                this.RemoveCompletedPendingUnderlyingSynchronizationContextCallbacks();
-                if (this.pendingUnderlyingSynchronizationContextCallbacks?.Count > 0)
+                lock (this.pendingUnderlyingSynchronizationContextCallbacksLock)
                 {
-                    callback = this.pendingUnderlyingSynchronizationContextCallbacks.Dequeue();
+                    this.RemoveCompletedPendingUnderlyingSynchronizationContextCallbacks();
+                    if (this.pendingUnderlyingSynchronizationContextCallbacks?.Count > 0)
+                    {
+                        callback = this.pendingUnderlyingSynchronizationContextCallbacks.Dequeue();
+                    }
+                }
+
+                if (callback is { } work)
+                {
+                    work.Callback(work.State);
                 }
             }
-
-            if (callback is { } work)
+            finally
             {
-                work.Callback(work.State);
+                TaskCompletionSource<object?>? postCompletion = null;
+                lock (this.pendingUnderlyingSynchronizationContextCallbacksLock)
+                {
+                    this.RemoveCompletedPendingUnderlyingSynchronizationContextCallbacks();
+                    if (this.pendingUnderlyingSynchronizationContextCallbacks?.Count > 0)
+                    {
+                        if (synchronouslyPostingFactory == this)
+                        {
+                            continueSynchronously = true;
+                        }
+                        else
+                        {
+                            postCompletion = this.underlyingSynchronizationContextPostCompletion = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+                        }
+                    }
+                    else
+                    {
+                        this.pendingUnderlyingSynchronizationContextCallbacks = null;
+                        this.underlyingSynchronizationContextCallbackPending = false;
+                    }
+                }
+
+                if (postCompletion is object)
+                {
+                    this.PostPendingUnderlyingSynchronizationContextCallback(postCompletion);
+                }
             }
         }
-        finally
-        {
-            TaskCompletionSource<object?>? postCompletion = null;
-            lock (this.pendingUnderlyingSynchronizationContextCallbacksLock)
-            {
-                this.RemoveCompletedPendingUnderlyingSynchronizationContextCallbacks();
-                if (this.pendingUnderlyingSynchronizationContextCallbacks?.Count > 0)
-                {
-                    postCompletion = this.underlyingSynchronizationContextPostCompletion = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
-                }
-                else
-                {
-                    this.pendingUnderlyingSynchronizationContextCallbacks = null;
-                    this.underlyingSynchronizationContextCallbackPending = false;
-                }
-            }
-
-            if (postCompletion is object)
-            {
-                this.PostPendingUnderlyingSynchronizationContextCallback(postCompletion);
-            }
-        }
+        while (continueSynchronously);
     }
 
     private void PostPendingUnderlyingSynchronizationContextCallback(TaskCompletionSource<object?> postCompletion)

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
@@ -725,6 +725,16 @@ public partial class JoinableTaskFactory
         }
     }
 
+    /// <summary>
+    /// Executes one callback from the private queue and, when more work is already queued,
+    /// posts its successor to the underlying synchronization context before invoking the callback.
+    /// </summary>
+    /// <remarks>
+    /// Posting the successor first ensures that code invoked by the callback can enter a nested
+    /// message loop and find the next message already available. Synchronization contexts that
+    /// execute <see cref="SynchronizationContext.Post(SendOrPostCallback, object?)"/> inline are
+    /// drained iteratively instead to avoid recursive stack growth.
+    /// </remarks>
     private void ExecuteOnePendingUnderlyingSynchronizationContextCallback()
     {
         bool continueSynchronously;
@@ -732,6 +742,8 @@ public partial class JoinableTaskFactory
         {
             continueSynchronously = false;
             (SendOrPostCallback Callback, object State)? callback = null;
+            TaskCompletionSource<object?>? postCompletion = null;
+            bool completeSynchronousDrainAfterCallback = false;
             try
             {
                 lock (this.pendingUnderlyingSynchronizationContextCallbacksLock)
@@ -741,29 +753,16 @@ public partial class JoinableTaskFactory
                     {
                         callback = this.pendingUnderlyingSynchronizationContextCallbacks.Dequeue();
                     }
-                }
 
-                if (callback is { } work)
-                {
-                    work.Callback(work.State);
-                }
-            }
-            finally
-            {
-                TaskCompletionSource<object?>? postCompletion = null;
-                lock (this.pendingUnderlyingSynchronizationContextCallbacksLock)
-                {
                     this.RemoveCompletedPendingUnderlyingSynchronizationContextCallbacks();
-                    if (this.pendingUnderlyingSynchronizationContextCallbacks?.Count > 0)
+                    if (synchronouslyPostingFactory == this)
                     {
-                        if (synchronouslyPostingFactory == this)
-                        {
-                            continueSynchronously = true;
-                        }
-                        else
-                        {
-                            postCompletion = this.underlyingSynchronizationContextPostCompletion = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
-                        }
+                        completeSynchronousDrainAfterCallback = true;
+                        continueSynchronously = this.pendingUnderlyingSynchronizationContextCallbacks?.Count > 0;
+                    }
+                    else if (this.pendingUnderlyingSynchronizationContextCallbacks?.Count > 0)
+                    {
+                        postCompletion = this.underlyingSynchronizationContextPostCompletion = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
                     }
                     else
                     {
@@ -775,6 +774,30 @@ public partial class JoinableTaskFactory
                 if (postCompletion is object)
                 {
                     this.PostPendingUnderlyingSynchronizationContextCallback(postCompletion);
+                }
+
+                if (callback is { } work)
+                {
+                    work.Callback(work.State);
+                }
+            }
+            finally
+            {
+                if (completeSynchronousDrainAfterCallback)
+                {
+                    lock (this.pendingUnderlyingSynchronizationContextCallbacksLock)
+                    {
+                        this.RemoveCompletedPendingUnderlyingSynchronizationContextCallbacks();
+                        if (this.pendingUnderlyingSynchronizationContextCallbacks?.Count > 0)
+                        {
+                            continueSynchronously = true;
+                        }
+                        else
+                        {
+                            this.pendingUnderlyingSynchronizationContextCallbacks = null;
+                            this.underlyingSynchronizationContextCallbackPending = false;
+                        }
+                    }
                 }
             }
         }

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
@@ -25,6 +25,9 @@ public partial class JoinableTaskFactory
 {
     private static readonly SendOrPostCallback ExecuteOnePendingUnderlyingSynchronizationContextCallbackDelegate = state => ((UnderlyingSynchronizationContextCallback)state!).Execute();
 
+    [ThreadStatic]
+    private static JoinableTaskFactory? synchronouslyPostingFactory;
+
     /// <summary>
     /// The <see cref="JoinableTaskContext"/> that owns this instance.
     /// </summary>
@@ -42,6 +45,8 @@ public partial class JoinableTaskFactory
     private Queue<(SendOrPostCallback Callback, object State)>? pendingUnderlyingSynchronizationContextCallbacks;
 
     private bool underlyingSynchronizationContextCallbackPending;
+
+    private TaskCompletionSource<object?>? underlyingSynchronizationContextPostCompletion;
 
     /// <summary>
     /// Backing field for the <see cref="HangDetectionTimeout"/> property.
@@ -667,19 +672,31 @@ public partial class JoinableTaskFactory
     {
         Requires.NotNull(callback, nameof(callback));
 
-        bool postCallback;
+        TaskCompletionSource<object?>? postCompletion = null;
+        Task? waitForPost = null;
         lock (this.pendingUnderlyingSynchronizationContextCallbacksLock)
         {
             this.pendingUnderlyingSynchronizationContextCallbacks ??= new Queue<(SendOrPostCallback, object)>();
             this.RemoveCompletedPendingUnderlyingSynchronizationContextCallbacks();
             this.pendingUnderlyingSynchronizationContextCallbacks.Enqueue((callback, state));
-            postCallback = !this.underlyingSynchronizationContextCallbackPending;
-            this.underlyingSynchronizationContextCallbackPending = true;
+            if (!this.underlyingSynchronizationContextCallbackPending)
+            {
+                this.underlyingSynchronizationContextCallbackPending = true;
+                postCompletion = this.underlyingSynchronizationContextPostCompletion = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+            }
+            else
+            {
+                waitForPost = this.underlyingSynchronizationContextPostCompletion?.Task;
+            }
         }
 
-        if (postCallback)
+        if (postCompletion is object)
         {
-            this.PostPendingUnderlyingSynchronizationContextCallback();
+            this.PostPendingUnderlyingSynchronizationContextCallback(postCompletion);
+        }
+        else if (synchronouslyPostingFactory != this)
+        {
+            waitForPost?.GetAwaiter().GetResult();
         }
     }
 
@@ -729,42 +746,69 @@ public partial class JoinableTaskFactory
         }
         finally
         {
-            bool postAnotherCallback;
+            TaskCompletionSource<object?>? postCompletion = null;
             lock (this.pendingUnderlyingSynchronizationContextCallbacksLock)
             {
                 this.RemoveCompletedPendingUnderlyingSynchronizationContextCallbacks();
-                postAnotherCallback = this.pendingUnderlyingSynchronizationContextCallbacks?.Count > 0;
-                if (!postAnotherCallback)
+                if (this.pendingUnderlyingSynchronizationContextCallbacks?.Count > 0)
+                {
+                    postCompletion = this.underlyingSynchronizationContextPostCompletion = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+                }
+                else
                 {
                     this.pendingUnderlyingSynchronizationContextCallbacks = null;
+                    this.underlyingSynchronizationContextCallbackPending = false;
                 }
-
-                this.underlyingSynchronizationContextCallbackPending = postAnotherCallback;
             }
 
-            if (postAnotherCallback)
+            if (postCompletion is object)
             {
-                this.PostPendingUnderlyingSynchronizationContextCallback();
+                this.PostPendingUnderlyingSynchronizationContextCallback(postCompletion);
             }
         }
     }
 
-    private void PostPendingUnderlyingSynchronizationContextCallback()
+    private void PostPendingUnderlyingSynchronizationContextCallback(TaskCompletionSource<object?> postCompletion)
     {
         try
         {
-            this.PostToUnderlyingSynchronizationContextCore(ExecuteOnePendingUnderlyingSynchronizationContextCallbackDelegate, new UnderlyingSynchronizationContextCallback(this));
+            JoinableTaskFactory? priorSynchronouslyPostingFactory = synchronouslyPostingFactory;
+            synchronouslyPostingFactory = this;
+            try
+            {
+                this.PostToUnderlyingSynchronizationContextCore(ExecuteOnePendingUnderlyingSynchronizationContextCallbackDelegate, new UnderlyingSynchronizationContextCallback(this));
+            }
+            finally
+            {
+                synchronouslyPostingFactory = priorSynchronouslyPostingFactory;
+            }
+
+            lock (this.pendingUnderlyingSynchronizationContextCallbacksLock)
+            {
+                if (this.underlyingSynchronizationContextPostCompletion == postCompletion)
+                {
+                    this.underlyingSynchronizationContextPostCompletion = null;
+                }
+            }
+
+            postCompletion.SetResult(null);
         }
-        catch
+        catch (Exception ex)
         {
             lock (this.pendingUnderlyingSynchronizationContextCallbacksLock)
             {
-                // Every callback remains in its owning JoinableTask's execution queue, so abandon this
-                // secondary route when no underlying message was established.
-                this.pendingUnderlyingSynchronizationContextCallbacks = null;
-                this.underlyingSynchronizationContextCallbackPending = false;
+                if (this.underlyingSynchronizationContextPostCompletion == postCompletion)
+                {
+                    // Every callback remains in its owning JoinableTask's execution queue, so abandon this
+                    // secondary route when no underlying message was established.
+                    this.pendingUnderlyingSynchronizationContextCallbacks = null;
+                    this.underlyingSynchronizationContextCallbackPending = false;
+                    this.underlyingSynchronizationContextPostCompletion = null;
+                }
             }
 
+            postCompletion.SetException(ex);
+            _ = postCompletion.Task.Exception;
             throw;
         }
     }

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
@@ -23,6 +23,12 @@ namespace Microsoft.VisualStudio.Threading;
 /// </remarks>
 public partial class JoinableTaskFactory
 {
+    private static readonly ContextCallback ExecutePendingUnderlyingSynchronizationContextCallbackDelegate = state =>
+    {
+        var callback = ((SendOrPostCallback Callback, object State))state!;
+        callback.Callback(callback.State);
+    };
+
     private static readonly SendOrPostCallback ExecuteOnePendingUnderlyingSynchronizationContextCallbackDelegate = state => ((UnderlyingSynchronizationContextCallback)state!).Execute();
 
     [ThreadStatic]
@@ -42,7 +48,7 @@ public partial class JoinableTaskFactory
     /// </summary>
     private readonly JoinableTaskCollection? jobCollection;
 
-    private Queue<(SendOrPostCallback Callback, object State)>? pendingUnderlyingSynchronizationContextCallbacks;
+    private Queue<(SendOrPostCallback Callback, object State, ExecutionContext? ExecutionContext)>? pendingUnderlyingSynchronizationContextCallbacks;
 
     private bool underlyingSynchronizationContextCallbackPending;
 
@@ -686,12 +692,13 @@ public partial class JoinableTaskFactory
     {
         Requires.NotNull(callback, nameof(callback));
 
+        ExecutionContext? executionContext = ExecutionContext.Capture();
         bool postCallback = false;
         lock (this.pendingUnderlyingSynchronizationContextCallbacksLock)
         {
-            this.pendingUnderlyingSynchronizationContextCallbacks ??= new Queue<(SendOrPostCallback, object)>();
+            this.pendingUnderlyingSynchronizationContextCallbacks ??= new Queue<(SendOrPostCallback, object, ExecutionContext?)>();
             this.RemoveCompletedPendingUnderlyingSynchronizationContextCallbacks();
-            this.pendingUnderlyingSynchronizationContextCallbacks.Enqueue((callback, state));
+            this.pendingUnderlyingSynchronizationContextCallbacks.Enqueue((callback, state, executionContext));
             if (!this.underlyingSynchronizationContextCallbackPending)
             {
                 this.underlyingSynchronizationContextCallbackPending = true;
@@ -758,7 +765,7 @@ public partial class JoinableTaskFactory
         do
         {
             continueSynchronously = false;
-            (SendOrPostCallback Callback, object State)? callback = null;
+            (SendOrPostCallback Callback, object State, ExecutionContext? ExecutionContext)? callback = null;
             bool postSuccessor = false;
             bool completeSynchronousDrainAfterCallback = false;
             try
@@ -795,7 +802,14 @@ public partial class JoinableTaskFactory
 
                 if (callback is { } work)
                 {
-                    work.Callback(work.State);
+                    if (work.ExecutionContext is object)
+                    {
+                        ExecutionContext.Run(work.ExecutionContext, ExecutePendingUnderlyingSynchronizationContextCallbackDelegate, (work.Callback, work.State));
+                    }
+                    else
+                    {
+                        work.Callback(work.State);
+                    }
                 }
             }
             finally
@@ -827,12 +841,23 @@ public partial class JoinableTaskFactory
         {
             List<JoinableTaskFactory> synchronousPostingChain = synchronouslyPostingFactories ??= new();
             synchronousPostingChain.Add(this);
+            bool restoreFlow = !ExecutionContext.IsFlowSuppressed();
+            if (restoreFlow)
+            {
+                ExecutionContext.SuppressFlow();
+            }
+
             try
             {
                 this.PostToUnderlyingSynchronizationContextCore(ExecuteOnePendingUnderlyingSynchronizationContextCallbackDelegate, new UnderlyingSynchronizationContextCallback(this));
             }
             finally
             {
+                if (restoreFlow)
+                {
+                    ExecutionContext.RestoreFlow();
+                }
+
                 synchronousPostingChain.RemoveAt(synchronousPostingChain.Count - 1);
             }
         }

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
@@ -476,6 +476,13 @@ public partial class JoinableTaskFactory
     /// </summary>
     /// <param name="callback">The callback to invoke.</param>
     /// <param name="state">State to pass to the callback.</param>
+    /// <remarks>
+    /// The base implementation coalesces pending callbacks. An override replaces that behavior entirely,
+    /// preserving the semantics of derived types written before coalescing was introduced. A derived type
+    /// may opt into coalescing by calling <see cref="PostToUnderlyingSynchronizationContextWithCoalescing"/>
+    /// from this override and overriding <see cref="PostToUnderlyingSynchronizationContextCore"/> to perform
+    /// the actual post.
+    /// </remarks>
     protected internal virtual void PostToUnderlyingSynchronizationContext(SendOrPostCallback callback, object state)
     {
         Requires.NotNull(callback, nameof(callback));
@@ -489,6 +496,10 @@ public partial class JoinableTaskFactory
     /// </summary>
     /// <param name="callback">The callback to invoke.</param>
     /// <param name="state">State to pass to the callback.</param>
+    /// <remarks>
+    /// Derived types that opt into coalescing should override this method, rather than
+    /// <see cref="PostToUnderlyingSynchronizationContext"/>, with their custom dispatcher operation.
+    /// </remarks>
     protected internal virtual void PostToUnderlyingSynchronizationContextCore(SendOrPostCallback callback, object state)
     {
         Requires.NotNull(callback, nameof(callback));
@@ -666,6 +677,11 @@ public partial class JoinableTaskFactory
     /// State to pass to the callback. Implementing <see cref="IPendingExecutionRequestState"/> allows
     /// the callback to be removed from the private queue when it has already executed by another means.
     /// </param>
+    /// <remarks>
+    /// This method is intended for derived types that override <see cref="PostToUnderlyingSynchronizationContext"/>
+    /// and explicitly opt into coalescing. Such types should also override
+    /// <see cref="PostToUnderlyingSynchronizationContextCore"/> to perform the actual dispatcher post.
+    /// </remarks>
     protected void PostToUnderlyingSynchronizationContextWithCoalescing(SendOrPostCallback callback, object state)
     {
         Requires.NotNull(callback, nameof(callback));

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
@@ -26,7 +26,7 @@ public partial class JoinableTaskFactory
     private static readonly SendOrPostCallback ExecuteOnePendingUnderlyingSynchronizationContextCallbackDelegate = state => ((UnderlyingSynchronizationContextCallback)state!).Execute();
 
     [ThreadStatic]
-    private static JoinableTaskFactory? synchronouslyPostingFactory;
+    private static List<JoinableTaskFactory>? synchronouslyPostingFactories;
 
     /// <summary>
     /// The <see cref="JoinableTaskContext"/> that owns this instance.
@@ -694,10 +694,15 @@ public partial class JoinableTaskFactory
         {
             this.PostPendingUnderlyingSynchronizationContextCallback(postCompletion);
         }
-        else if (synchronouslyPostingFactory != this)
+        else if (!IsSynchronouslyPosting(this))
         {
             waitForPost?.GetAwaiter().GetResult();
         }
+    }
+
+    private static bool IsSynchronouslyPosting(JoinableTaskFactory factory)
+    {
+        return synchronouslyPostingFactories?.Contains(factory) is true;
     }
 
     /// <summary>
@@ -755,7 +760,7 @@ public partial class JoinableTaskFactory
                     }
 
                     this.RemoveCompletedPendingUnderlyingSynchronizationContextCallbacks();
-                    if (synchronouslyPostingFactory == this)
+                    if (IsSynchronouslyPosting(this))
                     {
                         completeSynchronousDrainAfterCallback = true;
                         continueSynchronously = this.pendingUnderlyingSynchronizationContextCallbacks?.Count > 0;
@@ -808,15 +813,15 @@ public partial class JoinableTaskFactory
     {
         try
         {
-            JoinableTaskFactory? priorSynchronouslyPostingFactory = synchronouslyPostingFactory;
-            synchronouslyPostingFactory = this;
+            List<JoinableTaskFactory> synchronousPostingChain = synchronouslyPostingFactories ??= new();
+            synchronousPostingChain.Add(this);
             try
             {
                 this.PostToUnderlyingSynchronizationContextCore(ExecuteOnePendingUnderlyingSynchronizationContextCallbackDelegate, new UnderlyingSynchronizationContextCallback(this));
             }
             finally
             {
-                synchronouslyPostingFactory = priorSynchronouslyPostingFactory;
+                synchronousPostingChain.RemoveAt(synchronousPostingChain.Count - 1);
             }
 
             lock (this.pendingUnderlyingSynchronizationContextCallbacksLock)

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
@@ -39,7 +39,7 @@ public partial class JoinableTaskFactory
     /// </summary>
     private readonly JoinableTaskCollection? jobCollection;
 
-    private Queue<SingleExecuteProtector>? pendingUnderlyingSynchronizationContextCallbacks;
+    private Queue<(SendOrPostCallback Callback, object State)>? pendingUnderlyingSynchronizationContextCallbacks;
 
     private bool underlyingSynchronizationContextCallbackPending;
 
@@ -422,20 +422,7 @@ public partial class JoinableTaskFactory
 
         if (this.UnderlyingSynchronizationContext is object)
         {
-            bool postCallback;
-            lock (this.pendingUnderlyingSynchronizationContextCallbacksLock)
-            {
-                this.pendingUnderlyingSynchronizationContextCallbacks ??= new Queue<SingleExecuteProtector>();
-                this.RemoveCompletedPendingUnderlyingSynchronizationContextCallbacks();
-                this.pendingUnderlyingSynchronizationContextCallbacks.Enqueue(callback);
-                postCallback = !this.underlyingSynchronizationContextCallbackPending;
-                this.underlyingSynchronizationContextCallbackPending = true;
-            }
-
-            if (postCallback)
-            {
-                this.PostPendingUnderlyingSynchronizationContextCallback();
-            }
+            this.PostToUnderlyingSynchronizationContext(SingleExecuteProtector.ExecuteOnce, callback);
         }
         else
         {
@@ -487,6 +474,19 @@ public partial class JoinableTaskFactory
     /// <param name="callback">The callback to invoke.</param>
     /// <param name="state">State to pass to the callback.</param>
     protected internal virtual void PostToUnderlyingSynchronizationContext(SendOrPostCallback callback, object state)
+    {
+        Requires.NotNull(callback, nameof(callback));
+        Assumes.NotNull(this.UnderlyingSynchronizationContext);
+
+        this.PostToUnderlyingSynchronizationContextWithCoalescing(callback, state);
+    }
+
+    /// <summary>
+    /// Posts a message directly to the underlying synchronization context.
+    /// </summary>
+    /// <param name="callback">The callback to invoke.</param>
+    /// <param name="state">State to pass to the callback.</param>
+    protected internal virtual void PostToUnderlyingSynchronizationContextCore(SendOrPostCallback callback, object state)
     {
         Requires.NotNull(callback, nameof(callback));
         Assumes.NotNull(this.UnderlyingSynchronizationContext);
@@ -656,6 +656,34 @@ public partial class JoinableTaskFactory
     }
 
     /// <summary>
+    /// Posts a message to the underlying synchronization context while coalescing pending messages.
+    /// </summary>
+    /// <param name="callback">The callback to invoke.</param>
+    /// <param name="state">
+    /// State to pass to the callback. Implementing <see cref="IPendingExecutionRequestState"/> allows
+    /// the callback to be removed from the private queue when it has already executed by another means.
+    /// </param>
+    protected void PostToUnderlyingSynchronizationContextWithCoalescing(SendOrPostCallback callback, object state)
+    {
+        Requires.NotNull(callback, nameof(callback));
+
+        bool postCallback;
+        lock (this.pendingUnderlyingSynchronizationContextCallbacksLock)
+        {
+            this.pendingUnderlyingSynchronizationContextCallbacks ??= new Queue<(SendOrPostCallback, object)>();
+            this.RemoveCompletedPendingUnderlyingSynchronizationContextCallbacks();
+            this.pendingUnderlyingSynchronizationContextCallbacks.Enqueue((callback, state));
+            postCallback = !this.underlyingSynchronizationContextCallbackPending;
+            this.underlyingSynchronizationContextCallbackPending = true;
+        }
+
+        if (postCallback)
+        {
+            this.PostPendingUnderlyingSynchronizationContextCallback();
+        }
+    }
+
+    /// <summary>
     /// Throws an exception if an active AsyncReaderWriterLock
     /// upgradeable read or write lock is held by the caller.
     /// </summary>
@@ -682,7 +710,7 @@ public partial class JoinableTaskFactory
 
     private void ExecuteOnePendingUnderlyingSynchronizationContextCallback()
     {
-        SingleExecuteProtector? callback = null;
+        (SendOrPostCallback Callback, object State)? callback = null;
         try
         {
             lock (this.pendingUnderlyingSynchronizationContextCallbacksLock)
@@ -694,7 +722,10 @@ public partial class JoinableTaskFactory
                 }
             }
 
-            callback?.TryExecute();
+            if (callback is { } work)
+            {
+                work.Callback(work.State);
+            }
         }
         finally
         {
@@ -722,7 +753,7 @@ public partial class JoinableTaskFactory
     {
         try
         {
-            this.PostToUnderlyingSynchronizationContext(ExecuteOnePendingUnderlyingSynchronizationContextCallbackDelegate, this);
+            this.PostToUnderlyingSynchronizationContextCore(ExecuteOnePendingUnderlyingSynchronizationContextCallbackDelegate, this);
         }
         catch
         {
@@ -742,7 +773,10 @@ public partial class JoinableTaskFactory
     {
         Assumes.True(Monitor.IsEntered(this.pendingUnderlyingSynchronizationContextCallbacksLock));
 
-        while (this.pendingUnderlyingSynchronizationContextCallbacks?.Count > 0 && this.pendingUnderlyingSynchronizationContextCallbacks.Peek().HasBeenExecuted)
+#pragma warning disable VSOnly // IPendingExecutionRequestState is intended for evaluation purposes only.
+        while (this.pendingUnderlyingSynchronizationContextCallbacks?.Count > 0
+            && this.pendingUnderlyingSynchronizationContextCallbacks.Peek().State is IPendingExecutionRequestState { IsCompleted: true })
+#pragma warning restore VSOnly
         {
             this.pendingUnderlyingSynchronizationContextCallbacks.Dequeue();
         }

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
@@ -1533,7 +1533,6 @@ public partial class JoinableTaskFactory
                 this.job.Factory.OnTransitionedToMainThread(this.job, !this.job.Factory.Context.IsOnMainThread);
             }
         }
-
     }
 
     private sealed class UnderlyingSynchronizationContextCallback

--- a/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
+++ b/src/Microsoft.VisualStudio.Threading/JoinableTaskFactory.cs
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.Threading;
 /// </remarks>
 public partial class JoinableTaskFactory
 {
-    private static readonly SendOrPostCallback ExecuteOnePendingUnderlyingSynchronizationContextCallbackDelegate = state => ((JoinableTaskFactory)state!).ExecuteOnePendingUnderlyingSynchronizationContextCallback();
+    private static readonly SendOrPostCallback ExecuteOnePendingUnderlyingSynchronizationContextCallbackDelegate = state => ((UnderlyingSynchronizationContextCallback)state!).Execute();
 
     /// <summary>
     /// The <see cref="JoinableTaskContext"/> that owns this instance.
@@ -753,7 +753,7 @@ public partial class JoinableTaskFactory
     {
         try
         {
-            this.PostToUnderlyingSynchronizationContextCore(ExecuteOnePendingUnderlyingSynchronizationContextCallbackDelegate, this);
+            this.PostToUnderlyingSynchronizationContextCore(ExecuteOnePendingUnderlyingSynchronizationContextCallbackDelegate, new UnderlyingSynchronizationContextCallback(this));
         }
         catch
         {
@@ -1532,6 +1532,22 @@ public partial class JoinableTaskFactory
 
                 this.job.Factory.OnTransitionedToMainThread(this.job, !this.job.Factory.Context.IsOnMainThread);
             }
+        }
+
+    }
+
+    private sealed class UnderlyingSynchronizationContextCallback
+    {
+        private JoinableTaskFactory? factory;
+
+        internal UnderlyingSynchronizationContextCallback(JoinableTaskFactory factory)
+        {
+            this.factory = factory;
+        }
+
+        internal void Execute()
+        {
+            Interlocked.Exchange(ref this.factory, null)?.ExecuteOnePendingUnderlyingSynchronizationContextCallback();
         }
     }
 }

--- a/test/Microsoft.VisualStudio.Threading.Tests/DispatcherExtensionsTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/DispatcherExtensionsTests.cs
@@ -4,6 +4,7 @@
 #if NETFRAMEWORK || WINDOWS
 
 using System;
+using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Threading;
@@ -64,6 +65,85 @@ public class DispatcherExtensionsTests : JoinableTaskTestBase
                 Assert.False(idleTask.IsCompleted);
             });
             await Task.WhenAll(idleTask.Task, normalTask.Task).WithCancellation(this.TimeoutToken);
+        });
+    }
+
+    [Fact]
+    public void WithPriority_PreservesDispatcherCultureSemantics()
+    {
+        this.SimulateUIThread(async delegate
+        {
+            var dispatcherCulture = CultureInfo.GetCultureInfo("en-US");
+            var postingCulture = CultureInfo.GetCultureInfo("fr-FR");
+            var callbackCulture = CultureInfo.GetCultureInfo("de-DE");
+            Dispatcher dispatcher = Dispatcher.CurrentDispatcher;
+            JoinableTaskFactory factory = this.asyncPump.WithPriority(dispatcher, DispatcherPriority.Normal);
+            var dispatcherCultureEstablished = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+            CultureInfo? originalDispatcherCulture = null;
+            CultureInfo? originalDispatcherUICulture = null;
+            _ = dispatcher.BeginInvoke(new Action(delegate
+            {
+                originalDispatcherCulture = CultureInfo.CurrentCulture;
+                originalDispatcherUICulture = CultureInfo.CurrentUICulture;
+                CultureInfo.CurrentCulture = dispatcherCulture;
+                CultureInfo.CurrentUICulture = dispatcherCulture;
+                dispatcherCultureEstablished.SetResult(null);
+            }));
+            await dispatcherCultureEstablished.Task.WithCancellation(this.TimeoutToken);
+
+            try
+            {
+                CultureInfo? observedCulture = null;
+                CultureInfo? observedUICulture = null;
+                CultureInfo? cultureAfterCallback = null;
+                var callbackCompleted = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var observedAfterCallback = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+                await Task.Run(delegate
+                {
+                    CultureInfo.CurrentCulture = postingCulture;
+                    CultureInfo.CurrentUICulture = postingCulture;
+                    JoinableTaskFactory.MainThreadAwaiter awaiter = factory.SwitchToMainThreadAsync().GetAwaiter();
+                    awaiter.OnCompleted(delegate
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            observedCulture = CultureInfo.CurrentCulture;
+                            observedUICulture = CultureInfo.CurrentUICulture;
+                            CultureInfo.CurrentCulture = callbackCulture;
+                            CultureInfo.CurrentUICulture = callbackCulture;
+                            _ = dispatcher.BeginInvoke(new Action(delegate
+                            {
+                                cultureAfterCallback = CultureInfo.CurrentCulture;
+                                observedAfterCallback.SetResult(null);
+                            }));
+                            callbackCompleted.SetResult(null);
+                        }
+                        catch (Exception ex)
+                        {
+                            callbackCompleted.SetException(ex);
+                        }
+                    });
+                });
+
+                await callbackCompleted.Task.WithCancellation(this.TimeoutToken);
+                await observedAfterCallback.Task.WithCancellation(this.TimeoutToken);
+                Assert.Equal(dispatcherCulture, observedCulture);
+                Assert.Equal(dispatcherCulture, observedUICulture);
+                Assert.Equal(callbackCulture, cultureAfterCallback);
+            }
+            finally
+            {
+                var dispatcherCultureRestored = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+                _ = dispatcher.BeginInvoke(new Action(delegate
+                {
+                    CultureInfo.CurrentCulture = originalDispatcherCulture!;
+                    CultureInfo.CurrentUICulture = originalDispatcherUICulture!;
+                    dispatcherCultureRestored.SetResult(null);
+                }));
+                await dispatcherCultureRestored.Task.WithCancellation(this.TimeoutToken);
+            }
         });
     }
 

--- a/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskFactoryTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskFactoryTests.cs
@@ -146,10 +146,13 @@ public class JoinableTaskFactoryTests : JoinableTaskTestBase
         var factory = new QueueingJoinableTaskFactory(this.context);
         int executionCount = 0;
 
-        (JoinableTask _, Task firstQueued) = factory.QueueCallback(() => executionCount++);
-        (JoinableTask _, Task secondQueued) = factory.QueueCallback(() => executionCount++);
-        (JoinableTask _, Task thirdQueued) = factory.QueueCallback(() => executionCount++);
-        Task.WhenAll(firstQueued, secondQueued, thirdQueued).GetAwaiter().GetResult();
+        factory.QueueUnderlyingCallback(delegate
+        {
+            Assert.Single(factory.PostedCallbacks);
+            executionCount++;
+        });
+        factory.QueueUnderlyingCallback(() => executionCount++);
+        factory.QueueUnderlyingCallback(() => executionCount++);
 
         Assert.Single(factory.PostedCallbacks);
         factory.ExecutePostedCallback();
@@ -359,6 +362,11 @@ public class JoinableTaskFactoryTests : JoinableTaskTestBase
             Assert.True(this.PostedCallbacks.TryDequeue(out (SendOrPostCallback Callback, object State) work));
             (SendOrPostCallback callback, object state) = work;
             callback(state);
+        }
+
+        internal void QueueUnderlyingCallback(Action callback)
+        {
+            this.PostToUnderlyingSynchronizationContextWithCoalescing(static state => ((Action)state!).Invoke(), callback);
         }
 
         internal (JoinableTask Job, Task Queued) QueueCallback(Action callback)

--- a/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskFactoryTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskFactoryTests.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Concurrent;
+using System.Threading;
 using System.Threading.Tasks;
 
 public class JoinableTaskFactoryTests : JoinableTaskTestBase
@@ -139,6 +141,48 @@ public class JoinableTaskFactoryTests : JoinableTaskTestBase
     }
 
     [Fact]
+    public void PostsToUnderlyingSynchronizationContextConservatively()
+    {
+        var factory = new QueueingJoinableTaskFactory(this.context);
+        int executionCount = 0;
+
+        (JoinableTask _, Task firstQueued) = factory.QueueCallback(() => executionCount++);
+        (JoinableTask _, Task secondQueued) = factory.QueueCallback(() => executionCount++);
+        (JoinableTask _, Task thirdQueued) = factory.QueueCallback(() => executionCount++);
+        Task.WhenAll(firstQueued, secondQueued, thirdQueued).GetAwaiter().GetResult();
+
+        Assert.Single(factory.PostedCallbacks);
+        factory.ExecutePostedCallback();
+        Assert.Equal(1, executionCount);
+        Assert.Single(factory.PostedCallbacks);
+        factory.ExecutePostedCallback();
+        Assert.Equal(2, executionCount);
+        Assert.Single(factory.PostedCallbacks);
+        factory.ExecutePostedCallback();
+        Assert.Equal(3, executionCount);
+        Assert.Empty(factory.PostedCallbacks);
+    }
+
+    [Fact]
+    public void CompletedCallbacksAreRemovedBeforePostingAnotherMessage()
+    {
+        var factory = new QueueingJoinableTaskFactory(this.context);
+        int executionCount = 0;
+        (JoinableTask first, Task firstQueued) = factory.QueueCallback(() => executionCount++);
+        (JoinableTask second, Task secondQueued) = factory.QueueCallback(() => executionCount++);
+        (JoinableTask _, Task thirdQueued) = factory.QueueCallback(() => executionCount++);
+        Task.WhenAll(firstQueued, secondQueued, thirdQueued).GetAwaiter().GetResult();
+
+        first.Join();
+        second.Join();
+
+        Assert.Single(factory.PostedCallbacks);
+        factory.ExecutePostedCallback();
+        Assert.Equal(3, executionCount);
+        Assert.Empty(factory.PostedCallbacks);
+    }
+
+    [Fact]
     public void DisableProcessing_ThrowsOutsideJoinableTask()
     {
         Assert.Throws<InvalidOperationException>(() => this.asyncPump.DisableProcessing());
@@ -267,6 +311,47 @@ public class JoinableTaskFactoryTests : JoinableTaskTestBase
         {
             base.OnTransitionedToMainThread(joinableTask, canceled);
             this.OnTransitionedToMainThreadCallback?.Invoke(joinableTask, canceled);
+        }
+    }
+
+    private class QueueingJoinableTaskFactory : JoinableTaskFactory
+    {
+        internal QueueingJoinableTaskFactory(JoinableTaskContext owner)
+            : base(owner)
+        {
+        }
+
+        internal ConcurrentQueue<(SendOrPostCallback Callback, object State)> PostedCallbacks { get; } = new();
+
+        internal void ExecutePostedCallback()
+        {
+            Assert.True(this.PostedCallbacks.TryDequeue(out (SendOrPostCallback Callback, object State) work));
+            (SendOrPostCallback callback, object state) = work;
+            callback(state);
+        }
+
+        internal (JoinableTask Job, Task Queued) QueueCallback(Action callback)
+        {
+            var queued = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+            JoinableTask job = this.RunAsync(async delegate
+            {
+                await TaskScheduler.Default.SwitchTo(alwaysYield: true);
+                var callbackCompleted = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+                this.SwitchToMainThreadAsync().GetAwaiter().OnCompleted(delegate
+                {
+                    callback();
+                    callbackCompleted.SetResult(null);
+                });
+                queued.SetResult(null);
+                await callbackCompleted.Task;
+            });
+
+            return (job, queued.Task);
+        }
+
+        protected override void PostToUnderlyingSynchronizationContext(SendOrPostCallback callback, object state)
+        {
+            this.PostedCallbacks.Enqueue((callback, state));
         }
     }
 }

--- a/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskFactoryTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskFactoryTests.cs
@@ -232,6 +232,21 @@ public class JoinableTaskFactoryTests : JoinableTaskTestBase
     }
 
     [Fact]
+    public void CoalescingSupportsSynchronousUnderlyingPostAcrossFactories()
+    {
+        var firstFactory = new SynchronouslyPostingJoinableTaskFactory(this.context);
+        var secondFactory = new SynchronouslyPostingJoinableTaskFactory(this.context);
+        using var completed = new ManualResetEventSlim();
+
+        Task postTask = Task.Run(() => firstFactory.Post(() => secondFactory.Post(() => firstFactory.Post(completed.Set))));
+
+        Assert.True(postTask.Wait(UnexpectedTimeout));
+        Assert.True(completed.IsSet);
+        Assert.Equal(1, firstFactory.MaximumPostDepth);
+        Assert.Equal(1, secondFactory.MaximumPostDepth);
+    }
+
+    [Fact]
     public void DisableProcessing_ThrowsOutsideJoinableTask()
     {
         Assert.Throws<InvalidOperationException>(() => this.asyncPump.DisableProcessing());

--- a/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskFactoryTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskFactoryTests.cs
@@ -201,6 +201,15 @@ public class JoinableTaskFactoryTests : JoinableTaskTestBase
     }
 
     [Fact]
+    public void InitialPostFailurePropagates()
+    {
+        var factory = new QueueingJoinableTaskFactory(this.context) { FailNextPost = true };
+
+        Assert.Throws<InvalidOperationException>(() => factory.QueueUnderlyingCallback(() => { }));
+        Assert.Empty(factory.PostedCallbacks);
+    }
+
+    [Fact]
     public void DerivedFactoryDoesNotCoalesceUnlessOptedIn()
     {
         var factory = new NonCoalescingJoinableTaskFactory(this.context);

--- a/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskFactoryTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskFactoryTests.cs
@@ -500,7 +500,18 @@ public class JoinableTaskFactoryTests : JoinableTaskTestBase
         protected override void PostToUnderlyingSynchronizationContextCore(SendOrPostCallback callback, object state)
         {
             int depth = Interlocked.Increment(ref this.currentPostDepth);
-            Interlocked.Exchange(ref this.maximumPostDepth, Math.Max(this.MaximumPostDepth, depth));
+            int observedMaximum = this.MaximumPostDepth;
+            while (depth > observedMaximum)
+            {
+                int priorMaximum = Interlocked.CompareExchange(ref this.maximumPostDepth, depth, observedMaximum);
+                if (priorMaximum == observedMaximum)
+                {
+                    break;
+                }
+
+                observedMaximum = priorMaximum;
+            }
+
             try
             {
                 callback(state);

--- a/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskFactoryTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskFactoryTests.cs
@@ -339,8 +339,15 @@ public class JoinableTaskFactoryTests : JoinableTaskTestBase
                 var callbackCompleted = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
                 this.SwitchToMainThreadAsync().GetAwaiter().OnCompleted(delegate
                 {
-                    callback();
-                    callbackCompleted.SetResult(null);
+                    try
+                    {
+                        callback();
+                        callbackCompleted.SetResult(null);
+                    }
+                    catch (Exception ex)
+                    {
+                        callbackCompleted.SetException(ex);
+                    }
                 });
                 queued.SetResult(null);
                 await callbackCompleted.Task;

--- a/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskFactoryTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskFactoryTests.cs
@@ -196,6 +196,17 @@ public class JoinableTaskFactoryTests : JoinableTaskTestBase
     }
 
     [Fact]
+    public void CoalescingSupportsSynchronousUnderlyingPost()
+    {
+        var factory = new SynchronouslyPostingJoinableTaskFactory(this.context);
+        int executionCount = 0;
+
+        factory.Post(() => factory.Post(() => executionCount++));
+
+        Assert.Equal(1, executionCount);
+    }
+
+    [Fact]
     public void DisableProcessing_ThrowsOutsideJoinableTask()
     {
         Assert.Throws<InvalidOperationException>(() => this.asyncPump.DisableProcessing());
@@ -350,10 +361,12 @@ public class JoinableTaskFactoryTests : JoinableTaskTestBase
             {
                 await TaskScheduler.Default.SwitchTo(alwaysYield: true);
                 var callbackCompleted = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
-                this.SwitchToMainThreadAsync().GetAwaiter().OnCompleted(delegate
+                JoinableTaskFactory.MainThreadAwaiter awaiter = this.SwitchToMainThreadAsync().GetAwaiter();
+                awaiter.OnCompleted(delegate
                 {
                     try
                     {
+                        awaiter.GetResult();
                         callback();
                         callbackCompleted.SetResult(null);
                     }
@@ -402,6 +415,24 @@ public class JoinableTaskFactoryTests : JoinableTaskTestBase
         protected override void PostToUnderlyingSynchronizationContext(SendOrPostCallback callback, object state)
         {
             Interlocked.Increment(ref this.postCount);
+        }
+    }
+
+    private class SynchronouslyPostingJoinableTaskFactory : JoinableTaskFactory
+    {
+        internal SynchronouslyPostingJoinableTaskFactory(JoinableTaskContext owner)
+            : base(owner)
+        {
+        }
+
+        internal void Post(Action callback)
+        {
+            this.PostToUnderlyingSynchronizationContextWithCoalescing(state => ((Action)state!).Invoke(), callback);
+        }
+
+        protected override void PostToUnderlyingSynchronizationContextCore(SendOrPostCallback callback, object state)
+        {
+            callback(state);
         }
     }
 }

--- a/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskFactoryTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskFactoryTests.cs
@@ -186,6 +186,21 @@ public class JoinableTaskFactoryTests : JoinableTaskTestBase
     }
 
     [Fact]
+    public void RepostFailureDoesNotPreventCurrentCallback()
+    {
+        var factory = new QueueingJoinableTaskFactory(this.context);
+        int executionCount = 0;
+        factory.QueueUnderlyingCallback(() => executionCount++);
+        factory.QueueUnderlyingCallback(() => executionCount++);
+        factory.FailNextPost = true;
+
+        factory.ExecutePostedCallback();
+
+        Assert.Equal(1, executionCount);
+        Assert.Empty(factory.PostedCallbacks);
+    }
+
+    [Fact]
     public void DerivedFactoryDoesNotCoalesceUnlessOptedIn()
     {
         var factory = new NonCoalescingJoinableTaskFactory(this.context);
@@ -357,6 +372,8 @@ public class JoinableTaskFactoryTests : JoinableTaskTestBase
 
         internal ConcurrentQueue<(SendOrPostCallback Callback, object State)> PostedCallbacks { get; } = new();
 
+        internal bool FailNextPost { get; set; }
+
         internal void ExecutePostedCallback()
         {
             Assert.True(this.PostedCallbacks.TryDequeue(out (SendOrPostCallback Callback, object State) work));
@@ -399,6 +416,12 @@ public class JoinableTaskFactoryTests : JoinableTaskTestBase
 
         protected override void PostToUnderlyingSynchronizationContextCore(SendOrPostCallback callback, object state)
         {
+            if (this.FailNextPost)
+            {
+                this.FailNextPost = false;
+                throw new InvalidOperationException();
+            }
+
             this.PostedCallbacks.Enqueue((callback, state));
         }
     }

--- a/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskFactoryTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskFactoryTests.cs
@@ -183,6 +183,19 @@ public class JoinableTaskFactoryTests : JoinableTaskTestBase
     }
 
     [Fact]
+    public void DerivedFactoryDoesNotCoalesceUnlessOptedIn()
+    {
+        var factory = new NonCoalescingJoinableTaskFactory(this.context);
+
+        (JoinableTask _, Task firstQueued) = factory.QueueCallback();
+        (JoinableTask _, Task secondQueued) = factory.QueueCallback();
+        Task.WhenAll(firstQueued, secondQueued).GetAwaiter().GetResult();
+
+        Assert.True(SpinWait.SpinUntil(() => factory.PostCount == 2, UnexpectedTimeout));
+        Assert.Equal(2, factory.PostCount);
+    }
+
+    [Fact]
     public void DisableProcessing_ThrowsOutsideJoinableTask()
     {
         Assert.Throws<InvalidOperationException>(() => this.asyncPump.DisableProcessing());
@@ -356,9 +369,39 @@ public class JoinableTaskFactoryTests : JoinableTaskTestBase
             return (job, queued.Task);
         }
 
-        protected override void PostToUnderlyingSynchronizationContext(SendOrPostCallback callback, object state)
+        protected override void PostToUnderlyingSynchronizationContextCore(SendOrPostCallback callback, object state)
         {
             this.PostedCallbacks.Enqueue((callback, state));
+        }
+    }
+
+    private class NonCoalescingJoinableTaskFactory : JoinableTaskFactory
+    {
+        private int postCount;
+
+        internal NonCoalescingJoinableTaskFactory(JoinableTaskContext owner)
+            : base(owner)
+        {
+        }
+
+        internal int PostCount => Volatile.Read(ref this.postCount);
+
+        internal (JoinableTask Job, Task Queued) QueueCallback()
+        {
+            var queued = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+            JoinableTask job = this.RunAsync(async delegate
+            {
+                await TaskScheduler.Default.SwitchTo(alwaysYield: true);
+                this.SwitchToMainThreadAsync().GetAwaiter().OnCompleted(() => { });
+                queued.SetResult(null);
+            });
+
+            return (job, queued.Task);
+        }
+
+        protected override void PostToUnderlyingSynchronizationContext(SendOrPostCallback callback, object state)
+        {
+            Interlocked.Increment(ref this.postCount);
         }
     }
 }

--- a/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskFactoryTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskFactoryTests.cs
@@ -255,6 +255,25 @@ public class JoinableTaskFactoryTests : JoinableTaskTestBase
         Assert.Equal(1, secondFactory.MaximumPostDepth);
     }
 
+    [Fact]
+    public void CoalescingSupportsSynchronousCallbackExceptions()
+    {
+        var factory = new SynchronouslyPostingJoinableTaskFactory(this.context);
+        bool nestedCallbackExecuted = false;
+        bool subsequentCallbackExecuted = false;
+
+        Assert.Throws<InvalidOperationException>(() => factory.Post(delegate
+        {
+            factory.Post(() => nestedCallbackExecuted = true);
+            throw new InvalidOperationException();
+        }));
+
+        Assert.True(nestedCallbackExecuted);
+        factory.Post(() => subsequentCallbackExecuted = true);
+        Assert.True(subsequentCallbackExecuted);
+        Assert.Equal(1, factory.MaximumPostDepth);
+    }
+
     [Theory]
     [InlineData(true, true)]
     [InlineData(true, false)]

--- a/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskFactoryTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskFactoryTests.cs
@@ -255,6 +255,45 @@ public class JoinableTaskFactoryTests : JoinableTaskTestBase
         Assert.Equal(1, secondFactory.MaximumPostDepth);
     }
 
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public void CoalescingPreservesExecutionContextPerCallback(bool firstFlowsExecutionContext, bool secondFlowsExecutionContext)
+    {
+        var factory = new QueueingJoinableTaskFactory(this.context);
+        var asyncLocal = new System.Threading.AsyncLocal<string?>();
+        string? firstObservedValue = null;
+        string? secondObservedValue = null;
+
+        asyncLocal.Value = "first";
+        QueueCallback(firstFlowsExecutionContext, () => firstObservedValue = asyncLocal.Value);
+        asyncLocal.Value = "second";
+        QueueCallback(secondFlowsExecutionContext, () => secondObservedValue = asyncLocal.Value);
+        asyncLocal.Value = null;
+
+        factory.ExecutePostedCallback();
+        factory.ExecutePostedCallback();
+
+        Assert.Equal(firstFlowsExecutionContext ? "first" : null, firstObservedValue);
+        Assert.Equal(secondFlowsExecutionContext ? "second" : null, secondObservedValue);
+
+        void QueueCallback(bool flowExecutionContext, Action callback)
+        {
+            if (flowExecutionContext)
+            {
+                factory.QueueUnderlyingCallback(callback);
+            }
+            else
+            {
+                using (ExecutionContext.SuppressFlow())
+                {
+                    factory.QueueUnderlyingCallback(callback);
+                }
+            }
+        }
+    }
+
     [Fact]
     public void DisableProcessing_ThrowsOutsideJoinableTask()
     {

--- a/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskFactoryTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Tests/JoinableTaskFactoryTests.cs
@@ -201,9 +201,16 @@ public class JoinableTaskFactoryTests : JoinableTaskTestBase
         var factory = new SynchronouslyPostingJoinableTaskFactory(this.context);
         int executionCount = 0;
 
-        factory.Post(() => factory.Post(() => executionCount++));
+        factory.Post(delegate
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                factory.Post(() => executionCount++);
+            }
+        });
 
-        Assert.Equal(1, executionCount);
+        Assert.Equal(100, executionCount);
+        Assert.Equal(1, factory.MaximumPostDepth);
     }
 
     [Fact]
@@ -420,10 +427,15 @@ public class JoinableTaskFactoryTests : JoinableTaskTestBase
 
     private class SynchronouslyPostingJoinableTaskFactory : JoinableTaskFactory
     {
+        private int currentPostDepth;
+        private int maximumPostDepth;
+
         internal SynchronouslyPostingJoinableTaskFactory(JoinableTaskContext owner)
             : base(owner)
         {
         }
+
+        internal int MaximumPostDepth => Volatile.Read(ref this.maximumPostDepth);
 
         internal void Post(Action callback)
         {
@@ -432,7 +444,16 @@ public class JoinableTaskFactoryTests : JoinableTaskTestBase
 
         protected override void PostToUnderlyingSynchronizationContextCore(SendOrPostCallback callback, object state)
         {
-            callback(state);
+            int depth = Interlocked.Increment(ref this.currentPostDepth);
+            Interlocked.Exchange(ref this.maximumPostDepth, Math.Max(this.MaximumPostDepth, depth));
+            try
+            {
+                callback(state);
+            }
+            finally
+            {
+                Interlocked.Decrement(ref this.currentPostDepth);
+            }
         }
     }
 }


### PR DESCRIPTION
Repeated main-thread transitions can leave large numbers of already-executed work items in the underlying dispatcher queue, consuming memory and CPU until the dispatcher eventually processes them.

This change adds a private per-factory queue for pending main-thread callbacks. It keeps at most one lower-level synchronization-context message outstanding, removes callbacks that were already executed through another JTF avenue, and reposts one item at a time to preserve dispatcher fairness. The existing virtual posting hook remains intact, so dispatcher-priority and delegating factories retain their scheduling behavior.

Tests cover conservative posting, stale callback removal, dispatcher priority, and delegating factories across the configured target frameworks.

Fixes #1272

## Validation

* [x] [Validation insertion](https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=15050640&view=results)
* [ ] [Validation PR](https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/772743)