### PR TITLE
Use configured NuGet source for analyzer tests

### DIFF
--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/Helpers/ReferencesHelper.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/Helpers/ReferencesHelper.cs
@@ -14,10 +14,20 @@ internal static class ReferencesHelper
 {
     private static readonly string NuGetConfigPath = FindNuGetConfigPath();
 
+    /// <summary>
+    /// Gets the .NET 8 reference assemblies using this repository's NuGet sources.
+    /// </summary>
+    internal static readonly ReferenceAssemblies Net80References = ReferenceAssemblies.Net.Net80.WithNuGetConfigFilePath(NuGetConfigPath);
+
+    /// <summary>
+    /// Gets the .NET Framework 2.0 reference assemblies using this repository's NuGet sources.
+    /// </summary>
+    internal static readonly ReferenceAssemblies NetFramework20References = ReferenceAssemblies.NetFramework.Net20.Default.WithNuGetConfigFilePath(NuGetConfigPath);
+
 #if NETFRAMEWORK
     public static ReferenceAssemblies DefaultReferences = ReferenceAssemblies.NetFramework.Net471.Default
 #elif NET8_0
-    public static ReferenceAssemblies DefaultReferences = ReferenceAssemblies.Net.Net80
+    public static ReferenceAssemblies DefaultReferences = Net80References
 #else
 #error Fix TFM conditions
 #endif

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD002UseJtfRunAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD002UseJtfRunAnalyzerTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using CSVerify = Microsoft.VisualStudio.Threading.Analyzers.Tests.CSharpCodeFixVerifier<Microsoft.VisualStudio.Threading.Analyzers.VSTHRD002UseJtfRunAnalyzer, Microsoft.VisualStudio.Threading.Analyzers.VSTHRD002UseJtfRunCodeFixWithAwait>;
+using ReferencesHelper = Microsoft.VisualStudio.Threading.Analyzers.Tests.ReferencesHelper;
 
 public class VSTHRD002UseJtfRunAnalyzerTests
 {
@@ -1272,7 +1273,7 @@ class Test {
         await new CSVerify.Test
         {
             TestCode = test,
-            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+            ReferenceAssemblies = ReferencesHelper.Net80References,
         }.RunAsync();
     }
 
@@ -1384,7 +1385,7 @@ class Test {
         {
             TestCode = test,
             FixedCode = test,
-            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.NetFramework.Net20.Default,
+            ReferenceAssemblies = ReferencesHelper.NetFramework20References,
         };
         verifyTest.TestState.AdditionalFiles.Add(("vs-threading.SyncBlockingMethods.txt", "[CustomWaiter]::Join"));
         await verifyTest.RunAsync();
@@ -2096,7 +2097,7 @@ class Test : Base, ITest {
         {
             TestCode = test,
             FixedCode = test,
-            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+            ReferenceAssemblies = ReferencesHelper.Net80References,
         }.RunAsync();
     }
 

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD103UseAsyncOptionAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD103UseAsyncOptionAnalyzerTests.cs
@@ -3,6 +3,7 @@
 
 using static Microsoft.VisualStudio.Threading.Analyzers.VSTHRD103UseAsyncOptionAnalyzer;
 using CSVerify = Microsoft.VisualStudio.Threading.Analyzers.Tests.CSharpCodeFixVerifier<Microsoft.VisualStudio.Threading.Analyzers.VSTHRD103UseAsyncOptionAnalyzer, Microsoft.VisualStudio.Threading.Analyzers.VSTHRD103UseAsyncOptionCodeFix>;
+using ReferencesHelper = Microsoft.VisualStudio.Threading.Analyzers.Tests.ReferencesHelper;
 
 public class VSTHRD103UseAsyncOptionAnalyzerTests
 {
@@ -970,7 +971,7 @@ class Test {
         await new CSVerify.Test
         {
             TestCode = test,
-            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+            ReferenceAssemblies = ReferencesHelper.Net80References,
         }.RunAsync();
     }
 
@@ -997,7 +998,7 @@ class Test {
         var analyzerTest = new CSVerify.Test
         {
             TestCode = test,
-            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+            ReferenceAssemblies = ReferencesHelper.Net80References,
         };
         analyzerTest.ExpectedDiagnostics.Add(CSVerify.Diagnostic(DescriptorNoAlternativeMethod).WithLocation(0).WithArguments("Result"));
         await analyzerTest.RunAsync();
@@ -1027,7 +1028,7 @@ class Test {
         var analyzerTest = new CSVerify.Test
         {
             TestCode = test,
-            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+            ReferenceAssemblies = ReferencesHelper.Net80References,
         };
         analyzerTest.ExpectedDiagnostics.Add(CSVerify.Diagnostic(DescriptorNoAlternativeMethod).WithLocation(0).WithArguments("Result"));
         await analyzerTest.RunAsync();
@@ -1057,7 +1058,7 @@ class Test {
         var analyzerTest = new CSVerify.Test
         {
             TestCode = test,
-            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+            ReferenceAssemblies = ReferencesHelper.Net80References,
         };
         analyzerTest.ExpectedDiagnostics.Add(CSVerify.Diagnostic(DescriptorNoAlternativeMethod).WithLocation(0).WithArguments("Result"));
         await analyzerTest.RunAsync();
@@ -1088,7 +1089,7 @@ class Test {
         var analyzerTest = new CSVerify.Test
         {
             TestCode = test,
-            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+            ReferenceAssemblies = ReferencesHelper.Net80References,
         };
         analyzerTest.ExpectedDiagnostics.Add(CSVerify.Diagnostic(DescriptorNoAlternativeMethod).WithLocation(0).WithArguments("Result"));
         await analyzerTest.RunAsync();
@@ -1121,7 +1122,7 @@ class Test {
         var analyzerTest = new CSVerify.Test
         {
             TestCode = test,
-            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+            ReferenceAssemblies = ReferencesHelper.Net80References,
         };
         analyzerTest.ExpectedDiagnostics.Add(CSVerify.Diagnostic(DescriptorNoAlternativeMethod).WithLocation(0).WithArguments("Result"));
         await analyzerTest.RunAsync();
@@ -1150,7 +1151,7 @@ class Test {
         var analyzerTest = new CSVerify.Test
         {
             TestCode = test,
-            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+            ReferenceAssemblies = ReferencesHelper.Net80References,
         };
         await analyzerTest.RunAsync();
     }
@@ -1285,7 +1286,7 @@ class Test {
         await new CSVerify.Test
         {
             TestCode = test,
-            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+            ReferenceAssemblies = ReferencesHelper.Net80References,
             ExpectedDiagnostics =
             {
                 CSVerify.Diagnostic(DescriptorNoAlternativeMethod).WithLocation(0).WithArguments("Result"),
@@ -1319,7 +1320,7 @@ class Test {
         await new CSVerify.Test
         {
             TestCode = test,
-            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+            ReferenceAssemblies = ReferencesHelper.Net80References,
             ExpectedDiagnostics =
             {
                 CSVerify.Diagnostic(DescriptorNoAlternativeMethod).WithLocation(0).WithArguments("Result"),
@@ -1358,7 +1359,7 @@ class Test {
         await new CSVerify.Test
         {
             TestCode = test,
-            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+            ReferenceAssemblies = ReferencesHelper.Net80References,
             ExpectedDiagnostics =
             {
                 CSVerify.Diagnostic(DescriptorNoAlternativeMethod).WithLocation(0).WithArguments("Result"),
@@ -1389,7 +1390,7 @@ class Test {
         await new CSVerify.Test
         {
             TestCode = test,
-            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+            ReferenceAssemblies = ReferencesHelper.Net80References,
             ExpectedDiagnostics =
             {
                 CSVerify.Diagnostic(DescriptorNoAlternativeMethod).WithLocation(0).WithArguments("Result"),
@@ -1587,7 +1588,7 @@ class Test {
         var verifyTest = new CSVerify.Test
         {
             TestCode = test,
-            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+            ReferenceAssemblies = ReferencesHelper.Net80References,
         };
         verifyTest.ExpectedDiagnostics.Add(CSVerify.Diagnostic(DescriptorNoAlternativeMethod).WithLocation(0).WithArguments("Result"));
         await verifyTest.RunAsync();
@@ -1622,7 +1623,7 @@ class Test {
         await new CSVerify.Test
         {
             TestCode = test,
-            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+            ReferenceAssemblies = ReferencesHelper.Net80References,
         }.RunAsync();
     }
 
@@ -1651,7 +1652,7 @@ class Test {
         var verifyTest = new CSVerify.Test
         {
             TestCode = test,
-            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+            ReferenceAssemblies = ReferencesHelper.Net80References,
         };
         verifyTest.ExpectedDiagnostics.Add(CSVerify.Diagnostic(DescriptorNoAlternativeMethod).WithLocation(0).WithArguments("Result"));
         await verifyTest.RunAsync();
@@ -1682,7 +1683,7 @@ class Test {
         var verifyTest = new CSVerify.Test
         {
             TestCode = test,
-            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+            ReferenceAssemblies = ReferencesHelper.Net80References,
         };
         verifyTest.ExpectedDiagnostics.Add(CSVerify.Diagnostic(DescriptorNoAlternativeMethod).WithLocation(0).WithArguments("Result"));
         await verifyTest.RunAsync();

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD104OfferAsyncOptionAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD104OfferAsyncOptionAnalyzerTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using CSVerify = Microsoft.VisualStudio.Threading.Analyzers.Tests.CSharpCodeFixVerifier<Microsoft.VisualStudio.Threading.Analyzers.VSTHRD104OfferAsyncOptionAnalyzer, Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using ReferencesHelper = Microsoft.VisualStudio.Threading.Analyzers.Tests.ReferencesHelper;
 
 public class VSTHRD104OfferAsyncOptionAnalyzerTests
 {
@@ -193,7 +194,7 @@ public class Test {
         await new CSVerify.Test
         {
             TestCode = test,
-            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+            ReferenceAssemblies = ReferencesHelper.Net80References,
         }.RunAsync();
     }
 
@@ -217,7 +218,7 @@ public class Test {
         var analyzerTest = new CSVerify.Test
         {
             TestCode = test,
-            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+            ReferenceAssemblies = ReferencesHelper.Net80References,
         };
         analyzerTest.ExpectedDiagnostics.Add(CSVerify.Diagnostic().WithSpan(7, 25, 7, 31));
         await analyzerTest.RunAsync();
@@ -243,7 +244,7 @@ public class Test {
         var analyzerTest = new CSVerify.Test
         {
             TestCode = test,
-            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+            ReferenceAssemblies = ReferencesHelper.Net80References,
         };
         analyzerTest.ExpectedDiagnostics.Add(CSVerify.Diagnostic().WithSpan(7, 25, 7, 31));
         await analyzerTest.RunAsync();
@@ -271,7 +272,7 @@ public class Test {
         var analyzerTest = new CSVerify.Test
         {
             TestCode = test,
-            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+            ReferenceAssemblies = ReferencesHelper.Net80References,
         };
         analyzerTest.ExpectedDiagnostics.Add(CSVerify.Diagnostic().WithSpan(9, 33, 9, 39));
         await analyzerTest.RunAsync();
@@ -298,7 +299,7 @@ public class Test {
         var analyzerTest = new CSVerify.Test
         {
             TestCode = test,
-            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+            ReferenceAssemblies = ReferencesHelper.Net80References,
         };
         analyzerTest.ExpectedDiagnostics.Add(CSVerify.Diagnostic().WithSpan(7, 41, 7, 47));
         await analyzerTest.RunAsync();
@@ -325,7 +326,7 @@ public class Test {
         var analyzerTest = new CSVerify.Test
         {
             TestCode = test,
-            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+            ReferenceAssemblies = ReferencesHelper.Net80References,
         };
         analyzerTest.ExpectedDiagnostics.Add(CSVerify.Diagnostic().WithSpan(8, 25, 8, 31));
         await analyzerTest.RunAsync();
@@ -355,7 +356,7 @@ public class Test {
         var analyzerTest = new CSVerify.Test
         {
             TestCode = test,
-            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+            ReferenceAssemblies = ReferencesHelper.Net80References,
         };
         analyzerTest.ExpectedDiagnostics.Add(CSVerify.Diagnostic().WithSpan(8, 25, 8, 31));
         await analyzerTest.RunAsync();
@@ -383,7 +384,7 @@ public class Test {
         var analyzerTest = new CSVerify.Test
         {
             TestCode = test,
-            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+            ReferenceAssemblies = ReferencesHelper.Net80References,
         };
         analyzerTest.ExpectedDiagnostics.Add(CSVerify.Diagnostic().WithSpan(9, 25, 9, 31));
         await analyzerTest.RunAsync();
@@ -411,7 +412,7 @@ public class Test {
         var analyzerTest = new CSVerify.Test
         {
             TestCode = test,
-            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+            ReferenceAssemblies = ReferencesHelper.Net80References,
         };
         analyzerTest.ExpectedDiagnostics.Add(CSVerify.Diagnostic().WithSpan(9, 25, 9, 31));
         await analyzerTest.RunAsync();
@@ -442,7 +443,7 @@ public class Test {
         var analyzerTest = new CSVerify.Test
         {
             TestCode = test,
-            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+            ReferenceAssemblies = ReferencesHelper.Net80References,
         };
         analyzerTest.ExpectedDiagnostics.Add(CSVerify.Diagnostic().WithSpan(7, 25, 7, 31));
         await analyzerTest.RunAsync();
@@ -470,7 +471,7 @@ public class Test {
         var analyzerTest = new CSVerify.Test
         {
             TestCode = test,
-            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+            ReferenceAssemblies = ReferencesHelper.Net80References,
         };
         analyzerTest.ExpectedDiagnostics.Add(CSVerify.Diagnostic().WithSpan(9, 26, 9, 32));
         await analyzerTest.RunAsync();
@@ -499,7 +500,7 @@ public class Test {
         var analyzerTest = new CSVerify.Test
         {
             TestCode = test,
-            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80,
+            ReferenceAssemblies = ReferencesHelper.Net80References,
         };
         analyzerTest.ExpectedDiagnostics.Add(CSVerify.Diagnostic().WithSpan(8, 26, 8, 32));
         await analyzerTest.RunAsync();


### PR DESCRIPTION
The isolated DevDiv pipeline fails because analyzer tests that override their reference assemblies bypass the repository's NuGet configuration and attempt to contact nuget.org directly.

This centralizes the .NET 8 and .NET Framework 2.0 reference assembly configurations in `ReferencesHelper`, preserving each test's intended framework while routing package resolution through the authenticated `msft_consumption_public` feed. All explicit reference assembly overrides now use these isolation-safe configurations.

The analyzer test project passes across net8.0, net8.0-windows, and net472 with 1,869 tests passed and 27 skipped.