### PR TITLE
Fix VSTHRD002 for nested lambdas in Task-returning methods

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD002UseJtfRunAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD002UseJtfRunAnalyzer.cs
@@ -92,8 +92,8 @@ public class VSTHRD002UseJtfRunAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
-        // Task-returning methods and delegates are covered by VSTHRD103. VSTHRD002 covers
-        // nested functions that do not return Task so that every synchronous wait is diagnosed.
+        // Methods and delegates with async-compatible return types are covered by VSTHRD103.
+        // VSTHRD002 covers other nested functions so that every synchronous wait is diagnosed.
         return context.SemanticModel.GetEnclosingSymbol(context.Node.SpanStart, context.CancellationToken) is IMethodSymbol containingMethod
             && !containingMethod.HasAsyncCompatibleReturnType();
     }

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD002UseJtfRunAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD002UseJtfRunAnalyzer.cs
@@ -85,8 +85,15 @@ public class VSTHRD002UseJtfRunAnalyzer : DiagnosticAnalyzer
             return true;
         }
 
-        // Task-returning methods and delegates are covered by VSTHRD103. Nested non-Task-returning
-        // functions still need VSTHRD002 because they cannot use await.
+        SyntaxNode? containingFunction = context.Node.Ancestors().FirstOrDefault(
+            node => node is AnonymousFunctionExpressionSyntax or LocalFunctionStatementSyntax or BaseMethodDeclarationSyntax);
+        if (containingFunction is not AnonymousFunctionExpressionSyntax and not LocalFunctionStatementSyntax)
+        {
+            return false;
+        }
+
+        // Task-returning methods and delegates are covered by VSTHRD103. VSTHRD002 covers
+        // nested functions that do not return Task so that every synchronous wait is diagnosed.
         return context.SemanticModel.GetEnclosingSymbol(context.Node.SpanStart, context.CancellationToken) is IMethodSymbol containingMethod
             && !containingMethod.HasAsyncCompatibleReturnType();
     }

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD002UseJtfRunAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD002UseJtfRunAnalyzer.cs
@@ -65,17 +65,30 @@ public class VSTHRD002UseJtfRunAnalyzer : DiagnosticAnalyzer
             {
                 compilationContext.RegisterCodeBlockStartAction<SyntaxKind>(codeBlockContext =>
                 {
-                    // We want to scan properties and methods that do not return Task or Task<T>.
                     var methodSymbol = codeBlockContext.OwningSymbol as IMethodSymbol;
                     var propertySymbol = codeBlockContext.OwningSymbol as IPropertySymbol;
-                    if (propertySymbol is object || (methodSymbol is object && !methodSymbol.HasAsyncCompatibleReturnType()))
+                    if (propertySymbol is object || methodSymbol is object)
                     {
-                        codeBlockContext.RegisterSyntaxNodeAction(Utils.DebuggableWrapper(c => AnalyzeInvocation(c, taskSymbol)), SyntaxKind.InvocationExpression);
-                        codeBlockContext.RegisterSyntaxNodeAction(Utils.DebuggableWrapper(c => AnalyzeMemberAccess(c, taskSymbol)), SyntaxKind.SimpleMemberAccessExpression);
+                        bool analyzeWholeCodeBlock = propertySymbol is object || !methodSymbol!.HasAsyncCompatibleReturnType();
+                        codeBlockContext.RegisterSyntaxNodeAction(Utils.DebuggableWrapper(c => AnalyzeInvocation(c, taskSymbol, analyzeWholeCodeBlock)), SyntaxKind.InvocationExpression);
+                        codeBlockContext.RegisterSyntaxNodeAction(Utils.DebuggableWrapper(c => AnalyzeMemberAccess(c, taskSymbol, analyzeWholeCodeBlock)), SyntaxKind.SimpleMemberAccessExpression);
                     }
                 });
             }
         });
+    }
+
+    private static bool ShouldAnalyze(SyntaxNodeAnalysisContext context, bool analyzeWholeCodeBlock)
+    {
+        if (analyzeWholeCodeBlock)
+        {
+            return true;
+        }
+
+        // Task-returning methods and delegates are covered by VSTHRD103. Nested non-Task-returning
+        // functions still need VSTHRD002 because they cannot use await.
+        return context.SemanticModel.GetEnclosingSymbol(context.Node.SpanStart, context.CancellationToken) is IMethodSymbol containingMethod
+            && !containingMethod.HasAsyncCompatibleReturnType();
     }
 
     private static ParameterSyntax? GetFirstParameter(AnonymousFunctionExpressionSyntax? anonymousFunctionSyntax)
@@ -136,8 +149,13 @@ public class VSTHRD002UseJtfRunAnalyzer : DiagnosticAnalyzer
         CSharpCommonInterest.InspectMemberAccess(context, memberAccessSyntax, Descriptor, problematicMethods);
     }
 
