### PR TITLE
Exclude non-equivalent async alternatives from VSTHRD103

### DIFF
--- a/docfx/analyzers/VSTHRD103.md
+++ b/docfx/analyzers/VSTHRD103.md
@@ -35,4 +35,3 @@ Some APIs may have async versions that are less efficient or inappropriate for c
 
 See our [configuration](configuration.md) topic to learn how to exclude specific methods
 using the `vs-threading.SyncMethodsToExcludeFromVSTHRD103.txt` file.
-```

--- a/docfx/analyzers/configuration.md
+++ b/docfx/analyzers/configuration.md
@@ -97,7 +97,8 @@ when in an async context. Sometimes certain APIs have async versions but those a
 are significantly slower, less efficient, or simply not preferred. These methods can be 
 excluded from VSTHRD103 analysis by specifying them in a configuration file.
 
-**Filename:** `vs-threading.SyncMethodsToExcludeFromVSTHRD103.txt`
+**Filename:** `vs-threading.SyncMethodsToExcludeFromVSTHRD103.txt`, or
+`vs-threading.SyncMethodsToExcludeFromVSTHRD103.<suffix>.txt`
 
 **Line format:** `[Namespace.TypeName]::MethodName`
 

--- a/docfx/analyzers/configuration.md
+++ b/docfx/analyzers/configuration.md
@@ -105,6 +105,19 @@ excluded from VSTHRD103 analysis by specifying them in a configuration file.
 
 **Generic sample:** ``[Microsoft.EntityFrameworkCore.DbSet`1]::Add``
 
+The analyzer package supplies default exclusions for APIs whose Async-suffixed alternatives
+are intended for different operations or exceptional use cases:
+
+| API | Excluded methods |
+| --- | --- |
+| Entity Framework Core `DbContext` | `Add`, `AddRange` |
+| Entity Framework Core `DbSet<TEntity>` | `Add`, `AddRange` |
+| NUnit `Assert` | `That` |
+| xUnit `Assert` | `Throws`, `ThrowsAny` |
+
+Projects and NuGet packages can extend this list by adding their own files that match the
+filename pattern above.
+
 ## Additional synchronous blocking methods for VSTHRD002
 
 Projects that wrap synchronous waits in their own APIs can configure those methods to be

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/buildTransitive/AdditionalFiles/vs-threading.SyncMethodsToExcludeFromVSTHRD103.frameworks.txt
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/buildTransitive/AdditionalFiles/vs-threading.SyncMethodsToExcludeFromVSTHRD103.frameworks.txt
@@ -1,0 +1,8 @@
+# These APIs have Async-suffixed alternatives that are not generally equivalent to or preferred over their synchronous counterparts.
+[Microsoft.EntityFrameworkCore.DbContext]::Add
+[Microsoft.EntityFrameworkCore.DbContext]::AddRange
+[Microsoft.EntityFrameworkCore.DbSet`1]::Add
+[Microsoft.EntityFrameworkCore.DbSet`1]::AddRange
+[NUnit.Framework.Assert]::That
+[Xunit.Assert]::Throws
+[Xunit.Assert]::ThrowsAny

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD103UseAsyncOptionAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD103UseAsyncOptionAnalyzerTests.cs
@@ -2650,6 +2650,87 @@ namespace TestNamespace {
     }
 
     [Fact]
+    public async Task KnownFrameworkMethodsWithNonEquivalentAsyncAlternativesDoNotGenerateWarning()
+    {
+        string test = """
+            using System;
+            using System.Threading.Tasks;
+
+            class Test
+            {
+                async Task TestAsync()
+                {
+                    Xunit.Assert.Throws<Exception>(() => { });
+                    Xunit.Assert.ThrowsAny<Exception>(() => { });
+                    NUnit.Framework.Assert.That(true, true);
+
+                    var context = new Microsoft.EntityFrameworkCore.DbContext();
+                    context.Add(new object());
+                    context.AddRange(new object());
+
+                    var set = new Microsoft.EntityFrameworkCore.DbSet<object>();
+                    set.Add(new object());
+                    set.AddRange(new object());
+
+                    Unrelated.Assert.{|#0:Throws<Exception>|}(() => { });
+                }
+            }
+
+            namespace Xunit
+            {
+                static class Assert
+                {
+                    public static void Throws<T>(Action action) { }
+                    public static Task ThrowsAsync<T>(Action action) => Task.CompletedTask;
+                    public static void ThrowsAny<T>(Action action) { }
+                    public static Task ThrowsAnyAsync<T>(Action action) => Task.CompletedTask;
+                }
+            }
+
+            namespace NUnit.Framework
+            {
+                static class Assert
+                {
+                    public static void That<T>(T actual, T expected) { }
+                    public static Task ThatAsync<T>(T actual, T expected) => Task.CompletedTask;
+                }
+            }
+
+            namespace Microsoft.EntityFrameworkCore
+            {
+                class DbContext
+                {
+                    public void Add(object entity) { }
+                    public Task AddAsync(object entity) => Task.CompletedTask;
+                    public void AddRange(params object[] entities) { }
+                    public Task AddRangeAsync(params object[] entities) => Task.CompletedTask;
+                }
+
+                class DbSet<T>
+                {
+                    public void Add(T entity) { }
+                    public Task AddAsync(T entity) => Task.CompletedTask;
+                    public void AddRange(params T[] entities) { }
+                    public Task AddRangeAsync(params T[] entities) => Task.CompletedTask;
+                }
+            }
+
+            namespace Unrelated
+            {
+                static class Assert
+                {
+                    public static void Throws<T>(Action action) { }
+                    public static Task ThrowsAsync<T>(Action action) => Task.CompletedTask;
+                }
+            }
+            """;
+
+        await CSVerify.VerifyAnalyzerAsync(
+            test,
+            CSVerify.Diagnostic(Descriptor).WithLocation(0).WithArguments("Throws<Exception>", "ThrowsAsync"));
+    }
+
+    [Fact]
     public async Task GenericTypeExclusion_DoesNotExcludeNonGenericType()
     {
         string test = """


### PR DESCRIPTION
VSTHRD103 assumes an `Async`-suffixed counterpart is generally preferable, but several framework APIs use the async variant for different semantics or specialized cases. This causes incorrect recommendations for synchronous assertions and Entity Framework Core change tracking APIs.

## Changes

- Ship package-provided AdditionalFile exclusions for xUnit `Throws`/`ThrowsAny`, NUnit `Assert.That`, and EF Core `DbContext`/`DbSet<TEntity>` `Add`/`AddRange`.
- Keep the policy data-driven so projects and NuGet packages can extend the same exclusion file pattern for their own APIs.
- Document the built-in exclusions and add regression coverage that confirms matching remains scoped to exact containing types.

The task-flow case in #1662 is intentionally not addressed here because it is being fixed separately through semantic analysis.

## Validation

- All 98 VSTHRD103 analyzer tests pass on `net8.0`.
- The packed analyzer includes the exclusion file under `buildTransitive/AdditionalFiles`.

Fixes #1661
Fixes #1480