### PR TITLE
Fix VSTHRD104 false positives

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD104OfferAsyncOptionAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD104OfferAsyncOptionAnalyzer.cs
@@ -127,6 +127,7 @@ public class VSTHRD104OfferAsyncOptionAnalyzer : DiagnosticAnalyzer
             {
                 if (ifStatement.Statement.Span.Contains(resultAccess.Span)
                     && ConditionProvesSuccessfulCompletion(ifStatement.Condition, taskSymbol)
+                    && !MayWriteSymbolBefore(ifStatement.Condition, resultAccess, taskSymbol)
                     && !MayWriteSymbolBefore(ifStatement.Statement, resultAccess, taskSymbol))
                 {
                     return true;
@@ -160,13 +161,13 @@ public class VSTHRD104OfferAsyncOptionAnalyzer : DiagnosticAnalyzer
                     && SymbolEqualityComparer.Default.Equals(expectedTaskSymbol, completedTaskSymbol);
             }
 
-            bool MayWriteSymbolBefore(StatementSyntax statement, ExpressionSyntax expression, ISymbol expectedTaskSymbol)
+            bool MayWriteSymbolBefore(SyntaxNode region, ExpressionSyntax expression, ISymbol expectedTaskSymbol)
             {
                 SyntaxNode executableScope = expression.Ancestors().FirstOrDefault(ancestor =>
                     ancestor is AnonymousFunctionExpressionSyntax
                     or LocalFunctionStatementSyntax
                     or BaseMethodDeclarationSyntax
-                    or AccessorDeclarationSyntax) ?? statement;
+                    or AccessorDeclarationSyntax) ?? region;
                 if (executableScope.DescendantNodes()
                     .OfType<RefExpressionSyntax>()
                     .Where(refExpression => refExpression.SpanStart < expression.SpanStart)
@@ -177,7 +178,7 @@ public class VSTHRD104OfferAsyncOptionAnalyzer : DiagnosticAnalyzer
                     return true;
                 }
 
-                foreach (SyntaxNode node in statement.DescendantNodes().Where(node => node.SpanStart < expression.SpanStart))
+                foreach (SyntaxNode node in region.DescendantNodes().Where(node => node.SpanStart < expression.SpanStart))
                 {
                     ExpressionSyntax? writtenExpression = node switch
                     {

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD104OfferAsyncOptionAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD104OfferAsyncOptionAnalyzer.cs
@@ -98,11 +98,60 @@ public class VSTHRD104OfferAsyncOptionAnalyzer : DiagnosticAnalyzer
                 {
                     if (item.Method.IsMatch(invokedMember))
                     {
+                        if (invokedMember is IPropertySymbol { Name: nameof(Task<int>.Result) } && this.IsGuardedBySuccessfulCompletion(context, memberAccessSyntax))
+                        {
+                            return;
+                        }
+
                         Location? location = memberAccessSyntax.Name.GetLocation();
                         context.ReportDiagnostic(Diagnostic.Create(Descriptor, location));
                         this.diagnosticReported = true;
                     }
                 }
+            }
+        }
+
+        private bool IsGuardedBySuccessfulCompletion(SyntaxNodeAnalysisContext context, MemberAccessExpressionSyntax resultAccess)
+        {
+            ISymbol? taskSymbol = context.SemanticModel.GetSymbolInfo(resultAccess.Expression, context.CancellationToken).Symbol;
+            if (taskSymbol is null)
+            {
+                return false;
+            }
+
+            foreach (IfStatementSyntax ifStatement in resultAccess.Ancestors().OfType<IfStatementSyntax>())
+            {
+                if (ifStatement.Statement.Span.Contains(resultAccess.Span) && ConditionProvesSuccessfulCompletion(ifStatement.Condition, taskSymbol))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+
+            bool ConditionProvesSuccessfulCompletion(ExpressionSyntax condition, ISymbol expectedTaskSymbol)
+            {
+                while (condition is ParenthesizedExpressionSyntax parenthesized)
+                {
+                    condition = parenthesized.Expression;
+                }
+
+                if (condition is BinaryExpressionSyntax { RawKind: (int)SyntaxKind.LogicalAndExpression } logicalAnd)
+                {
+                    return ConditionProvesSuccessfulCompletion(logicalAnd.Left, expectedTaskSymbol)
+                        || ConditionProvesSuccessfulCompletion(logicalAnd.Right, expectedTaskSymbol);
+                }
+
+                if (condition is not MemberAccessExpressionSyntax { Name.Identifier.ValueText: "IsCompletedSuccessfully" } completionAccess)
+                {
+                    return false;
+                }
+
+                ISymbol? completionProperty = context.SemanticModel.GetSymbolInfo(completionAccess, context.CancellationToken).Symbol;
+                ISymbol? completedTaskSymbol = context.SemanticModel.GetSymbolInfo(completionAccess.Expression, context.CancellationToken).Symbol;
+                return completionProperty is IPropertySymbol { ContainingType: { } containingType }
+                    && Utils.IsTask(containingType)
+                    && SymbolEqualityComparer.Default.Equals(expectedTaskSymbol, completedTaskSymbol);
             }
         }
     }

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD104OfferAsyncOptionAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD104OfferAsyncOptionAnalyzer.cs
@@ -121,7 +121,9 @@ public class VSTHRD104OfferAsyncOptionAnalyzer : DiagnosticAnalyzer
                 return false;
             }
 