-    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context, INamedTypeSymbol taskSymbol)
+    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context, INamedTypeSymbol taskSymbol, bool analyzeWholeCodeBlock)
     {
+        if (!ShouldAnalyze(context, analyzeWholeCodeBlock))
+        {
+            return;
+        }
+
         var invocationExpressionSyntax = (InvocationExpressionSyntax)context.Node;
         InspectMemberAccess(
             context,
@@ -146,8 +164,13 @@ public class VSTHRD002UseJtfRunAnalyzer : DiagnosticAnalyzer
             taskSymbol);
     }
 
-    private static void AnalyzeMemberAccess(SyntaxNodeAnalysisContext context, INamedTypeSymbol taskSymbol)
+    private static void AnalyzeMemberAccess(SyntaxNodeAnalysisContext context, INamedTypeSymbol taskSymbol, bool analyzeWholeCodeBlock)
     {
+        if (!ShouldAnalyze(context, analyzeWholeCodeBlock))
+        {
+            return;
+        }
+
         var memberAccessSyntax = (MemberAccessExpressionSyntax)context.Node;
         InspectMemberAccess(
             context,

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/VSTHRD002UseJtfRunCodeFixWithAwait.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/VSTHRD002UseJtfRunCodeFixWithAwait.cs
@@ -71,9 +71,10 @@ public class VSTHRD002UseJtfRunCodeFixWithAwait : CodeFixProvider
         target = null;
 
         var syntaxNode = (ExpressionSyntax)root.FindNode(diagnostic.Location.SourceSpan);
-        if (syntaxNode.FirstAncestorOrSelf<AnonymousFunctionExpressionSyntax>() is object)
+        if (syntaxNode.FirstAncestorOrSelf<AnonymousFunctionExpressionSyntax>() is object ||
+            syntaxNode.FirstAncestorOrSelf<LocalFunctionStatementSyntax>() is object)
         {
-            // We don't support converting anonymous delegates to async.
+            // We don't support converting anonymous delegates or local functions to async.
             return false;
         }
 

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD002UseJtfRunAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD002UseJtfRunAnalyzerTests.cs
@@ -400,6 +400,63 @@ class Test {
     }
 
     [Fact]
+    public async Task TaskWaitShouldReportWarning_WithinActionInTaskReturningMethod()
+    {
+        var test = @"
+using System;
+using System.Threading.Tasks;
+
+class Test {
+    Task F() {
+        Action action = () => Task.Delay(1).[|Wait|]();
+        return Task.CompletedTask;
+    }
+}
+";
+        await CSVerify.VerifyCodeFixAsync(test, test);
+    }
+
+    [Fact]
+    public async Task TaskWaitShouldReportWarning_WithinActionArgumentInTaskReturningMethod()
+    {
+        var test = @"
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+class Test {
+    Task F() {
+        new List<int>().ForEach(i => { Task.Delay(1).[|Wait|](); });
+        return Task.CompletedTask;
+    }
+}
+";
+        await CSVerify.VerifyCodeFixAsync(test, test);
+    }
+
+    [Fact]
+    public async Task TaskWaitShouldNotReportWarning_WithinTaskReturningDelegateInTaskReturningMethod()
+    {
+        var test = @"
+using System;
+using System.Threading.Tasks;
+
+class Test {
+    Task F() {
+        Func<Task> action = () => {
+            // VSTHRD103 covers synchronous waits in Task-returning delegates,
+            // so VSTHRD002 should not produce a duplicate diagnostic.
+            Task.Delay(1).Wait();
+            return Task.CompletedTask;
+        };
+        return Task.CompletedTask;
+    }
+}
+";
+        await CSVerify.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
     public async Task Task_Result_ShouldReportWarning()
     {
         var test = @"

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD002UseJtfRunAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD002UseJtfRunAnalyzerTests.cs
@@ -435,6 +435,23 @@ class Test {
     }
 
     [Fact]
+    public async Task TaskWaitShouldReportWarning_WithinLocalFunctionInTaskReturningMethod()
+    {
+        var test = @"
+using System.Threading.Tasks;
+
+class Test {
+    Task F() {
+        void Local() => Task.Delay(1).[|Wait|]();
+        Local();
+        return Task.CompletedTask;
+    }
+}
+";
+        await CSVerify.VerifyCodeFixAsync(test, test);
+    }
+
+    [Fact]
     public async Task TaskWaitShouldNotReportWarning_WithinTaskReturningDelegateInTaskReturningMethod()
     {
         var test = @"


### PR DESCRIPTION
VSTHRD002 currently skips entire Task-returning code blocks because VSTHRD103 covers synchronous waits in Task-returning methods and delegates. This leaves a gap for nested non-Task-returning functions, such as `Action` lambdas, because VSTHRD103 also excludes those functions.

Register VSTHRD002 for Task-returning code blocks, but analyze only nested functions whose return type is not async-compatible. This preserves the division between VSTHRD002 and VSTHRD103 while detecting synchronous waits in assigned lambdas and callback arguments.

Adds regression coverage for nested `Action` forms and verifies that Task-returning delegates remain excluded to avoid duplicate diagnostics.

Fixes #632
Fixes #1427