### PR TITLE
Fix VSTHRD010 worker thread transitions

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/CSharpCommonInterest.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/CSharpCommonInterest.cs
@@ -22,6 +22,7 @@ internal static class CSharpCommonInterest
         SyntaxKind.AnonymousMethodExpression,
         SyntaxKind.SimpleLambdaExpression,
         SyntaxKind.ParenthesizedLambdaExpression,
+        SyntaxKind.LocalFunctionStatement,
         SyntaxKind.GetAccessorDeclaration,
         SyntaxKind.SetAccessorDeclaration,
         SyntaxKind.AddAccessorDeclaration,

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD010MainThreadUsageAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD010MainThreadUsageAnalyzer.cs
@@ -302,7 +302,8 @@ public class VSTHRD010MainThreadUsageAnalyzer : DiagnosticAnalyzer
 
     private class MethodAnalyzer
     {
-        private ImmutableDictionary<SyntaxNode, ThreadingContext> methodDeclarationNodes = ImmutableDictionary<SyntaxNode, ThreadingContext>.Empty;
+        private readonly object methodDeclarationNodesSyncObject = new object();
+        private ImmutableDictionary<SyntaxNode, ImmutableArray<ThreadingContextTransition>> methodDeclarationNodes = ImmutableDictionary<SyntaxNode, ImmutableArray<ThreadingContextTransition>>.Empty;
 
         public MethodAnalyzer(
             ImmutableArray<CommonInterest.QualifiedMember> mainThreadAssertingMethods,
@@ -338,7 +339,7 @@ public class VSTHRD010MainThreadUsageAnalyzer : DiagnosticAnalyzer
             SyntaxNode? methodDeclaration = context.Node.FirstAncestorOrSelf<SyntaxNode>(n => CSharpCommonInterest.MethodSyntaxKinds.Contains(n.Kind()));
             if (methodDeclaration is object && InvalidatesMainThreadContext(awaitSyntax.Expression, context.SemanticModel, context.CancellationToken))
             {
-                this.methodDeclarationNodes = this.methodDeclarationNodes.SetItem(methodDeclaration, ThreadingContext.Unknown);
+                this.RecordThreadingContext(methodDeclaration, awaitSyntax.Span.End, ThreadingContext.Unknown);
             }
 
             static bool InvalidatesMainThreadContext(ExpressionSyntax awaitedExpression, SemanticModel semanticModel, CancellationToken cancellationToken)
@@ -390,7 +391,7 @@ public class VSTHRD010MainThreadUsageAnalyzer : DiagnosticAnalyzer
                             }
                         }
 
-                        this.methodDeclarationNodes = this.methodDeclarationNodes.SetItem(methodDeclaration, ThreadingContext.MainThread);
+                        this.RecordThreadingContext(methodDeclaration, invocationSyntax.Span.End, ThreadingContext.MainThread);
                         return;
                     }
                 }
@@ -506,7 +507,18 @@ public class VSTHRD010MainThreadUsageAnalyzer : DiagnosticAnalyzer
                 SyntaxNode? methodDeclaration = context.Node.FirstAncestorOrSelf<SyntaxNode>(n => CSharpCommonInterest.MethodSyntaxKinds.Contains(n.Kind()));
                 if (methodDeclaration is object)
                 {
-                    threadingContext = this.methodDeclarationNodes.GetValueOrDefault(methodDeclaration);
+                    lock (this.methodDeclarationNodesSyncObject)
+                    {
+                        ImmutableArray<ThreadingContextTransition> transitions = this.methodDeclarationNodes.GetValueOrDefault(methodDeclaration);
+                        if (!transitions.IsDefault)
+                        {
+                            threadingContext = transitions
+                                .Where(transition => transition.Position <= context.Node.SpanStart)
+                                .OrderByDescending(transition => transition.Position)
+                                .Select(transition => transition.Context)
+                                .FirstOrDefault();
+                        }
+                    }
                 }
 
                 if (threadingContext != ThreadingContext.MainThread)
@@ -521,6 +533,33 @@ public class VSTHRD010MainThreadUsageAnalyzer : DiagnosticAnalyzer
             }
 
             return false;
