### PR TITLE
Fix VSTHRD200 handling of custom awaitables

### DIFF
--- a/docfx/analyzers/VSTHRD200.md
+++ b/docfx/analyzers/VSTHRD200.md
@@ -7,6 +7,9 @@ Methods that return awaitable types such as `Task` or `ValueTask`
 should have an Async suffix.
 Methods that do not return awaitable types should not use the Async suffix.
 
+Custom async-focused return types can be configured to require the suffix.
+See the [configuration](configuration.md#types-that-require-the-async-suffix) topic.
+
 ## Examples of patterns that are flagged by this analyzer
 
 This `Task`-returning method should have a name that ends with Async:

--- a/docfx/analyzers/configuration.md
+++ b/docfx/analyzers/configuration.md
@@ -104,3 +104,15 @@ excluded from VSTHRD103 analysis by specifying them in a configuration file.
 **Sample:** `[System.Data.SqlClient.SqlDataReader]::Read`
 
 **Generic sample:** ``[Microsoft.EntityFrameworkCore.DbSet`1]::Add``
+
+## Types that require the Async suffix
+
+VSTHRD200 requires methods returning `Task`, `ValueTask`, and other async-focused types
+to end with the `Async` suffix. Libraries can identify additional async-focused return
+types with this configuration file.
+
+**Filename:** `vs-threading.AsyncSuffixRequiredTypes.txt`
+
+**Line format:** `[Namespace.TypeName]`
+
+**Sample:** `[Microsoft.VisualStudio.Shell.Interop.IVsTask]`

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/CommonInterest.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/CommonInterest.cs
@@ -26,6 +26,7 @@ public static class CommonInterest
     public static readonly Regex FileNamePatternForMethodsThatAssertMainThread = new Regex(@"^vs-threading\.MainThreadAssertingMethods(\..*)?.txt$", FileNamePatternRegexOptions);
     public static readonly Regex FileNamePatternForMethodsThatSwitchToMainThread = new Regex(@"^vs-threading\.MainThreadSwitchingMethods(\..*)?.txt$", FileNamePatternRegexOptions);
     public static readonly Regex FileNamePatternForSyncMethodsToExcludeFromVSTHRD103 = new Regex(@"^vs-threading\.SyncMethodsToExcludeFromVSTHRD103(\..*)?.txt$", FileNamePatternRegexOptions);
+    public static readonly Regex FileNamePatternForAsyncSuffixRequiredTypes = new Regex(@"^vs-threading\.AsyncSuffixRequiredTypes(\..*)?.txt$", FileNamePatternRegexOptions);
 
     public static readonly IEnumerable<SyncBlockingMethod> JTFSyncBlockers =
     [
@@ -577,20 +578,38 @@ public static class CommonInterest
 
         public bool IsAwaitableType(ITypeSymbol typeSymbol)
         {
-            if (this.awaitableTypes.Contains(typeSymbol))
+            if (this.IsKnownAwaitableType(typeSymbol))
             {
                 return true;
             }
 
-            if (typeSymbol is INamedTypeSymbol { IsGenericType: true } genericTypeSymbol)
+            if (typeSymbol is INamedTypeSymbol namedTypeSymbol)
             {
-                if (this.awaitableTypes.Contains(genericTypeSymbol.ConstructUnboundGenericType()))
+                for (INamedTypeSymbol? baseType = namedTypeSymbol.BaseType; baseType is not null; baseType = baseType.BaseType)
                 {
-                    return true;
+                    if (this.IsKnownAwaitableType(baseType))
+                    {
+                        return true;
+                    }
+                }
+
+                foreach (INamedTypeSymbol interfaceType in namedTypeSymbol.AllInterfaces)
+                {
+                    if (this.IsKnownAwaitableType(interfaceType))
+                    {
+                        return true;
+                    }
                 }
             }
 
             return false;
+        }
+
+        private bool IsKnownAwaitableType(ITypeSymbol typeSymbol)
+        {
+            return this.awaitableTypes.Contains(typeSymbol)
+                || (typeSymbol is INamedTypeSymbol { IsGenericType: true } genericTypeSymbol
+                    && this.awaitableTypes.Contains(genericTypeSymbol.ConstructUnboundGenericType()));
         }
     }
 }

--- a/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD200UseAsyncNamingConventionAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/VSTHRD200UseAsyncNamingConventionAnalyzer.cs
@@ -52,28 +52,37 @@ public class VSTHRD200UseAsyncNamingConventionAnalyzer : DiagnosticAnalyzer
         context.RegisterCompilationStartAction(context =>
         {
             CommonInterest.AwaitableTypeTester awaitableTypes = CommonInterest.CollectAwaitableTypes(context.Compilation, context.CancellationToken);
-            context.RegisterSymbolAction(Utils.DebuggableWrapper(context => this.AnalyzeNode(context, awaitableTypes)), SymbolKind.Method);
-            context.RegisterOperationAction(Utils.DebuggableWrapper(context => this.AnalyzeLocalFunction(context, awaitableTypes)), OperationKind.LocalFunction);
+            ImmutableArray<CommonInterest.TypeMatchSpec> asyncSuffixRequiredTypes = CommonInterest.ReadTypesAndMembers(
+                context.Options,
+                CommonInterest.FileNamePatternForAsyncSuffixRequiredTypes,
+                context.CancellationToken).ToImmutableArray();
+            context.RegisterSymbolAction(Utils.DebuggableWrapper(context => this.AnalyzeNode(context, awaitableTypes, asyncSuffixRequiredTypes)), SymbolKind.Method);
+            context.RegisterOperationAction(Utils.DebuggableWrapper(context => this.AnalyzeLocalFunction(context, awaitableTypes, asyncSuffixRequiredTypes)), OperationKind.LocalFunction);
         });
     }
 
-    private void AnalyzeLocalFunction(OperationAnalysisContext context, CommonInterest.AwaitableTypeTester awaitableTypes)
+    private void AnalyzeLocalFunction(OperationAnalysisContext context, CommonInterest.AwaitableTypeTester awaitableTypes, ImmutableArray<CommonInterest.TypeMatchSpec> asyncSuffixRequiredTypes)
     {
-        if (this.AnalyzeMethodSymbol(context.Compilation, ((ILocalFunctionOperation)context.Operation).Symbol, awaitableTypes, context.CancellationToken) is Diagnostic diagnostic)
+        if (this.AnalyzeMethodSymbol(context.Compilation, ((ILocalFunctionOperation)context.Operation).Symbol, awaitableTypes, asyncSuffixRequiredTypes, context.CancellationToken) is Diagnostic diagnostic)
         {
             context.ReportDiagnostic(diagnostic);
         }
     }
 
-    private void AnalyzeNode(SymbolAnalysisContext context, CommonInterest.AwaitableTypeTester awaitableTypes)
+    private void AnalyzeNode(SymbolAnalysisContext context, CommonInterest.AwaitableTypeTester awaitableTypes, ImmutableArray<CommonInterest.TypeMatchSpec> asyncSuffixRequiredTypes)
     {
-        if (this.AnalyzeMethodSymbol(context.Compilation, (IMethodSymbol)context.Symbol, awaitableTypes, context.CancellationToken) is Diagnostic diagnostic)
+        if (this.AnalyzeMethodSymbol(context.Compilation, (IMethodSymbol)context.Symbol, awaitableTypes, asyncSuffixRequiredTypes, context.CancellationToken) is Diagnostic diagnostic)
         {
             context.ReportDiagnostic(diagnostic);
         }
     }
 
-    private Diagnostic? AnalyzeMethodSymbol(Compilation compilation, IMethodSymbol methodSymbol, CommonInterest.AwaitableTypeTester awaitableTypes, CancellationToken cancellationToken)
+    private Diagnostic? AnalyzeMethodSymbol(
+        Compilation compilation,
+        IMethodSymbol methodSymbol,
+        CommonInterest.AwaitableTypeTester awaitableTypes,
+        ImmutableArray<CommonInterest.TypeMatchSpec> asyncSuffixRequiredTypes,
+        CancellationToken cancellationToken)
     {
         if (methodSymbol.AssociatedSymbol is IPropertySymbol)
         {
@@ -93,7 +102,8 @@ public class VSTHRD200UseAsyncNamingConventionAnalyzer : DiagnosticAnalyzer
             return null;
         }
 
-        bool hasAsyncFocusedReturnType = Utils.HasAsyncCompatibleReturnType(methodSymbol);
+        bool hasAsyncFocusedReturnType = Utils.HasAsyncCompatibleReturnType(methodSymbol)
+            || asyncSuffixRequiredTypes.Contains(methodSymbol.ReturnType, memberSymbol: null);
 
         bool actuallyEndsWithAsync = methodSymbol.Name.EndsWith(MandatoryAsyncSuffix, StringComparison.CurrentCulture);
 

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/AdditionalFiles/vs-threading.AsyncSuffixRequiredTypes.mocks.txt
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/AdditionalFiles/vs-threading.AsyncSuffixRequiredTypes.mocks.txt
@@ -1,0 +1,1 @@
+[TestNS.AsyncFocusedAwaitable]

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD110ObserveResultOfAsyncCallsAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD110ObserveResultOfAsyncCallsAnalyzerTests.cs
@@ -350,6 +350,35 @@ class CustomAwaitable : INotifyCompletion
     }
 
     [Fact]
+    public async Task DerivedCustomAwaitable_ProducesDiagnostic()
+    {
+        string test = """
+            using System.Runtime.CompilerServices;
+
+            class Test
+            {
+                void Foo()
+                {
+                    [|BarAsync()|];
+                }
+
+                DerivedCustomTask BarAsync() => new();
+            }
+
+            class CustomTask
+            {
+                public TaskAwaiter GetAwaiter() => default;
+            }
+
+            class DerivedCustomTask : CustomTask
+            {
+            }
+            """;
+
+        await CSVerify.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
     public async Task CustomAwaitableLikeType_ProducesNoDiagnostic()
     {
         var test = @"

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD200UseAsyncNamingConventionAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD200UseAsyncNamingConventionAnalyzerTests.cs
@@ -655,4 +655,62 @@ class Test : IAsyncDisposable
         DiagnosticResult expected = CSVerify.Diagnostic(AddSuffixDescriptor).WithLocation(0);
         await CSVerify.VerifyCodeFixAsync(test, expected, fix);
     }
+
+    [Fact]
+    public async Task DerivedAwaitableReturningMethodWithSuffix_GeneratesNoWarning()
+    {
+        string test = """
+            using System.Runtime.CompilerServices;
+
+            class Awaitable
+            {
+                public TaskAwaiter GetAwaiter() => default;
+            }
+
+            class DerivedAwaitable : Awaitable
+            {
+            }
+
+            class Test
+            {
+                DerivedAwaitable GetValueAsync() => new();
+            }
+            """;
+
+        await CSVerify.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task ConfiguredAsyncFocusedTypeWithoutSuffix_GeneratesWarning()
+    {
+        string test = """
+            namespace TestNS
+            {
+                class AsyncFocusedAwaitable
+                {
+                }
+
+                class Test
+                {
+                    AsyncFocusedAwaitable {|#0:GetValue|}() => new();
+                }
+            }
+            """;
+        string fix = """
+            namespace TestNS
+            {
+                class AsyncFocusedAwaitable
+                {
+                }
+
+                class Test
+                {
+                    AsyncFocusedAwaitable GetValueAsync() => new();
+                }
+            }
+            """;
+
+        DiagnosticResult expected = CSVerify.Diagnostic(AddSuffixDescriptor).WithLocation(0);
+        await CSVerify.VerifyCodeFixAsync(test, expected, fix);
+    }
 }


### PR DESCRIPTION
VSTHRD200 can incorrectly reject the `Async` suffix for derived awaitable types, while libraries have no way to identify custom types that should require the suffix.

This change makes awaitable detection inheritance-aware and adds `vs-threading.AsyncSuffixRequiredTypes.txt` configuration for opt-in async-focused return types. The shared awaitable detection improvement also covers VSTHRD110. Documentation and regression coverage are included.

Fixes #419
Fixes #1023