### PR TITLE
Validate docfx links in documentation workflow

### DIFF
--- a/.github/workflows/docs_validate.yml
+++ b/.github/workflows/docs_validate.yml
@@ -19,7 +19,7 @@ jobs:
     - name: 🔗 Markup Link Checker (mlc)
       uses: becheran/mlc@7ec24825cefe0c9c8c6bac48430e1f69e3ec356e # v1.2.0
       with:
-        args: --do-not-warn-for-redirect-to https://learn.microsoft.com*,https://dotnet.microsoft.com/*,https://dev.azure.com/*,https://app.codecov.io/*,https://github.com/microsoft/vssdktestfx*,https://github.com/Microsoft/perfview* -i https://aka.ms/onboardsupport,https://aka.ms/spot,https://msrc.microsoft.com/*,https://www.microsoft.com/msrc*,https://microsoft.com/msrc*,https://www.npmjs.com/package/*,https://get.dot.net/
+        args: --do-not-warn-for-redirect-to https://learn.microsoft.com*,https://dotnet.microsoft.com/*,https://dev.azure.com/*,https://app.codecov.io/*,https://github.com/microsoft/vssdktestfx*,https://github.com/Microsoft/perfview*,https://github.com/microsoft/perfview* -i https://aka.ms/onboardsupport,https://aka.ms/spot,https://msrc.microsoft.com/*,https://www.microsoft.com/msrc*,https://microsoft.com/msrc*,https://www.npmjs.com/package/*,https://get.dot.net/
     - name: ⚙ Install prerequisites
       run: |
         ./init.ps1 -UpgradePrerequisites

--- a/.github/workflows/docs_validate.yml
+++ b/.github/workflows/docs_validate.yml
@@ -19,7 +19,7 @@ jobs:
     - name: 🔗 Markup Link Checker (mlc)
       uses: becheran/mlc@7ec24825cefe0c9c8c6bac48430e1f69e3ec356e # v1.2.0
       with:
-        args: --do-not-warn-for-redirect-to https://learn.microsoft.com*,https://dotnet.microsoft.com/*,https://dev.azure.com/*,https://app.codecov.io/* -p docfx -i https://aka.ms/onboardsupport,https://aka.ms/spot,https://msrc.microsoft.com/*,https://www.microsoft.com/msrc*,https://microsoft.com/msrc*,https://www.npmjs.com/package/*,https://get.dot.net/
+        args: --do-not-warn-for-redirect-to https://learn.microsoft.com*,https://dotnet.microsoft.com/*,https://dev.azure.com/*,https://app.codecov.io/*,https://github.com/microsoft/vssdktestfx*,https://github.com/Microsoft/perfview* -i https://aka.ms/onboardsupport,https://aka.ms/spot,https://msrc.microsoft.com/*,https://www.microsoft.com/msrc*,https://microsoft.com/msrc*,https://www.npmjs.com/package/*,https://get.dot.net/
     - name: ⚙ Install prerequisites
       run: |
         ./init.ps1 -UpgradePrerequisites

--- a/docfx/analyzers/VSTHRD001.md
+++ b/docfx/analyzers/VSTHRD001.md
@@ -35,7 +35,7 @@ void Foo() {
 
 In the above example, we obtain a `JoinableTaskFactory` instance from the `ThreadHelper.JoinableTaskFactory` static property
 as it exists within Visual Studio itself. Other applications should create and expose their own `JoinableTaskContext` and/or `JoinableTaskFactory` for use in code that run in these applications.
-See our doc on [consuming `JoinableTaskFactory` from a library](https://github.com/microsoft/vs-threading/blob/main/doc/library_with_jtf.md) for more information.
+See our doc on [consuming `JoinableTaskFactory` from a library](../docs/library_with_jtf.md) for more information.
 
 ### Replacing Dispatcher.BeginInvoke
 

--- a/docfx/docs/cookbook_vs.md
+++ b/docfx/docs/cookbook_vs.md
@@ -462,5 +462,5 @@ So how do we get the best of both worlds? How can we have a responsive app, keep
 [NuPkg]: https://www.nuget.org/packages/Microsoft.VisualStudio.Threading
 [AnalyzerNuPkg]: https://www.nuget.org/packages/Microsoft.VisualStudio.Threading.Analyzers
 [MSDNIVsTaskGetAwaiter]: https://msdn.microsoft.com/en-us/library/vstudio/hh598836.aspx
-[AsyncPackage101]: https://microsoft.sharepoint.com/teams/DD_VSIDE/_layouts/15/WopiFrame.aspx?sourcedoc=%7b84C6ABED-E111-4B5D-B2D6-8B6FAF37F0D4%7d&file=Async%20Package%20101.docx&action=default
+[AsyncPackage101]: https://learn.microsoft.com/visualstudio/extensibility/how-to-use-asyncpackage-to-load-vspackages-in-the-background
 [ThreadpoolStarvation]: threadpool_starvation.md

--- a/docfx/docs/cookbook_vs.md
+++ b/docfx/docs/cookbook_vs.md
@@ -461,6 +461,6 @@ So how do we get the best of both worlds? How can we have a responsive app, keep
 
 [NuPkg]: https://www.nuget.org/packages/Microsoft.VisualStudio.Threading
 [AnalyzerNuPkg]: https://www.nuget.org/packages/Microsoft.VisualStudio.Threading.Analyzers
-[MSDNIVsTaskGetAwaiter]: https://msdn.microsoft.com/en-us/library/vstudio/hh598836.aspx
+[MSDNIVsTaskGetAwaiter]: https://learn.microsoft.com/dotnet/api/microsoft.visualstudio.shell.vstasklibraryhelper.getawaiter
 [AsyncPackage101]: https://learn.microsoft.com/visualstudio/extensibility/how-to-use-asyncpackage-to-load-vspackages-in-the-background
 [ThreadpoolStarvation]: threadpool_starvation.md


### PR DESCRIPTION
The documentation workflow passed while broken links accumulated under `docfx` because MLC's `-p docfx` argument explicitly excluded that directory.

Remove the exclusion so MLC scans all documentation, and repair the two broken links it exposes. Approved `aka.ms` redirects remain validated while their known destinations are allowed to redirect without warnings.