+        }
+
+        private void RecordThreadingContext(SyntaxNode methodDeclaration, int position, ThreadingContext context)
+        {
+            lock (this.methodDeclarationNodesSyncObject)
+            {
+                ImmutableArray<ThreadingContextTransition> transitions = this.methodDeclarationNodes.GetValueOrDefault(methodDeclaration);
+                if (transitions.IsDefault)
+                {
+                    transitions = ImmutableArray<ThreadingContextTransition>.Empty;
+                }
+
+                this.methodDeclarationNodes = this.methodDeclarationNodes.SetItem(methodDeclaration, transitions.Add(new ThreadingContextTransition(position, context)));
+            }
+        }
+
+        private readonly struct ThreadingContextTransition
+        {
+            internal ThreadingContextTransition(int position, ThreadingContext context)
+            {
+                this.Position = position;
+                this.Context = context;
+            }
+
+            internal int Position { get; }
+
+            internal ThreadingContext Context { get; }
         }
     }
 }

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD010MainThreadUsageAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD010MainThreadUsageAnalyzer.cs
@@ -139,7 +139,6 @@ public class VSTHRD010MainThreadUsageAnalyzer : DiagnosticAnalyzer
                     methodsDeclaringUIThreadRequirement: methodsDeclaringUIThreadRequirement,
                     methodsAssertingUIThreadRequirement: methodsAssertingUIThreadRequirement,
                     diagnosticProperties: diagnosticProperties);
-                codeBlockStartContext.RegisterSyntaxNodeAction(Utils.DebuggableWrapper(methodAnalyzer.AnalyzeAwait), SyntaxKind.AwaitExpression);
                 codeBlockStartContext.RegisterSyntaxNodeAction(Utils.DebuggableWrapper(methodAnalyzer.AnalyzeInvocation), SyntaxKind.InvocationExpression);
                 codeBlockStartContext.RegisterSyntaxNodeAction(Utils.DebuggableWrapper(methodAnalyzer.AnalyzeMemberAccess), SyntaxKind.SimpleMemberAccessExpression);
                 codeBlockStartContext.RegisterSyntaxNodeAction(Utils.DebuggableWrapper(methodAnalyzer.AnalyzeCast), SyntaxKind.CastExpression);
@@ -333,35 +332,6 @@ public class VSTHRD010MainThreadUsageAnalyzer : DiagnosticAnalyzer
 
         internal ImmutableDictionary<string, string?> DiagnosticProperties { get; }
 
-        internal void AnalyzeAwait(SyntaxNodeAnalysisContext context)
-        {
-            var awaitSyntax = (AwaitExpressionSyntax)context.Node;
-            SyntaxNode? methodDeclaration = context.Node.FirstAncestorOrSelf<SyntaxNode>(n => CSharpCommonInterest.MethodSyntaxKinds.Contains(n.Kind()));
-            if (methodDeclaration is object && InvalidatesMainThreadContext(awaitSyntax.Expression, context.SemanticModel, context.CancellationToken))
-            {
-                this.RecordThreadingContext(methodDeclaration, awaitSyntax.Span.End, ThreadingContext.Unknown);
-            }
-
-            static bool InvalidatesMainThreadContext(ExpressionSyntax awaitedExpression, SemanticModel semanticModel, CancellationToken cancellationToken)
-            {
-                ISymbol? awaitedSymbol = semanticModel.GetSymbolInfo(awaitedExpression, cancellationToken).Symbol;
-                if (awaitedSymbol is IPropertySymbol { Name: "Default", ContainingType.Name: "TaskScheduler", ContainingType: { } containingType }
-                    && containingType.BelongsToNamespace(Namespaces.SystemThreadingTasks))
-                {
-                    return true;
-                }
-
-                if (awaitedExpression is InvocationExpressionSyntax { ArgumentList.Arguments: [{ Expression: { } continueOnCapturedContext }] } invocation
-                    && semanticModel.GetSymbolInfo(invocation, cancellationToken).Symbol is IMethodSymbol { Name: "ConfigureAwait", Parameters: [{ Type.SpecialType: SpecialType.System_Boolean }] })
-                {
-                    Optional<object?> constantValue = semanticModel.GetConstantValue(continueOnCapturedContext, cancellationToken);
-                    return constantValue.HasValue && constantValue.Value is false;
-                }
-
-                return false;
-            }
-        }
-
         internal void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
         {
             var invocationSyntax = (InvocationExpressionSyntax)context.Node;
@@ -391,7 +361,6 @@ public class VSTHRD010MainThreadUsageAnalyzer : DiagnosticAnalyzer
                             }
                         }
 
