### PR TITLE
Recognize safely completed Task results in VSTHRD103

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/TaskCompletionAnalysis.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/TaskCompletionAnalysis.cs
@@ -1,0 +1,170 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Microsoft.VisualStudio.Threading.Analyzers;
+
+/// <summary>
+/// Recognizes cases where accessing <see cref="System.Threading.Tasks.Task{TResult}.Result"/> cannot block.
+/// </summary>
+internal static class TaskCompletionAnalysis
+{
+    /// <summary>
+    /// Determines whether a task is known to be complete at a particular <c>Result</c> access.
+    /// </summary>
+    /// <param name="context">The analyzer context.</param>
+    /// <param name="resultAccess">The <c>Result</c> access.</param>
+    /// <returns><see langword="true"/> if the task is known to be complete; otherwise, <see langword="false"/>.</returns>
+    internal static bool IsTaskKnownToBeCompleted(SyntaxNodeAnalysisContext context, MemberAccessExpressionSyntax resultAccess)
+    {
+        ISymbol? taskSymbol = context.SemanticModel.GetSymbolInfo(resultAccess.Expression, context.CancellationToken).Symbol;
+        if (taskSymbol is ILocalSymbol { RefKind: not RefKind.None }
+            || taskSymbol is IParameterSymbol { RefKind: not RefKind.None }
+            || taskSymbol is not ILocalSymbol and not IParameterSymbol)
+        {
+            return false;
+        }
+
+        SyntaxNode executableScope = GetExecutableScope(resultAccess);
+        ISymbol? executableSymbol = executableScope switch
+        {
+            AnonymousFunctionExpressionSyntax anonymousFunction => context.SemanticModel.GetSymbolInfo(anonymousFunction, context.CancellationToken).Symbol,
+            LocalFunctionStatementSyntax localFunction => context.SemanticModel.GetDeclaredSymbol(localFunction, context.CancellationToken),
+            BaseMethodDeclarationSyntax method => context.SemanticModel.GetDeclaredSymbol(method, context.CancellationToken),
+            AccessorDeclarationSyntax accessor => context.SemanticModel.GetDeclaredSymbol(accessor, context.CancellationToken),
+            _ => null,
+        };
+        if (!SymbolEqualityComparer.Default.Equals(taskSymbol.ContainingSymbol, executableSymbol))
+        {
+            return false;
+        }
+
+        return IsGuardedBySuccessfulCompletion(context, resultAccess, taskSymbol, executableScope)
+            || IsContinueWithAntecedent(context, resultAccess, taskSymbol, executableScope);
+    }
+
+    private static bool IsGuardedBySuccessfulCompletion(
+        SyntaxNodeAnalysisContext context,
+        MemberAccessExpressionSyntax resultAccess,
+        ISymbol taskSymbol,
+        SyntaxNode executableScope)
+    {
+        foreach (IfStatementSyntax ifStatement in resultAccess.Ancestors()
+            .TakeWhile(ancestor => ancestor != executableScope)
+            .OfType<IfStatementSyntax>())
+        {
+            if (ifStatement.Statement.Span.Contains(resultAccess.Span)
+                && ConditionProvesSuccessfulCompletion(context, ifStatement.Condition, taskSymbol)
+                && !MayWriteSymbol(context, executableScope, taskSymbol))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsContinueWithAntecedent(
+        SyntaxNodeAnalysisContext context,
+        MemberAccessExpressionSyntax resultAccess,
+        ISymbol taskSymbol,
+        SyntaxNode executableScope)
+    {
+        if (executableScope is not AnonymousFunctionExpressionSyntax anonymousFunction
+            || taskSymbol is not IParameterSymbol { ContainingSymbol: IMethodSymbol containingMethod, Ordinal: 0 } antecedentParameter
+            || !SymbolEqualityComparer.Default.Equals(
+                containingMethod,
+                context.SemanticModel.GetSymbolInfo(anonymousFunction, context.CancellationToken).Symbol)
+            || anonymousFunction.Parent is not ArgumentSyntax argument
+            || argument.Parent is not ArgumentListSyntax argumentList
+            || argumentList.Parent is not InvocationExpressionSyntax continueWithInvocation
+            || context.SemanticModel.GetSymbolInfo(continueWithInvocation, context.CancellationToken).Symbol is not IMethodSymbol continueWithMethod
+            || continueWithMethod.Name != nameof(System.Threading.Tasks.Task.ContinueWith)
+            || !Utils.IsTask(continueWithMethod.ContainingType))
+        {
+            return false;
+        }
+
+        if (context.SemanticModel.GetOperation(argument, context.CancellationToken) is not IArgumentOperation argumentOperation
+            || argumentOperation.Parameter?.Type is not INamedTypeSymbol { TypeKind: TypeKind.Delegate } continuationDelegate
+            || continuationDelegate.DelegateInvokeMethod is not { Parameters.Length: > 0 } delegateInvokeMethod
+            || !SymbolEqualityComparer.Default.Equals(delegateInvokeMethod.Parameters[0].Type, antecedentParameter.Type))
+        {
+            return false;
+        }
+
+        return !MayWriteSymbol(context, executableScope, taskSymbol);
+    }
+
+    private static bool ConditionProvesSuccessfulCompletion(SyntaxNodeAnalysisContext context, ExpressionSyntax condition, ISymbol expectedTaskSymbol)
+    {
+        while (condition is ParenthesizedExpressionSyntax parenthesized)
+        {
+            condition = parenthesized.Expression;
+        }
+
+        if (condition is BinaryExpressionSyntax { RawKind: (int)SyntaxKind.LogicalAndExpression } logicalAnd)
+        {
+            return ConditionProvesSuccessfulCompletion(context, logicalAnd.Left, expectedTaskSymbol)
+                || ConditionProvesSuccessfulCompletion(context, logicalAnd.Right, expectedTaskSymbol);
+        }
+
+        if (condition is not MemberAccessExpressionSyntax { Name.Identifier.ValueText: "IsCompletedSuccessfully" } completionAccess)
+        {
+            return false;
+        }
+
+        ISymbol? completionProperty = context.SemanticModel.GetSymbolInfo(completionAccess, context.CancellationToken).Symbol;
+        ISymbol? completedTaskSymbol = context.SemanticModel.GetSymbolInfo(completionAccess.Expression, context.CancellationToken).Symbol;
+        return completionProperty is IPropertySymbol { ContainingType: { } containingType }
+            && Utils.IsTask(containingType)
+            && SymbolEqualityComparer.Default.Equals(expectedTaskSymbol, completedTaskSymbol);
+    }
+
+    private static bool MayWriteSymbol(SyntaxNodeAnalysisContext context, SyntaxNode executableScope, ISymbol expectedTaskSymbol)
+    {
+        if (executableScope.DescendantNodes()
+            .OfType<RefExpressionSyntax>()
+            .Any())
+        {
+            return true;
+        }
+
+        foreach (SyntaxNode node in executableScope.DescendantNodes())
+        {
+            ExpressionSyntax? writtenExpression = node switch
+            {
+                AssignmentExpressionSyntax assignment => assignment.Left,
+                PrefixUnaryExpressionSyntax prefix when prefix.IsKind(SyntaxKind.PreIncrementExpression) || prefix.IsKind(SyntaxKind.PreDecrementExpression) => prefix.Operand,
+                PostfixUnaryExpressionSyntax postfix when postfix.IsKind(SyntaxKind.PostIncrementExpression) || postfix.IsKind(SyntaxKind.PostDecrementExpression) => postfix.Operand,
+                ArgumentSyntax argument when argument.RefOrOutKeyword.IsKind(SyntaxKind.RefKeyword) || argument.RefOrOutKeyword.IsKind(SyntaxKind.OutKeyword) => argument.Expression,
+                _ => null,
+            };
+
+            if (writtenExpression is not null && writtenExpression.DescendantNodesAndSelf()
+                .OfType<ExpressionSyntax>()
+                .Any(candidate => SymbolEqualityComparer.Default.Equals(
+                    context.SemanticModel.GetSymbolInfo(candidate, context.CancellationToken).Symbol,
+                    expectedTaskSymbol)))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static SyntaxNode GetExecutableScope(ExpressionSyntax expression)
+        => expression.Ancestors().FirstOrDefault(ancestor =>
+            ancestor is AnonymousFunctionExpressionSyntax
+            or LocalFunctionStatementSyntax
+            or QueryExpressionSyntax
+            or BaseMethodDeclarationSyntax
+            or AccessorDeclarationSyntax) ?? expression;
+}

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD103UseAsyncOptionAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD103UseAsyncOptionAnalyzer.cs
@@ -240,6 +240,14 @@ public class VSTHRD103UseAsyncOptionAnalyzer : DiagnosticAnalyzer
                 {
                     if (item.Method.IsMatch(memberSymbol))
                     {
+                        if (memberSymbol is IPropertySymbol { Name: nameof(Task<int>.Result), ContainingType: { } containingType }
+                            && Utils.IsTask(containingType)
+                            && memberName.Parent is MemberAccessExpressionSyntax resultAccess
+                            && TaskCompletionAnalysis.IsTaskKnownToBeCompleted(context, resultAccess))
+                        {
+                            return false;
+                        }
+
                         // Check if this method is excluded from VSTHRD103 diagnostics
                         if (this.excludedMethods.Contains(memberSymbol))
                         {

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD104OfferAsyncOptionAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CSharp/VSTHRD104OfferAsyncOptionAnalyzer.cs
@@ -4,8 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -100,7 +98,7 @@ public class VSTHRD104OfferAsyncOptionAnalyzer : DiagnosticAnalyzer
                     {
                         if (invokedMember is IPropertySymbol { Name: nameof(Task<int>.Result), ContainingType: { } containingType }
                             && Utils.IsTask(containingType)
-                            && this.IsGuardedBySuccessfulCompletion(context, memberAccessSyntax))
+                            && TaskCompletionAnalysis.IsTaskKnownToBeCompleted(context, memberAccessSyntax))
                         {
                             return;
                         }
@@ -110,96 +108,6 @@ public class VSTHRD104OfferAsyncOptionAnalyzer : DiagnosticAnalyzer
                         this.diagnosticReported = true;
                     }
                 }
-            }
-        }
-
-        private bool IsGuardedBySuccessfulCompletion(SyntaxNodeAnalysisContext context, MemberAccessExpressionSyntax resultAccess)
-        {
-            ISymbol? taskSymbol = context.SemanticModel.GetSymbolInfo(resultAccess.Expression, context.CancellationToken).Symbol;
-            if (taskSymbol is not ILocalSymbol and not IParameterSymbol)
-            {
-                return false;
-            }
-
-            foreach (IfStatementSyntax ifStatement in resultAccess.Ancestors()
-                .TakeWhile(ancestor => ancestor is not LocalFunctionStatementSyntax)
-                .OfType<IfStatementSyntax>())
-            {
-                if (ifStatement.Statement.Span.Contains(resultAccess.Span)
-                    && ConditionProvesSuccessfulCompletion(ifStatement.Condition, taskSymbol)
-                    && !MayWriteSymbolBefore(ifStatement.Condition, resultAccess, taskSymbol)
-                    && !MayWriteSymbolBefore(ifStatement.Statement, resultAccess, taskSymbol))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-
-            bool ConditionProvesSuccessfulCompletion(ExpressionSyntax condition, ISymbol expectedTaskSymbol)
-            {
-                while (condition is ParenthesizedExpressionSyntax parenthesized)
-                {
-                    condition = parenthesized.Expression;
-                }
-
-                if (condition is BinaryExpressionSyntax { RawKind: (int)SyntaxKind.LogicalAndExpression } logicalAnd)
-                {
-                    return ConditionProvesSuccessfulCompletion(logicalAnd.Left, expectedTaskSymbol)
-                        || ConditionProvesSuccessfulCompletion(logicalAnd.Right, expectedTaskSymbol);
-                }
-
-                if (condition is not MemberAccessExpressionSyntax { Name.Identifier.ValueText: "IsCompletedSuccessfully" } completionAccess)
-                {
-                    return false;
-                }
-
-                ISymbol? completionProperty = context.SemanticModel.GetSymbolInfo(completionAccess, context.CancellationToken).Symbol;
-                ISymbol? completedTaskSymbol = context.SemanticModel.GetSymbolInfo(completionAccess.Expression, context.CancellationToken).Symbol;
-                return completionProperty is IPropertySymbol { ContainingType: { } containingType }
-                    && Utils.IsTask(containingType)
-                    && SymbolEqualityComparer.Default.Equals(expectedTaskSymbol, completedTaskSymbol);
-            }
-
-            bool MayWriteSymbolBefore(SyntaxNode region, ExpressionSyntax expression, ISymbol expectedTaskSymbol)
-            {
-                SyntaxNode executableScope = expression.Ancestors().FirstOrDefault(ancestor =>
-                    ancestor is AnonymousFunctionExpressionSyntax
-                    or LocalFunctionStatementSyntax
-                    or BaseMethodDeclarationSyntax
-                    or AccessorDeclarationSyntax) ?? region;
-                if (executableScope.DescendantNodes()
-                    .OfType<RefExpressionSyntax>()
-                    .Where(refExpression => refExpression.SpanStart < expression.SpanStart)
-                    .Any(refExpression => SymbolEqualityComparer.Default.Equals(
-                        context.SemanticModel.GetSymbolInfo(refExpression.Expression, context.CancellationToken).Symbol,
-                        expectedTaskSymbol)))
-                {
-                    return true;
-                }
-
-                foreach (SyntaxNode node in region.DescendantNodes().Where(node => node.SpanStart < expression.SpanStart))
-                {
-                    ExpressionSyntax? writtenExpression = node switch
-                    {
-                        AssignmentExpressionSyntax assignment => assignment.Left,
-                        PrefixUnaryExpressionSyntax prefix when prefix.IsKind(SyntaxKind.PreIncrementExpression) || prefix.IsKind(SyntaxKind.PreDecrementExpression) => prefix.Operand,
-                        PostfixUnaryExpressionSyntax postfix when postfix.IsKind(SyntaxKind.PostIncrementExpression) || postfix.IsKind(SyntaxKind.PostDecrementExpression) => postfix.Operand,
-                        ArgumentSyntax argument when argument.RefOrOutKeyword.IsKind(SyntaxKind.RefKeyword) || argument.RefOrOutKeyword.IsKind(SyntaxKind.OutKeyword) => argument.Expression,
-                        _ => null,
-                    };
-
-                    if (writtenExpression is not null && writtenExpression.DescendantNodesAndSelf()
-                        .OfType<ExpressionSyntax>()
-                        .Any(candidate => SymbolEqualityComparer.Default.Equals(
-                            context.SemanticModel.GetSymbolInfo(candidate, context.CancellationToken).Symbol,
-                            expectedTaskSymbol)))
-                    {
-                        return true;
-                    }
-                }
-
-                return false;
             }
         }
     }

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD103UseAsyncOptionAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD103UseAsyncOptionAnalyzerTests.cs
@@ -791,6 +791,457 @@ class Test {
     }
 
     [Fact]
+    public async Task TaskResultGuardedByIsCompletedSuccessfully_GeneratesNoWarning()
+    {
+        string test = """
+            using System.Threading.Tasks;
+
+            class Test
+            {
+                Task<int> GetResultAsync(Task<int> task)
+                {
+                    if (task.IsCompletedSuccessfully)
+                    {
+                        return Task.FromResult(task.Result);
+                    }
+
+                    return task;
+                }
+            }
+            """;
+
+        await new CSVerify.Test
+        {
+            TestCode = test,
+            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TaskResultGuardedByOtherTaskCompletion_GeneratesWarning()
+    {
+        string test = """
+            using System.Threading.Tasks;
+
+            class Test
+            {
+                Task<int> GetResultAsync(Task<int> task, Task<int> otherTask)
+                {
+                    if (otherTask.IsCompletedSuccessfully)
+                    {
+                        return Task.FromResult(task.{|#0:Result|});
+                    }
+
+                    return task;
+                }
+            }
+            """;
+
+        var analyzerTest = new CSVerify.Test
+        {
+            TestCode = test,
+            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+        };
+        analyzerTest.ExpectedDiagnostics.Add(CSVerify.Diagnostic(DescriptorNoAlternativeMethod).WithLocation(0).WithArguments("Result"));
+        await analyzerTest.RunAsync();
+    }
+
+    [Fact]
+    public async Task TaskResultAfterReassignmentWithinCompletionGuard_GeneratesWarning()
+    {
+        string test = """
+            using System.Threading.Tasks;
+
+            class Test
+            {
+                Task<int> GetResultAsync(Task<int> task)
+                {
+                    if (task.IsCompletedSuccessfully)
+                    {
+                        task = new TaskCompletionSource<int>().Task;
+                        return Task.FromResult(task.{|#0:Result|});
+                    }
+
+                    return task;
+                }
+            }
+            """;
+
+        var analyzerTest = new CSVerify.Test
+        {
+            TestCode = test,
+            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+        };
+        analyzerTest.ExpectedDiagnostics.Add(CSVerify.Diagnostic(DescriptorNoAlternativeMethod).WithLocation(0).WithArguments("Result"));
+        await analyzerTest.RunAsync();
+    }
+
+    [Fact]
+    public async Task TaskResultInLocalFunctionWithOuterCompletionGuard_GeneratesWarning()
+    {
+        string test = """
+            using System.Threading.Tasks;
+
+            class Test
+            {
+                Task<int> GetResultAsync(Task<int> task)
+                {
+                    if (task.IsCompletedSuccessfully)
+                    {
+                        Task<int> LocalAsync() => Task.FromResult(task.{|#0:Result|});
+                        return LocalAsync();
+                    }
+
+                    return task;
+                }
+            }
+            """;
+
+        var analyzerTest = new CSVerify.Test
+        {
+            TestCode = test,
+            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+        };
+        analyzerTest.ExpectedDiagnostics.Add(CSVerify.Diagnostic(DescriptorNoAlternativeMethod).WithLocation(0).WithArguments("Result"));
+        await analyzerTest.RunAsync();
+    }
+
+    [Fact]
+    public async Task TaskResultThroughRefAliasAfterOriginalReassignment_GeneratesWarning()
+    {
+        string test = """
+            using System.Threading.Tasks;
+
+            class Test
+            {
+                Task<int> GetResultAsync(Task<int> task)
+                {
+                    ref Task<int> alias = ref task;
+                    if (alias.IsCompletedSuccessfully)
+                    {
+                        task = new TaskCompletionSource<int>().Task;
+                        return Task.FromResult(alias.{|#0:Result|});
+                    }
+
+                    return task;
+                }
+            }
+            """;
+
+        var analyzerTest = new CSVerify.Test
+        {
+            TestCode = test,
+            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+        };
+        analyzerTest.ExpectedDiagnostics.Add(CSVerify.Diagnostic(DescriptorNoAlternativeMethod).WithLocation(0).WithArguments("Result"));
+        await analyzerTest.RunAsync();
+    }
+
+    [Fact]
+    public async Task TaskResultBeforeReassignmentInLoop_GeneratesWarning()
+    {
+        string test = """
+            using System.Threading.Tasks;
+
+            class Test
+            {
+                Task<int> GetResultAsync(Task<int> task, Task<int> replacement)
+                {
+                    if (task.IsCompletedSuccessfully)
+                    {
+                        while (true)
+                        {
+                            _ = task.{|#0:Result|};
+                            task = replacement;
+                        }
+                    }
+
+                    return task;
+                }
+            }
+            """;
+
+        var analyzerTest = new CSVerify.Test
+        {
+            TestCode = test,
+            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+        };
+        analyzerTest.ExpectedDiagnostics.Add(CSVerify.Diagnostic(DescriptorNoAlternativeMethod).WithLocation(0).WithArguments("Result"));
+        await analyzerTest.RunAsync();
+    }
+
+    [Fact]
+    public async Task ValueTaskResultGuardedByIsCompletedSuccessfully_GeneratesWarning()
+    {
+        string test = """
+            using System.Threading.Tasks;
+
+            class Test
+            {
+                Task<int> GetResultAsync(ValueTask<int> task)
+                {
+                    if (task.IsCompletedSuccessfully)
+                    {
+                        return Task.FromResult(task.{|#0:Result|});
+                    }
+
+                    return Task.FromResult(0);
+                }
+            }
+            """;
+
+        var analyzerTest = new CSVerify.Test
+        {
+            TestCode = test,
+            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+        };
+        analyzerTest.ExpectedDiagnostics.Add(CSVerify.Diagnostic(DescriptorNoAlternativeMethod).WithLocation(0).WithArguments("Result"));
+        await analyzerTest.RunAsync();
+    }
+
+    [Fact]
+    public async Task TaskResultForContinueWithAntecedent_GeneratesNoWarning()
+    {
+        string test = """
+            using System.Threading.Tasks;
+
+            class Test
+            {
+                Task<int> ContinueAsync(Task<int> task)
+                    => task.ContinueWith(
+                        antecedent => Task.FromResult(antecedent.Result),
+                        TaskScheduler.Default).Unwrap();
+            }
+            """;
+
+        await CSVerify.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TaskResultForUnrelatedTaskWithinContinueWith_GeneratesWarning()
+    {
+        string test = """
+            using System.Threading.Tasks;
+
+            class Test
+            {
+                Task<int> ContinueAsync(Task<int> task, Task<int> otherTask)
+                    => task.ContinueWith(
+                        antecedent => Task.FromResult(otherTask.{|#0:Result|}),
+                        TaskScheduler.Default).Unwrap();
+            }
+            """;
+
+        await CSVerify.VerifyAnalyzerAsync(
+            test,
+            CSVerify.Diagnostic(DescriptorNoAlternativeMethod).WithLocation(0).WithArguments("Result"));
+    }
+
+    [Fact]
+    public async Task TaskResultForReassignedContinueWithAntecedent_GeneratesWarning()
+    {
+        string test = """
+            using System.Threading.Tasks;
+
+            class Test
+            {
+                Task<int> ContinueAsync(Task<int> task)
+                    => task.ContinueWith(
+                        antecedent =>
+                        {
+                            antecedent = new TaskCompletionSource<int>().Task;
+                            return Task.FromResult(antecedent.{|#0:Result|});
+                        },
+                        TaskScheduler.Default).Unwrap();
+            }
+            """;
+
+        await CSVerify.VerifyAnalyzerAsync(
+            test,
+            CSVerify.Diagnostic(DescriptorNoAlternativeMethod).WithLocation(0).WithArguments("Result"));
+    }
+
+    [Fact]
+    public async Task TaskResultForCustomContinueWithCallback_GeneratesWarning()
+    {
+        string test = """
+            using System;
+            using System.Threading.Tasks;
+
+            class Test
+            {
+                Task<int> ContinueAsync(Task<int> task)
+                    => ContinueWith(antecedent => Task.FromResult(antecedent.{|#0:Result|}));
+
+                Task<int> ContinueWith(Func<Task<int>, Task<int>> continuation)
+                    => continuation(Task.FromResult(1));
+            }
+            """;
+
+        await CSVerify.VerifyAnalyzerAsync(
+            test,
+            CSVerify.Diagnostic(DescriptorNoAlternativeMethod).WithLocation(0).WithArguments("Result"));
+    }
+
+    [Fact]
+    public async Task TaskResultForContinueWithStateLambda_GeneratesWarning()
+    {
+        string test = """
+            using System;
+            using System.Threading.Tasks;
+
+            class Test
+            {
+                Task ContinueAsync(Task task)
+                    => task.ContinueWith(
+                        (antecedent, state) => ((Func<Task<int>, Task<int>>)state)(new TaskCompletionSource<int>().Task),
+                        (Task<int> stateTask) => Task.FromResult(stateTask.{|#0:Result|}));
+            }
+            """;
+
+        await CSVerify.VerifyAnalyzerAsync(
+            test,
+            CSVerify.Diagnostic(DescriptorNoAlternativeMethod).WithLocation(0).WithArguments("Result"));
+    }
+
+    [Fact]
+    public async Task TaskResultInDeferredQueryWithOuterCompletionGuard_GeneratesWarning()
+    {
+        string test = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using System.Threading.Tasks;
+
+            class Test
+            {
+                Task<IEnumerable<int>> GetResultAsync(Task<int> task, IEnumerable<int> items)
+                {
+                    if (task.IsCompletedSuccessfully)
+                    {
+                        return Task.FromResult(from item in items select task.{|#0:Result|});
+                    }
+
+                    return Task.FromResult(Enumerable.Empty<int>());
+                }
+            }
+            """;
+
+        await new CSVerify.Test
+        {
+            TestCode = test,
+            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+            ExpectedDiagnostics =
+            {
+                CSVerify.Diagnostic(DescriptorNoAlternativeMethod).WithLocation(0).WithArguments("Result"),
+            },
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TaskResultAfterLocalFunctionMutation_GeneratesWarning()
+    {
+        string test = """
+            using System.Threading.Tasks;
+
+            class Test
+            {
+                Task<int> GetResultAsync(Task<int> task, Task<int> replacement)
+                {
+                    void Replace() => task = replacement;
+
+                    if (task.IsCompletedSuccessfully)
+                    {
+                        Replace();
+                        return Task.FromResult(task.{|#0:Result|});
+                    }
+
+                    return task;
+                }
+            }
+            """;
+
+        await new CSVerify.Test
+        {
+            TestCode = test,
+            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+            ExpectedDiagnostics =
+            {
+                CSVerify.Diagnostic(DescriptorNoAlternativeMethod).WithLocation(0).WithArguments("Result"),
+            },
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task CapturedTaskResultAfterEnclosingLocalFunctionMutation_GeneratesWarning()
+    {
+        string test = """
+            using System;
+            using System.Threading.Tasks;
+
+            class Test
+            {
+                Task<int> GetResultAsync(Task<int> task, Task<int> replacement)
+                {
+                    void Replace() => task = replacement;
+                    Func<Task<int>> callback = () =>
+                    {
+                        if (task.IsCompletedSuccessfully)
+                        {
+                            Replace();
+                            return Task.FromResult(task.{|#0:Result|});
+                        }
+
+                        return task;
+                    };
+
+                    return callback();
+                }
+            }
+            """;
+
+        await new CSVerify.Test
+        {
+            TestCode = test,
+            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+            ExpectedDiagnostics =
+            {
+                CSVerify.Diagnostic(DescriptorNoAlternativeMethod).WithLocation(0).WithArguments("Result"),
+            },
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task RefParameterResultGuardedByIsCompletedSuccessfully_GeneratesWarning()
+    {
+        string test = """
+            using System.Threading.Tasks;
+
+            class Test
+            {
+                Task<int> GetResultAsync(ref Task<int> task)
+                {
+                    if (task.IsCompletedSuccessfully)
+                    {
+                        return Task.FromResult(task.{|#0:Result|});
+                    }
+
+                    return task;
+                }
+            }
+            """;
+
+        await new CSVerify.Test
+        {
+            TestCode = test,
+            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+            ExpectedDiagnostics =
+            {
+                CSVerify.Diagnostic(DescriptorNoAlternativeMethod).WithLocation(0).WithArguments("Result"),
+            },
+        }.RunAsync();
+    }
+
+    [Fact]
     public async Task TaskGetAwaiterGetResultInTaskReturningMethodGeneratesWarning()
     {
         var test = @"

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD104OfferAsyncOptionAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD104OfferAsyncOptionAnalyzerTests.cs
@@ -447,4 +447,61 @@ public class Test {
         analyzerTest.ExpectedDiagnostics.Add(CSVerify.Diagnostic().WithSpan(7, 25, 7, 31));
         await analyzerTest.RunAsync();
     }
+
+    [Fact]
+    public async Task TaskResultThroughRefAliasAfterOriginalReassignment_GeneratesWarning()
+    {
+        var test = @"
+using System.Threading.Tasks;
+
+public class Test {
+    public int GetResult(Task<int> task) {
+        ref Task<int> alias = ref task;
+        if (alias.IsCompletedSuccessfully) {
+            task = new TaskCompletionSource<int>().Task;
+            return alias.Result;
+        }
+
+        return 0;
+    }
+}
+";
+
+        var analyzerTest = new CSVerify.Test
+        {
+            TestCode = test,
+            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+        };
+        analyzerTest.ExpectedDiagnostics.Add(CSVerify.Diagnostic().WithSpan(9, 26, 9, 32));
+        await analyzerTest.RunAsync();
+    }
+
+    [Fact]
+    public async Task TaskResultBeforeReassignmentInLoop_GeneratesWarning()
+    {
+        var test = @"
+using System.Threading.Tasks;
+
+public class Test {
+    public int GetResult(Task<int> task, Task<int> replacement) {
+        if (task.IsCompletedSuccessfully) {
+            while (true) {
+                _ = task.Result;
+                task = replacement;
+            }
+        }
+
+        return 0;
+    }
+}
+";
+
+        var analyzerTest = new CSVerify.Test
+        {
+            TestCode = test,
+            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+        };
+        analyzerTest.ExpectedDiagnostics.Add(CSVerify.Diagnostic().WithSpan(8, 26, 8, 32));
+        await analyzerTest.RunAsync();
+    }
 }


### PR DESCRIPTION
## Summary

- suppress VSTHRD103 for `Task.Result` when the same stable task is proven complete by `IsCompletedSuccessfully`
- suppress VSTHRD103 for `Result` on the actual antecedent parameter of a BCL `Task.ContinueWith` callback
- share the conservative completion proof with VSTHRD104 and preserve diagnostics for reassignment, ref aliasing, captured storage, state delegates, loop backedges, local-function mutation, and deferred query execution

Fixes #1125
Fixes #680

## Issue #1480

This does not globally suppress EF Core `DbSet.AddRange`. EF Core documents that `AddRangeAsync` is required for special asynchronous value generators, so the analyzer cannot determine from the call site whether the synchronous operation is appropriate. A built-in suppression would hide valid VSTHRD103 diagnostics. Projects that do not use such generators can use the existing `vs-threading.SyncMethodsToExcludeFromVSTHRD103.txt` configuration with:

```text
[Microsoft.EntityFrameworkCore.DbSet`1]::AddRange
```

References #1480.

## Validation

- Release build
- full `Microsoft.VisualStudio.Threading.Analyzers.Tests` suite across `net472`, `net8.0`, and `net8.0-windows`