-            foreach (IfStatementSyntax ifStatement in resultAccess.Ancestors().OfType<IfStatementSyntax>())
+            foreach (IfStatementSyntax ifStatement in resultAccess.Ancestors()
+                .TakeWhile(ancestor => ancestor is not LocalFunctionStatementSyntax)
+                .OfType<IfStatementSyntax>())
             {
                 if (ifStatement.Statement.Span.Contains(resultAccess.Span) && ConditionProvesSuccessfulCompletion(ifStatement.Condition, taskSymbol))
                 {

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD104OfferAsyncOptionAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD104OfferAsyncOptionAnalyzer.cs
@@ -162,16 +162,23 @@ public class VSTHRD104OfferAsyncOptionAnalyzer : DiagnosticAnalyzer
 
             bool MayWriteSymbolBefore(StatementSyntax statement, ExpressionSyntax expression, ISymbol expectedTaskSymbol)
             {
+                SyntaxNode executableScope = expression.Ancestors().FirstOrDefault(ancestor =>
+                    ancestor is AnonymousFunctionExpressionSyntax
+                    or LocalFunctionStatementSyntax
+                    or BaseMethodDeclarationSyntax
+                    or AccessorDeclarationSyntax) ?? statement;
+                if (executableScope.DescendantNodes()
+                    .OfType<RefExpressionSyntax>()
+                    .Where(refExpression => refExpression.SpanStart < expression.SpanStart)
+                    .Any(refExpression => SymbolEqualityComparer.Default.Equals(
+                        context.SemanticModel.GetSymbolInfo(refExpression.Expression, context.CancellationToken).Symbol,
+                        expectedTaskSymbol)))
+                {
+                    return true;
+                }
+
                 foreach (SyntaxNode node in statement.DescendantNodes().Where(node => node.SpanStart < expression.SpanStart))
                 {
-                    if (node is RefExpressionSyntax refExpression
-                        && SymbolEqualityComparer.Default.Equals(
-                            context.SemanticModel.GetSymbolInfo(refExpression.Expression, context.CancellationToken).Symbol,
-                            expectedTaskSymbol))
-                    {
-                        return true;
-                    }
-
                     ExpressionSyntax? writtenExpression = node switch
                     {
                         AssignmentExpressionSyntax assignment => assignment.Left,

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD104OfferAsyncOptionAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD104OfferAsyncOptionAnalyzer.cs
@@ -125,7 +125,9 @@ public class VSTHRD104OfferAsyncOptionAnalyzer : DiagnosticAnalyzer
                 .TakeWhile(ancestor => ancestor is not LocalFunctionStatementSyntax)
                 .OfType<IfStatementSyntax>())
             {
-                if (ifStatement.Statement.Span.Contains(resultAccess.Span) && ConditionProvesSuccessfulCompletion(ifStatement.Condition, taskSymbol))
+                if (ifStatement.Statement.Span.Contains(resultAccess.Span)
+                    && ConditionProvesSuccessfulCompletion(ifStatement.Condition, taskSymbol)
+                    && !MayWriteSymbolBefore(ifStatement.Statement, resultAccess, taskSymbol))
                 {
                     return true;
                 }
@@ -156,6 +158,32 @@ public class VSTHRD104OfferAsyncOptionAnalyzer : DiagnosticAnalyzer
                 return completionProperty is IPropertySymbol { ContainingType: { } containingType }
                     && Utils.IsTask(containingType)
                     && SymbolEqualityComparer.Default.Equals(expectedTaskSymbol, completedTaskSymbol);
+            }
+
+            bool MayWriteSymbolBefore(StatementSyntax statement, ExpressionSyntax expression, ISymbol expectedTaskSymbol)
+            {
+                foreach (SyntaxNode node in statement.DescendantNodes().Where(node => node.SpanStart < expression.SpanStart))
+                {
+                    ExpressionSyntax? writtenExpression = node switch
+                    {
+                        AssignmentExpressionSyntax assignment => assignment.Left,
+                        PrefixUnaryExpressionSyntax prefix when prefix.IsKind(SyntaxKind.PreIncrementExpression) || prefix.IsKind(SyntaxKind.PreDecrementExpression) => prefix.Operand,
+                        PostfixUnaryExpressionSyntax postfix when postfix.IsKind(SyntaxKind.PostIncrementExpression) || postfix.IsKind(SyntaxKind.PostDecrementExpression) => postfix.Operand,
+                        ArgumentSyntax argument when argument.RefOrOutKeyword.IsKind(SyntaxKind.RefKeyword) || argument.RefOrOutKeyword.IsKind(SyntaxKind.OutKeyword) => argument.Expression,
+                        _ => null,
+                    };
+
+                    if (writtenExpression is not null && writtenExpression.DescendantNodesAndSelf()
+                        .OfType<ExpressionSyntax>()
+                        .Any(candidate => SymbolEqualityComparer.Default.Equals(
+                            context.SemanticModel.GetSymbolInfo(candidate, context.CancellationToken).Symbol,
+                            expectedTaskSymbol)))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
             }
         }
     }

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD104OfferAsyncOptionAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD104OfferAsyncOptionAnalyzer.cs
@@ -98,7 +98,9 @@ public class VSTHRD104OfferAsyncOptionAnalyzer : DiagnosticAnalyzer
                 {
                     if (item.Method.IsMatch(invokedMember))
                     {
-                        if (invokedMember is IPropertySymbol { Name: nameof(Task<int>.Result) } && this.IsGuardedBySuccessfulCompletion(context, memberAccessSyntax))
+                        if (invokedMember is IPropertySymbol { Name: nameof(Task<int>.Result), ContainingType: { } containingType }
+                            && Utils.IsTask(containingType)
+                            && this.IsGuardedBySuccessfulCompletion(context, memberAccessSyntax))
                         {
                             return;
                         }
@@ -114,7 +116,7 @@ public class VSTHRD104OfferAsyncOptionAnalyzer : DiagnosticAnalyzer
         private bool IsGuardedBySuccessfulCompletion(SyntaxNodeAnalysisContext context, MemberAccessExpressionSyntax resultAccess)
         {
             ISymbol? taskSymbol = context.SemanticModel.GetSymbolInfo(resultAccess.Expression, context.CancellationToken).Symbol;
-            if (taskSymbol is null)
+            if (taskSymbol is not ILocalSymbol and not IParameterSymbol)
             {
                 return false;
             }

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD104OfferAsyncOptionAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD104OfferAsyncOptionAnalyzer.cs
@@ -164,6 +164,14 @@ public class VSTHRD104OfferAsyncOptionAnalyzer : DiagnosticAnalyzer
             {
                 foreach (SyntaxNode node in statement.DescendantNodes().Where(node => node.SpanStart < expression.SpanStart))
                 {
+                    if (node is RefExpressionSyntax refExpression
+                        && SymbolEqualityComparer.Default.Equals(
+                            context.SemanticModel.GetSymbolInfo(refExpression.Expression, context.CancellationToken).Symbol,
+                            expectedTaskSymbol))
+                    {
+                        return true;
+                    }
+
                     ExpressionSyntax? writtenExpression = node switch
                     {
                         AssignmentExpressionSyntax assignment => assignment.Left,

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Utils.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Utils.cs
@@ -332,7 +332,9 @@ public static class Utils
 
         if (methodSymbol.IsExtensionMethod && !methodSymbol.Parameters.IsDefaultOrEmpty && methodSymbol.Parameters[0].Type is INamedTypeSymbol receiverType)
         {
-            IEnumerable<ISymbol> receiverMembers = receiverType.AllInterfaces.SelectMany(iface => iface.GetMembers(asyncMethodName));
+            IEnumerable<ISymbol> receiverMembers = receiverType.TypeKind == TypeKind.Interface
+                ? receiverType.AllInterfaces.SelectMany(iface => iface.GetMembers(asyncMethodName))
+                : Enumerable.Empty<ISymbol>();
             for (INamedTypeSymbol? currentType = receiverType; currentType is not null; currentType = currentType.BaseType)
             {
                 receiverMembers = receiverMembers.Concat(currentType.GetMembers(asyncMethodName));

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Utils.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Utils.cs
@@ -324,8 +324,20 @@ public static class Utils
     public static bool HasAsyncAlternative(this IMethodSymbol methodSymbol, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        return methodSymbol.ContainingType.GetMembers(methodSymbol.Name + VSTHRD200UseAsyncNamingConventionAnalyzer.MandatoryAsyncSuffix)
-            .Any(alt => IsXAtLeastAsPublicAsY(alt, methodSymbol));
+        string asyncMethodName = methodSymbol.Name + VSTHRD200UseAsyncNamingConventionAnalyzer.MandatoryAsyncSuffix;
+        if (methodSymbol.ContainingType.GetMembers(asyncMethodName).Any(alt => IsXAtLeastAsPublicAsY(alt, methodSymbol)))
+        {
+            return true;
+        }
+
+        if (methodSymbol.IsExtensionMethod && methodSymbol.Parameters[0].Type is INamedTypeSymbol receiverType)
+        {
+            return receiverType.GetMembers(asyncMethodName)
+                .Concat(receiverType.AllInterfaces.SelectMany(iface => iface.GetMembers(asyncMethodName)))
+                .Any(alt => IsXAtLeastAsPublicAsY(alt, methodSymbol));
+        }
+
+        return false;
     }
 
     public static bool IsXAtLeastAsPublicAsY(ISymbol x, ISymbol y)

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Utils.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Utils.cs
@@ -330,10 +330,15 @@ public static class Utils
             return true;
         }
 
-        if (methodSymbol.IsExtensionMethod && methodSymbol.Parameters[0].Type is INamedTypeSymbol receiverType)
+        if (methodSymbol.IsExtensionMethod && !methodSymbol.Parameters.IsDefaultOrEmpty && methodSymbol.Parameters[0].Type is INamedTypeSymbol receiverType)
         {
-            return receiverType.GetMembers(asyncMethodName)
-                .Concat(receiverType.AllInterfaces.SelectMany(iface => iface.GetMembers(asyncMethodName)))
+            IEnumerable<ISymbol> receiverMembers = receiverType.AllInterfaces.SelectMany(iface => iface.GetMembers(asyncMethodName));
+            for (INamedTypeSymbol? currentType = receiverType; currentType is not null; currentType = currentType.BaseType)
+            {
+                receiverMembers = receiverMembers.Concat(currentType.GetMembers(asyncMethodName));
+            }
+
+            return receiverMembers
                 .Any(alt => IsXAtLeastAsPublicAsY(alt, methodSymbol));
         }
 

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/Utils.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/Utils.cs
@@ -332,16 +332,21 @@ public static class Utils
 
         if (methodSymbol.IsExtensionMethod && !methodSymbol.Parameters.IsDefaultOrEmpty && methodSymbol.Parameters[0].Type is INamedTypeSymbol receiverType)
         {
-            IEnumerable<ISymbol> receiverMembers = receiverType.TypeKind == TypeKind.Interface
-                ? receiverType.AllInterfaces.SelectMany(iface => iface.GetMembers(asyncMethodName))
-                : Enumerable.Empty<ISymbol>();
-            for (INamedTypeSymbol? currentType = receiverType; currentType is not null; currentType = currentType.BaseType)
+            if (receiverType.TypeKind == TypeKind.Interface
+                && receiverType.AllInterfaces.Any(iface => iface.GetMembers(asyncMethodName).Any(alt => IsXAtLeastAsPublicAsY(alt, methodSymbol))))
             {
-                receiverMembers = receiverMembers.Concat(currentType.GetMembers(asyncMethodName));
+                return true;
             }
 
-            return receiverMembers
-                .Any(alt => IsXAtLeastAsPublicAsY(alt, methodSymbol));
+            for (INamedTypeSymbol? currentType = receiverType; currentType is not null; currentType = currentType.BaseType)
+            {
+                if (currentType.GetMembers(asyncMethodName).Any(alt => IsXAtLeastAsPublicAsY(alt, methodSymbol)))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         return false;

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD104OfferAsyncOptionAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD104OfferAsyncOptionAnalyzerTests.cs
@@ -122,6 +122,31 @@ public static class ServiceExtensions {
     }
 
     [Fact]
+    public async Task JTFRunFromPublicExtensionMethodWithInheritedAsyncInstanceMethod_GeneratesNoWarning()
+    {
+        var test = @"
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
+
+public class ServiceBase {
+    public Task ClearAsync(string category) => Task.CompletedTask;
+}
+
+public class Service : ServiceBase {
+}
+
+public static class ServiceExtensions {
+    private static readonly JoinableTaskFactory Jtf = new JoinableTaskFactory(new JoinableTaskContext());
+
+    public static void Clear(this Service service, string category)
+        => Jtf.Run(() => service.ClearAsync(category));
+}
+";
+
+        await CSVerify.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
     public async Task TaskResultGuardedByIsCompletedSuccessfully_GeneratesNoWarning()
     {
         var test = @"
@@ -168,6 +193,60 @@ public class Test {
             ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
         };
         analyzerTest.ExpectedDiagnostics.Add(CSVerify.Diagnostic().WithSpan(7, 25, 7, 31));
+        await analyzerTest.RunAsync();
+    }
+
+    [Fact]
+    public async Task ValueTaskResultGuardedByIsCompletedSuccessfully_GeneratesWarning()
+    {
+        var test = @"
+using System.Threading.Tasks;
+
+public class Test {
+    public int GetResult(ValueTask<int> task) {
+        if (task.IsCompletedSuccessfully) {
+            return task.Result;
+        }
+
+        return 0;
+    }
+}
+";
+
+        var analyzerTest = new CSVerify.Test
+        {
+            TestCode = test,
+            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+        };
+        analyzerTest.ExpectedDiagnostics.Add(CSVerify.Diagnostic().WithSpan(7, 25, 7, 31));
+        await analyzerTest.RunAsync();
+    }
+
+    [Fact]
+    public async Task TaskPropertyResultGuardedByIsCompletedSuccessfully_GeneratesWarning()
+    {
+        var test = @"
+using System.Threading.Tasks;
+
+public class Test {
+    private Task<int> TaskProperty => Task.FromResult(1);
+
+    public int GetResult() {
+        if (TaskProperty.IsCompletedSuccessfully) {
+            return TaskProperty.Result;
+        }
+
+        return 0;
+    }
+}
+";
+
+        var analyzerTest = new CSVerify.Test
+        {
+            TestCode = test,
+            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+        };
+        analyzerTest.ExpectedDiagnostics.Add(CSVerify.Diagnostic().WithSpan(9, 33, 9, 39));
         await analyzerTest.RunAsync();
     }
 }

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD104OfferAsyncOptionAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD104OfferAsyncOptionAnalyzerTests.cs
@@ -388,4 +388,32 @@ public class Test {
         analyzerTest.ExpectedDiagnostics.Add(CSVerify.Diagnostic().WithSpan(9, 25, 9, 31));
         await analyzerTest.RunAsync();
     }
+
+    [Fact]
+    public async Task TaskResultAfterPriorRefAliasWriteWithinCompletionGuard_GeneratesWarning()
+    {
+        var test = @"
+using System.Threading.Tasks;
+
+public class Test {
+    public int GetResult(Task<int> task) {
+        ref Task<int> alias = ref task;
+        if (task.IsCompletedSuccessfully) {
+            alias = new TaskCompletionSource<int>().Task;
+            return task.Result;
+        }
+
+        return 0;
+    }
+}
+";
+
+        var analyzerTest = new CSVerify.Test
+        {
+            TestCode = test,
+            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+        };
+        analyzerTest.ExpectedDiagnostics.Add(CSVerify.Diagnostic().WithSpan(9, 25, 9, 31));
+        await analyzerTest.RunAsync();
+    }
 }

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD104OfferAsyncOptionAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD104OfferAsyncOptionAnalyzerTests.cs
@@ -360,4 +360,32 @@ public class Test {
         analyzerTest.ExpectedDiagnostics.Add(CSVerify.Diagnostic().WithSpan(8, 25, 8, 31));
         await analyzerTest.RunAsync();
     }
+
+    [Fact]
+    public async Task TaskResultAfterRefAliasWriteWithinCompletionGuard_GeneratesWarning()
+    {
+        var test = @"
+using System.Threading.Tasks;
+
+public class Test {
+    public int GetResult(Task<int> task) {
+        if (task.IsCompletedSuccessfully) {
+            ref Task<int> alias = ref task;
+            alias = new TaskCompletionSource<int>().Task;
+            return task.Result;
+        }
+
+        return 0;
+    }
+}
+";
+
+        var analyzerTest = new CSVerify.Test
+        {
+            TestCode = test,
+            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+        };
+        analyzerTest.ExpectedDiagnostics.Add(CSVerify.Diagnostic().WithSpan(9, 25, 9, 31));
+        await analyzerTest.RunAsync();
+    }
 }

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD104OfferAsyncOptionAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD104OfferAsyncOptionAnalyzerTests.cs
@@ -249,4 +249,31 @@ public class Test {
         analyzerTest.ExpectedDiagnostics.Add(CSVerify.Diagnostic().WithSpan(9, 33, 9, 39));
         await analyzerTest.RunAsync();
     }
+
+    [Fact]
+    public async Task TaskResultInLocalFunctionWithOuterCompletionGuard_GeneratesWarning()
+    {
+        var test = @"
+using System.Threading.Tasks;
+
+public class Test {
+    public int GetResult(Task<int> task) {
+        if (task.IsCompletedSuccessfully) {
+            int LocalFunction() => task.Result;
+            return LocalFunction();
+        }
+
+        return 0;
+    }
+}
+";
+
+        var analyzerTest = new CSVerify.Test
+        {
+            TestCode = test,
+            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+        };
+        analyzerTest.ExpectedDiagnostics.Add(CSVerify.Diagnostic().WithSpan(7, 41, 7, 47));
+        await analyzerTest.RunAsync();
+    }
 }

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD104OfferAsyncOptionAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD104OfferAsyncOptionAnalyzerTests.cs
@@ -147,6 +147,33 @@ public static class ServiceExtensions {
     }
 
     [Fact]
+    public async Task JTFRunFromPublicExtensionMethodWithExplicitInterfaceAsyncMethod_GeneratesWarning()
+    {
+        var test = @"
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
+
+public interface IService {
+    Task ClearAsync();
+}
+
+public class Service : IService {
+    Task IService.ClearAsync() => Task.CompletedTask;
+}
+
+public static class ServiceExtensions {
+    private static readonly JoinableTaskFactory Jtf = new JoinableTaskFactory(new JoinableTaskContext());
+
+    public static void Clear(this Service service)
+        => Jtf.Run(() => ((IService)service).ClearAsync());
+}
+";
+
+        DiagnosticResult expected = CSVerify.Diagnostic().WithSpan(17, 16, 17, 19);
+        await CSVerify.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
     public async Task TaskResultGuardedByIsCompletedSuccessfully_GeneratesNoWarning()
     {
         var test = @"
@@ -274,6 +301,63 @@ public class Test {
             ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
         };
         analyzerTest.ExpectedDiagnostics.Add(CSVerify.Diagnostic().WithSpan(7, 41, 7, 47));
+        await analyzerTest.RunAsync();
+    }
+
+    [Fact]
+    public async Task TaskResultAfterReassignmentWithinCompletionGuard_GeneratesWarning()
+    {
+        var test = @"
+using System.Threading.Tasks;
+
+public class Test {
+    public int GetResult(Task<int> task) {
+        if (task.IsCompletedSuccessfully) {
+            task = new TaskCompletionSource<int>().Task;
+            return task.Result;
+        }
+
+        return 0;
+    }
+}
+";
+
+        var analyzerTest = new CSVerify.Test
+        {
+            TestCode = test,
+            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+        };
+        analyzerTest.ExpectedDiagnostics.Add(CSVerify.Diagnostic().WithSpan(8, 25, 8, 31));
+        await analyzerTest.RunAsync();
+    }
+
+    [Fact]
+    public async Task TaskResultAfterRefWriteWithinCompletionGuard_GeneratesWarning()
+    {
+        var test = @"
+using System.Threading.Tasks;
+
+public class Test {
+    public int GetResult(Task<int> task) {
+        if (task.IsCompletedSuccessfully) {
+            Replace(ref task);
+            return task.Result;
+        }
+
+        return 0;
+    }
+
+    private static void Replace(ref Task<int> task)
+        => task = new TaskCompletionSource<int>().Task;
+}
+";
+
+        var analyzerTest = new CSVerify.Test
+        {
+            TestCode = test,
+            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+        };
+        analyzerTest.ExpectedDiagnostics.Add(CSVerify.Diagnostic().WithSpan(8, 25, 8, 31));
         await analyzerTest.RunAsync();
     }
 }

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD104OfferAsyncOptionAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD104OfferAsyncOptionAnalyzerTests.cs
@@ -98,4 +98,76 @@ public class Test {
         DiagnosticResult expected = CSVerify.Diagnostic().WithSpan(9, 13, 9, 16);
         await CSVerify.VerifyAnalyzerAsync(test, expected);
     }
+
+    [Fact]
+    public async Task JTFRunFromPublicExtensionMethodWithAsyncInstanceMethod_GeneratesNoWarning()
+    {
+        var test = @"
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
+
+public interface IService {
+    Task ClearAsync(string category);
+}
+
+public static class ServiceExtensions {
+    private static readonly JoinableTaskFactory Jtf = new JoinableTaskFactory(new JoinableTaskContext());
+
+    public static void Clear(this IService service, string category)
+        => Jtf.Run(() => service.ClearAsync(category));
+}
+";
+
+        await CSVerify.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TaskResultGuardedByIsCompletedSuccessfully_GeneratesNoWarning()
+    {
+        var test = @"
+using System.Threading.Tasks;
+
+public class Test {
+    public int GetResult(Task<int> task) {
+        if (task.IsCompletedSuccessfully) {
+            return task.Result;
+        }
+
+        return 0;
+    }
+}
+";
+
+        await new CSVerify.Test
+        {
+            TestCode = test,
+            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TaskResultGuardedByOtherTaskCompletion_GeneratesWarning()
+    {
+        var test = @"
+using System.Threading.Tasks;
+
+public class Test {
+    public int GetResult(Task<int> task, Task<int> otherTask) {
+        if (otherTask.IsCompletedSuccessfully) {
+            return task.Result;
+        }
+
+        return 0;
+    }
+}
+";
+
+        var analyzerTest = new CSVerify.Test
+        {
+            TestCode = test,
+            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+        };
+        analyzerTest.ExpectedDiagnostics.Add(CSVerify.Diagnostic().WithSpan(7, 25, 7, 31));
+        await analyzerTest.RunAsync();
+    }
 }

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD104OfferAsyncOptionAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD104OfferAsyncOptionAnalyzerTests.cs
@@ -416,4 +416,35 @@ public class Test {
         analyzerTest.ExpectedDiagnostics.Add(CSVerify.Diagnostic().WithSpan(9, 25, 9, 31));
         await analyzerTest.RunAsync();
     }
+
+    [Fact]
+    public async Task TaskResultAfterRefWriteInCompletionCondition_GeneratesWarning()
+    {
+        var test = @"
+using System.Threading.Tasks;
+
+public class Test {
+    public int GetResult(Task<int> task) {
+        if (task.IsCompletedSuccessfully && Replace(ref task)) {
+            return task.Result;
+        }
+
+        return 0;
+    }
+
+    private static bool Replace(ref Task<int> task) {
+        task = new TaskCompletionSource<int>().Task;
+        return true;
+    }
+}
+";
+
+        var analyzerTest = new CSVerify.Test
+        {
+            TestCode = test,
+            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+        };
+        analyzerTest.ExpectedDiagnostics.Add(CSVerify.Diagnostic().WithSpan(7, 25, 7, 31));
+        await analyzerTest.RunAsync();
+    }
 }


### PR DESCRIPTION
VSTHRD104 currently reports diagnostics even when a synchronous extension method wraps an async method exposed by its receiver, and when `Task.Result` is safely guarded by `IsCompletedSuccessfully`.

This change:
- recognizes sufficiently accessible async alternatives on extension-method receiver types and their interfaces;
- suppresses `Task.Result` diagnostics only when the same task is guarded by `IsCompletedSuccessfully` in the containing `if` branch;
- adds positive and negative regression coverage for both scenarios.

Fixes #1215
Addresses the VSTHRD104 portion of #680.