### PR TITLE
Audit analyzers for ValueTask support

### DIFF
--- a/src/Microsoft.VisualStudio.Threading.Analyzers/AbstractVSTHRD114AvoidReturningNullTaskAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers/AbstractVSTHRD114AvoidReturningNullTaskAnalyzer.cs
@@ -10,9 +10,12 @@ using Microsoft.CodeAnalysis.Operations;
 namespace Microsoft.VisualStudio.Threading.Analyzers;
 
 /// <summary>
-/// Finds await expressions on <see cref="Task"/> that do not use <see cref="Task.ConfigureAwait(bool)"/>.
-/// Also works on <see cref="ValueTask"/>.
+/// Finds methods that return <see langword="null"/> in place of a <see cref="Task"/> or <see cref="Task{TResult}"/>.
 /// </summary>
+/// <remarks>
+/// <see cref="ValueTask"/> and <see cref="ValueTask{TResult}"/> are value types, so <see langword="null"/> cannot be
+/// returned in their place and the compiler already prevents this pattern for them.
+/// </remarks>
 public abstract class AbstractVSTHRD114AvoidReturningNullTaskAnalyzer : DiagnosticAnalyzer
 {
     public const string Id = "VSTHRD114";


### PR DESCRIPTION
Fixes #414.

Audited all analyzers in `Microsoft.VisualStudio.Threading.Analyzers` for `ValueTask`/`ValueTask<T>` support:

- **VSTHRD111** (ConfigureAwait): already explicitly handles `ValueTask`.
- **VSTHRD011, VSTHRD109, VSTHRD200**: use `HasAsyncCompatibleReturnType`/`IsAsyncCompatibleReturnType`, which already recognize `ValueTask` via its `AsyncMethodBuilderAttribute`.
- **VSTHRD110** and the "remove Async suffix" check in **VSTHRD200**: use `AwaitableTypeTester`, which discovers any type with a `GetAwaiter` method (including `ValueTask`) dynamically from the compilation.
- **VSTHRD012, VSTHRD108, VSTHRD001, VSTHRD004, VSTHRD100, VSTHRD106, VSTHRD116/117**: not `Task`-type-specific to begin with; no gap applies.
- **VSTHRD114** (avoid returning null `Task`): its doc comment incorrectly claimed `ValueTask` support (likely copy-pasted from VSTHRD111). In reality, `ValueTask`/`ValueTask<T>` are value types, so `return null;` is a compile error (CS0037) and this code path can never be reached for them. Corrected the doc comment to explain why `ValueTask` isn't applicable here instead of implying non-existent support.

No behavioral analyzer gaps were found — only a misleading doc comment was corrected. All existing VSTHRD114 tests (24) continue to pass.