-                        this.RecordThreadingContext(methodDeclaration, invocationSyntax.Span.End, ThreadingContext.MainThread);
                         return;
                     }
                 }
@@ -507,18 +476,7 @@ public class VSTHRD010MainThreadUsageAnalyzer : DiagnosticAnalyzer
                 SyntaxNode? methodDeclaration = context.Node.FirstAncestorOrSelf<SyntaxNode>(n => CSharpCommonInterest.MethodSyntaxKinds.Contains(n.Kind()));
                 if (methodDeclaration is object)
                 {
-                    lock (this.methodDeclarationNodesSyncObject)
-                    {
-                        ImmutableArray<ThreadingContextTransition> transitions = this.methodDeclarationNodes.GetValueOrDefault(methodDeclaration);
-                        if (!transitions.IsDefault)
-                        {
-                            threadingContext = transitions
-                                .Where(transition => transition.Position <= context.Node.SpanStart)
-                                .OrderByDescending(transition => transition.Position)
-                                .Select(transition => transition.Context)
-                                .FirstOrDefault();
-                        }
-                    }
+                    threadingContext = this.GetThreadingContext(methodDeclaration, context.Node.SpanStart, context.SemanticModel, context.CancellationToken);
                 }
 
                 if (threadingContext != ThreadingContext.MainThread)
