### PR TITLE
Exclude non-equivalent IDbContextFactory<TContext>.CreateDbContext() alternatives from VSTHRD103

### DIFF
--- a/docfx/analyzers/configuration.md
+++ b/docfx/analyzers/configuration.md
@@ -93,8 +93,8 @@ thread.
 ## Methods to exclude from VSTHRD103 checks
 
 The VSTHRD103 analyzer flags calls to synchronous methods where asynchronous equivalents exist,
-when in an async context. Sometimes certain APIs have async versions but those async versions 
-are significantly slower, less efficient, or simply not preferred. These methods can be 
+when in an async context. Sometimes certain APIs have async versions but those async versions
+are significantly slower, less efficient, or simply not preferred. These methods can be
 excluded from VSTHRD103 analysis by specifying them in a configuration file.
 
 **Filename:** `vs-threading.SyncMethodsToExcludeFromVSTHRD103.txt`, or
@@ -113,6 +113,7 @@ are intended for different operations or exceptional use cases:
 | --- | --- |
 | Entity Framework Core `DbContext` | `Add`, `AddRange` |
 | Entity Framework Core `DbSet<TEntity>` | `Add`, `AddRange` |
+| Entity Framework Core `IDbContextFactory<TContext>` | `CreateDbContext` |
 | NUnit `Assert` | `That` |
 | xUnit `Assert` | `Throws`, `ThrowsAny` |
 

--- a/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/buildTransitive/AdditionalFiles/vs-threading.SyncMethodsToExcludeFromVSTHRD103.frameworks.txt
+++ b/src/Microsoft.VisualStudio.Threading.Analyzers.CodeFixes/buildTransitive/AdditionalFiles/vs-threading.SyncMethodsToExcludeFromVSTHRD103.frameworks.txt
@@ -3,6 +3,7 @@
 [Microsoft.EntityFrameworkCore.DbContext]::AddRange
 [Microsoft.EntityFrameworkCore.DbSet`1]::Add
 [Microsoft.EntityFrameworkCore.DbSet`1]::AddRange
+[Microsoft.EntityFrameworkCore.IDbContextFactory`1]::CreateDbContext
 [NUnit.Framework.Assert]::That
 [Xunit.Assert]::Throws
 [Xunit.Assert]::ThrowsAny

--- a/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD103UseAsyncOptionAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Threading.Analyzers.Tests/VSTHRD103UseAsyncOptionAnalyzerTests.cs
@@ -2801,6 +2801,9 @@ namespace TestNamespace {
                     set.Add(new object());
                     set.AddRange(new object());
 
+                    Microsoft.EntityFrameworkCore.IDbContextFactory<Microsoft.EntityFrameworkCore.DbContext> factory = new Microsoft.EntityFrameworkCore.DbContextFactory<Microsoft.EntityFrameworkCore.DbContext>();
+                    factory.CreateDbContext();
+
                     Unrelated.Assert.{|#0:Throws<Exception>|}(() => { });
                 }
             }
@@ -2841,6 +2844,18 @@ namespace TestNamespace {
                     public Task AddAsync(T entity) => Task.CompletedTask;
                     public void AddRange(params T[] entities) { }
                     public Task AddRangeAsync(params T[] entities) => Task.CompletedTask;
+                }
+
+                interface IDbContextFactory<TContext> where TContext : DbContext
+                {
+                    TContext CreateDbContext();
+                    Task<TContext> CreateDbContextAsync();
+                }
+
+                class DbContextFactory<TContext> : IDbContextFactory<TContext> where TContext : DbContext, new()
+                {
+                    public TContext CreateDbContext() => new TContext();
+                    public Task<TContext> CreateDbContextAsync() => Task.FromResult(new TContext());
                 }
             }
 


### PR DESCRIPTION
Fixes #1679 
Builds on the recently closed PR #1665

This PR excludes `Microsoft.EntityFrameworkCore.IDbContextFactory<TContext>.CreateDbContext()` from VSTHRD103.