@@ -535,17 +493,62 @@ public class VSTHRD010MainThreadUsageAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
-        private void RecordThreadingContext(SyntaxNode methodDeclaration, int position, ThreadingContext context)
+        private ThreadingContext GetThreadingContext(SyntaxNode methodDeclaration, int position, SemanticModel semanticModel, CancellationToken cancellationToken)
         {
+            ImmutableArray<ThreadingContextTransition> transitions;
             lock (this.methodDeclarationNodesSyncObject)
             {
-                ImmutableArray<ThreadingContextTransition> transitions = this.methodDeclarationNodes.GetValueOrDefault(methodDeclaration);
+                transitions = this.methodDeclarationNodes.GetValueOrDefault(methodDeclaration);
                 if (transitions.IsDefault)
                 {
-                    transitions = ImmutableArray<ThreadingContextTransition>.Empty;
+                    transitions = this.GetThreadingContextTransitions(methodDeclaration, semanticModel, cancellationToken);
+                    this.methodDeclarationNodes = this.methodDeclarationNodes.SetItem(methodDeclaration, transitions);
+                }
+            }
+
+            return transitions
+                .Where(transition => transition.Position <= position)
+                .OrderByDescending(transition => transition.Position)
+                .Select(transition => transition.Context)
+                .FirstOrDefault();
+        }
+
+        private ImmutableArray<ThreadingContextTransition> GetThreadingContextTransitions(SyntaxNode methodDeclaration, SemanticModel semanticModel, CancellationToken cancellationToken)
+        {
+            ImmutableArray<ThreadingContextTransition>.Builder transitions = ImmutableArray.CreateBuilder<ThreadingContextTransition>();
+            foreach (SyntaxNode node in methodDeclaration.DescendantNodes().Where(node => node.FirstAncestorOrSelf<SyntaxNode>(ancestor => CSharpCommonInterest.MethodSyntaxKinds.Contains(ancestor.Kind())) == methodDeclaration))
+            {
+                if (node is InvocationExpressionSyntax invocation
+                    && semanticModel.GetSymbolInfo(invocation, cancellationToken).Symbol is IMethodSymbol invokedMethod
+                    && (this.MainThreadAssertingMethods.Contains(invokedMethod) || this.MainThreadSwitchingMethods.Contains(invokedMethod)))
+                {
+                    transitions.Add(new ThreadingContextTransition(invocation.Span.End, ThreadingContext.MainThread));
+                }
+                else if (node is AwaitExpressionSyntax awaitExpression && InvalidatesMainThreadContext(awaitExpression.Expression))
+                {
+                    transitions.Add(new ThreadingContextTransition(awaitExpression.Span.End, ThreadingContext.Unknown));
+                }
+            }
+
+            return transitions.ToImmutable();
+
+            bool InvalidatesMainThreadContext(ExpressionSyntax awaitedExpression)
+            {
+                ISymbol? awaitedSymbol = semanticModel.GetSymbolInfo(awaitedExpression, cancellationToken).Symbol;
+                if (awaitedSymbol is IPropertySymbol { Name: "Default", ContainingType.Name: "TaskScheduler", ContainingType: { } containingType }
+                    && containingType.BelongsToNamespace(Namespaces.SystemThreadingTasks))
+                {
+                    return true;
                 }
 
-                this.methodDeclarationNodes = this.methodDeclarationNodes.SetItem(methodDeclaration, transitions.Add(new ThreadingContextTransition(position, context)));
+                if (awaitedExpression is InvocationExpressionSyntax { ArgumentList.Arguments: [{ Expression: { } continueOnCapturedContext }] } invocation
+                    && semanticModel.GetSymbolInfo(invocation, cancellationToken).Symbol is IMethodSymbol { Name: "ConfigureAwait", Parameters: [{ Type.SpecialType: SpecialType.System_Boolean }] })
+                {
+                    Optional<object?> constantValue = semanticModel.GetConstantValue(continueOnCapturedContext, cancellationToken);
+                    return constantValue.HasValue && constantValue.Value is false;
+                }
+
+                return false;
             }
         }
 

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD010MainThreadUsageAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD010MainThreadUsageAnalyzer.cs
@@ -351,7 +351,8 @@ public class VSTHRD010MainThreadUsageAnalyzer : DiagnosticAnalyzer
                 }
 
                 if (awaitedExpression is InvocationExpressionSyntax { ArgumentList.Arguments: [{ Expression: { } continueOnCapturedContext }] } invocation
-                    && semanticModel.GetSymbolInfo(invocation, cancellationToken).Symbol is IMethodSymbol { Name: "ConfigureAwait" })
+                    && semanticModel.GetSymbolInfo(invocation, cancellationToken).Symbol is IMethodSymbol { Name: "ConfigureAwait", Parameters: [{ Type.SpecialType: SpecialType.System_Boolean }], ContainingType: { Name: Types.Task.TypeName or Types.ValueTask.TypeName } configureAwaitContainingType }
+                    && configureAwaitContainingType.BelongsToNamespace(Namespaces.SystemThreadingTasks))
                 {
                     Optional<object?> constantValue = semanticModel.GetConstantValue(continueOnCapturedContext, cancellationToken);
                     return constantValue.HasValue && constantValue.Value is false;

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD010MainThreadUsageAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD010MainThreadUsageAnalyzer.cs
@@ -351,8 +351,7 @@ public class VSTHRD010MainThreadUsageAnalyzer : DiagnosticAnalyzer
                 }
 
                 if (awaitedExpression is InvocationExpressionSyntax { ArgumentList.Arguments: [{ Expression: { } continueOnCapturedContext }] } invocation
-                    && semanticModel.GetSymbolInfo(invocation, cancellationToken).Symbol is IMethodSymbol { Name: "ConfigureAwait", Parameters: [{ Type.SpecialType: SpecialType.System_Boolean }], ContainingType: { Name: Types.Task.TypeName or Types.ValueTask.TypeName } configureAwaitContainingType }
-                    && configureAwaitContainingType.BelongsToNamespace(Namespaces.SystemThreadingTasks))
+                    && semanticModel.GetSymbolInfo(invocation, cancellationToken).Symbol is IMethodSymbol { Name: "ConfigureAwait", Parameters: [{ Type.SpecialType: SpecialType.System_Boolean }] })
                 {
                     Optional<object?> constantValue = semanticModel.GetConstantValue(continueOnCapturedContext, cancellationToken);
                     return constantValue.HasValue && constantValue.Value is false;

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD010MainThreadUsageAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD010MainThreadUsageAnalyzer.cs
@@ -506,11 +506,15 @@ public class VSTHRD010MainThreadUsageAnalyzer : DiagnosticAnalyzer
                 }
             }
 
-            return transitions
-                .Where(transition => transition.Position <= position)
-                .OrderByDescending(transition => transition.Position)
-                .Select(transition => transition.Context)
-                .FirstOrDefault();
+            for (int i = transitions.Length - 1; i >= 0; i--)
+            {
+                if (transitions[i].Position <= position)
+                {
+                    return transitions[i].Context;
+                }
+            }
+
+            return ThreadingContext.Unknown;
         }
 
         private ImmutableArray<ThreadingContextTransition> GetThreadingContextTransitions(SyntaxNode methodDeclaration, SemanticModel semanticModel, CancellationToken cancellationToken)
@@ -530,10 +534,15 @@ public class VSTHRD010MainThreadUsageAnalyzer : DiagnosticAnalyzer
                 }
             }
 
-            return transitions.ToImmutable();
+            return transitions.OrderBy(transition => transition.Position).ToImmutableArray();
 
             bool InvalidatesMainThreadContext(ExpressionSyntax awaitedExpression)
             {
+                while (awaitedExpression is ParenthesizedExpressionSyntax parenthesizedExpression)
+                {
+                    awaitedExpression = parenthesizedExpression.Expression;
+                }
+
                 ISymbol? awaitedSymbol = semanticModel.GetSymbolInfo(awaitedExpression, cancellationToken).Symbol;
                 if (awaitedSymbol is IPropertySymbol { Name: "Default", ContainingType.Name: "TaskScheduler", ContainingType: { } containingType }
                     && containingType.BelongsToNamespace(Namespaces.SystemThreadingTasks))

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD010MainThreadUsageAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD010MainThreadUsageAnalyzer.cs
@@ -139,6 +139,7 @@ public class VSTHRD010MainThreadUsageAnalyzer : DiagnosticAnalyzer
                     methodsDeclaringUIThreadRequirement: methodsDeclaringUIThreadRequirement,
                     methodsAssertingUIThreadRequirement: methodsAssertingUIThreadRequirement,
                     diagnosticProperties: diagnosticProperties);
+                codeBlockStartContext.RegisterSyntaxNodeAction(Utils.DebuggableWrapper(methodAnalyzer.AnalyzeAwait), SyntaxKind.AwaitExpression);
                 codeBlockStartContext.RegisterSyntaxNodeAction(Utils.DebuggableWrapper(methodAnalyzer.AnalyzeInvocation), SyntaxKind.InvocationExpression);
                 codeBlockStartContext.RegisterSyntaxNodeAction(Utils.DebuggableWrapper(methodAnalyzer.AnalyzeMemberAccess), SyntaxKind.SimpleMemberAccessExpression);
                 codeBlockStartContext.RegisterSyntaxNodeAction(Utils.DebuggableWrapper(methodAnalyzer.AnalyzeCast), SyntaxKind.CastExpression);
@@ -330,6 +331,35 @@ public class VSTHRD010MainThreadUsageAnalyzer : DiagnosticAnalyzer
         internal HashSet<IMethodSymbol> MethodsAssertingUIThreadRequirement { get; }
 
         internal ImmutableDictionary<string, string?> DiagnosticProperties { get; }
+
+        internal void AnalyzeAwait(SyntaxNodeAnalysisContext context)
+        {
+            var awaitSyntax = (AwaitExpressionSyntax)context.Node;
+            SyntaxNode? methodDeclaration = context.Node.FirstAncestorOrSelf<SyntaxNode>(n => CSharpCommonInterest.MethodSyntaxKinds.Contains(n.Kind()));
+            if (methodDeclaration is object && InvalidatesMainThreadContext(awaitSyntax.Expression, context.SemanticModel, context.CancellationToken))
+            {
+                this.methodDeclarationNodes = this.methodDeclarationNodes.SetItem(methodDeclaration, ThreadingContext.Unknown);
+            }
+
+            static bool InvalidatesMainThreadContext(ExpressionSyntax awaitedExpression, SemanticModel semanticModel, CancellationToken cancellationToken)
+            {
+                ISymbol? awaitedSymbol = semanticModel.GetSymbolInfo(awaitedExpression, cancellationToken).Symbol;
+                if (awaitedSymbol is IPropertySymbol { Name: "Default", ContainingType.Name: "TaskScheduler", ContainingType: { } containingType }
+                    && containingType.BelongsToNamespace(Namespaces.SystemThreadingTasks))
+                {
+                    return true;
+                }
+
+                if (awaitedExpression is InvocationExpressionSyntax { ArgumentList.Arguments: [{ Expression: { } continueOnCapturedContext }] } invocation
+                    && semanticModel.GetSymbolInfo(invocation, cancellationToken).Symbol is IMethodSymbol { Name: "ConfigureAwait" })
+                {
+                    Optional<object?> constantValue = semanticModel.GetConstantValue(continueOnCapturedContext, cancellationToken);
+                    return constantValue.HasValue && constantValue.Value is false;
+                }
+
+                return false;
+            }
+        }
 
         internal void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
         {

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD010MainThreadUsageAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD010MainThreadUsageAnalyzerTests.cs
@@ -501,7 +501,7 @@ class Test {
     }
 
     [Fact]
-    public async Task InvokeVsSolutionAfterUIThreadAssertionAndCustomConfigureAwaitFalse()
+    public async Task InvokeVsSolutionAfterUIThreadAssertionAndCustomConfigureAwaitFalseReportsWarning()
     {
         var test = @"
 using System.Runtime.CompilerServices;
@@ -527,7 +527,8 @@ class CustomAwaitable {
     public TaskAwaiter GetAwaiter() => default;
 }
 ";
-        await CSVerify.VerifyAnalyzerAsync(test);
+        DiagnosticResult expected = CSVerify.Diagnostic(DescriptorAsync).WithSpan(12, 13, 12, 24).WithArguments("IVsSolution", "JoinableTaskFactory.SwitchToMainThreadAsync");
+        await CSVerify.VerifyAnalyzerAsync(test, expected);
     }
 
     [Fact(Skip = "Not yet supported. See https://github.com/Microsoft/vs-threading/issues/38")]

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD010MainThreadUsageAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD010MainThreadUsageAnalyzerTests.cs
@@ -444,7 +444,7 @@ class Test {
         await CSVerify.VerifyAnalyzerAsync(test, expected);
     }
 
-    [Fact(Skip = "Not yet supported. See https://github.com/microsoft/vs-threading/issues/542")]
+    [Fact]
     public async Task InvokeVsSolutionAfterUIThreadAssertionAndSwitchToThreadPool()
     {
         var test = @"
@@ -471,7 +471,7 @@ class Test {
         await CSVerify.VerifyAnalyzerAsync(test, expected);
     }
 
-    [Fact(Skip = "Not yet supported. See https://github.com/microsoft/vs-threading/issues/542")]
+    [Fact]
     public async Task InvokeVsSolutionAfterUIThreadAssertionAndConfigureAwaitFalse()
     {
         var test = @"

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD010MainThreadUsageAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD010MainThreadUsageAnalyzerTests.cs
@@ -500,6 +500,36 @@ class Test {
         await CSVerify.VerifyAnalyzerAsync(test, expected);
     }
 
+    [Fact]
+    public async Task InvokeVsSolutionAfterUIThreadAssertionAndCustomConfigureAwaitFalse()
+    {
+        var test = @"
+using System.Runtime.CompilerServices;
+using Microsoft.VisualStudio.Shell.Interop;
+
+class Test {
+    async void F() {
+        IVsSolution sln = null;
+        VerifyOnUIThread();
+
+        await new CustomAwaitable().ConfigureAwait(false);
+
+        sln.SetProperty(1000, null);
+    }
+
+    void VerifyOnUIThread() {
+    }
+}
+
+class CustomAwaitable {
+    public CustomAwaitable ConfigureAwait(bool continueOnCapturedContext) => this;
+
+    public TaskAwaiter GetAwaiter() => default;
+}
+";
+        await CSVerify.VerifyAnalyzerAsync(test);
+    }
+
     [Fact(Skip = "Not yet supported. See https://github.com/Microsoft/vs-threading/issues/38")]
     public async Task InvokeVsSolutionAfterUIThreadAssertionAndConditionalSwitchToThreadPool()
     {

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD010MainThreadUsageAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD010MainThreadUsageAnalyzerTests.cs
@@ -501,6 +501,35 @@ class Test {
     }
 
     [Fact]
+    public async Task InvokeVsSolutionAfterUIThreadAssertionAndParenthesizedConfigureAwaitFalse()
+    {
+        var test = @"
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Threading;
+
+class Test {
+    async Task F() {
+        IVsSolution sln = null;
+        VerifyOnUIThread();
+
+        await (SomeAsync().ConfigureAwait(false));
+
+        sln.SetProperty(1000, null);
+    }
+
+    void VerifyOnUIThread() {
+    }
+
+    async Task SomeAsync() => await Task.Yield();
+}
+";
+        DiagnosticResult expected = CSVerify.Diagnostic(DescriptorAsync).WithSpan(14, 13, 14, 24).WithArguments("IVsSolution", "JoinableTaskFactory.SwitchToMainThreadAsync");
+        await CSVerify.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
     public async Task InvokeVsSolutionWithinAndAfterConfigureAwaitFalseOperand()
     {
         var test = @"
@@ -555,6 +584,33 @@ class CustomAwaitable {
 ";
         DiagnosticResult expected = CSVerify.Diagnostic(DescriptorAsync).WithSpan(12, 13, 12, 24).WithArguments("IVsSolution", "JoinableTaskFactory.SwitchToMainThreadAsync");
         await CSVerify.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task WorkerTransitionInLocalFunctionDoesNotAffectContainingMethod()
+    {
+        var test = @"
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Threading;
+
+class Test {
+    void F() {
+        IVsSolution sln = null;
+        VerifyOnUIThread();
+
+        async Task LocalAsync() {
+            await TaskScheduler.Default;
+        }
+
+        sln.SetProperty(1000, null);
+    }
+
+    void VerifyOnUIThread() {
+    }
+}
+";
+        await CSVerify.VerifyAnalyzerAsync(test);
     }
 
     [Fact(Skip = "Not yet supported. See https://github.com/Microsoft/vs-threading/issues/38")]

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD010MainThreadUsageAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD010MainThreadUsageAnalyzerTests.cs
@@ -501,6 +501,32 @@ class Test {
     }
 
     [Fact]
+    public async Task InvokeVsSolutionWithinAndAfterConfigureAwaitFalseOperand()
+    {
+        var test = @"
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Threading;
+
+class Test {
+    async Task F() {
+        IVsSolution sln = null;
+        VerifyOnUIThread();
+
+        await Task.FromResult(sln.SetProperty(1000, null)).ConfigureAwait(false);
+
+        sln.SetProperty(1000, null);
+    }
+
+    void VerifyOnUIThread() {
+    }
+}
+";
+        DiagnosticResult expected = CSVerify.Diagnostic(DescriptorAsync).WithSpan(13, 13, 13, 24).WithArguments("IVsSolution", "JoinableTaskFactory.SwitchToMainThreadAsync");
+        await CSVerify.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
     public async Task InvokeVsSolutionAfterUIThreadAssertionAndCustomConfigureAwaitFalseReportsWarning()
     {
         var test = @"


### PR DESCRIPTION
VSTHRD010 currently treats a prior main-thread assertion or switch as valid for the remainder of a method, even after execution explicitly moves away from the main thread. This can suppress diagnostics for thread-affinitized access that follows `await TaskScheduler.Default` or `ConfigureAwait(false)`.

Teach the analyzer to invalidate its established main-thread context for both worker-thread transition forms. The existing regression cases are enabled to cover each form across the analyzer test target frameworks.

Fixes #455
Fixes #542